### PR TITLE
Mask auth headers in url-plugin

### DIFF
--- a/bin/url-plugin.js
+++ b/bin/url-plugin.js
@@ -47,11 +47,14 @@ stream.on('json', function(job) {
 	if (params.headers) {
 		// allow headers to be substituted using [placeholders]
 		params.headers = Tools.sub( params.headers, job );
-	
-		print("\nRequest Headers:\n" + params.headers.trim() + "\n");
+		print("\nRequest Headers:\n");
 		params.headers.replace(/\r\n/g, "\n").trim().split(/\n/).forEach( function(pair) {
 			if (pair.match(/^([^\:]+)\:\s*(.+)$/)) {
-				request.setHeader( RegExp.$1, RegExp.$2 );
+				const headerKey = RegExp.$1;
+				const headerValue = RegExp.$2;
+				request.setHeader( headerKey, headerValue );
+				const maskedValue = (headerKey.toLowerCase() === 'authorization' && headerValue.trim().includes(' ')) ? headerValue.replace(headerValue.trim().split(' ')[1], '*'.repeat(headerValue.trim().split(' ')[1].length)) : headerValue;
+				print(`${headerKey}: ${maskedValue.trim()}\n` );
 			}
 		} );
 	}


### PR DESCRIPTION
Currently the console output of HTTP Requests can easily contain credentials.
Especially when collaborating and showcasing Cronicle jobs this easily can leak secrets which should not be displayed directly.
Also potentially if logs are propagated to other systems this may prevent from secret leakage.

![grafik](https://github.com/cronicle-edge/cronicle-edge/assets/7422353/48e3a15d-af2e-48cc-8f11-5eb56d01941e)

This enhancement will preserve the secret length, however obfuscate the rest:
![grafik](https://github.com/cronicle-edge/cronicle-edge/assets/7422353/3a1c40c2-785e-4d70-8fd5-1c83fb574370)
![grafik](https://github.com/cronicle-edge/cronicle-edge/assets/7422353/658abec9-6515-445e-a6a0-7f1b79c84847)

Should work for `Basic`, `Bearer` or other space delimited headers.

Regexes might also work, however the question is, how much to hide and how much is acceptable.

Open for further adjustments, would hope current state is safe enough and will not cause issues.