### PR TITLE
Enable storage transactions to match cronicle default

### DIFF
--- a/sample_conf/config.json
+++ b/sample_conf/config.json
@@ -86,8 +86,8 @@
 		"concurrency": 4,
 		"log_event_types": { "get": 1, "put": 1, "head": 1, "delete": 1, "expire_set": 1 },
 
-		"transactions": false,
-		"trans_auto_recover": false,
+		"transactions": true,
+		"trans_auto_recover": true,
 		
 		"Filesystem": {
 			"base_dir": "data",


### PR DESCRIPTION
Per [Storage Transactions](https://github.com/jhuckaby/Cronicle/wiki/Troubleshooting#storage-transactions) on the Cronicle wiki:
> It is highly recommended that you enable storage transactions. This protects against database corruption for events like backend storage errors, crashes and sudden power loss. Cronicle ships with transactions enabled in the default config, but if you have an older version you may need to manually enable them. 

This is also the default in upstream: https://github.com/jhuckaby/Cronicle/blob/master/sample_conf/config.json#L78
