### PR TITLE
V172

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -672,6 +672,7 @@ module.exports = Class.create({
 			// attach streams
 			worker.log_fd = fs.openSync(job.log_file, 'a');
 			child_opts.stdio = ['pipe', 'pipe', worker.log_fd];
+			if(job.plugin == 'workflow') child_opts.stdio = ['pipe', 'pipe', worker.log_fd, 'ipc'];
 
 			// spawn child
 			try {
@@ -1049,7 +1050,19 @@ module.exports = Class.create({
 			}, this.server.config.get('child_kill_timeout') * 1000);
 
 			// try killing nicely first
-			worker.child.kill('SIGTERM');
+			worker.child.connected ? worker.child.disconnect() : worker.child.kill('SIGTERM');
+			// try {
+			// 	worker.child.connected ? worker.child.disconnect() : worker.child.kill('SIGTERM');
+			// }
+			// catch (e) {
+			// 	this.logDebug(3, "Failed to abort job gracefully: " + stub.id , e.message)
+			// }
+			// if(worker.child.connected) {
+			// 	worker.child.disconnect() // jobs with ipc
+			// }
+			// else {
+			//   worker.child.kill('SIGTERM');
+			// }
 		}
 		else {
 			// detached process


### PR DESCRIPTION
workflow:
- make abort fully graceful
- use IPC when workflow child job is spawned (to fix Win issues, but also can be used to replace api polling )
- some output table tuning for windows (fix ugly table )
- fix column labels out WF output

schedule page:
 - mirror footer buttons as icons on the top widget
 - open confirm window on enable/disable event
 - add "copy" icon at the top of "Event Edit page"
