### PR TITLE
Update SQL.js to fix head operations for pg engine.

### DIFF
--- a/engines/SQL.js
+++ b/engines/SQL.js
@@ -87,7 +87,7 @@ module.exports = class SQLEngine extends Component {
         let UPDATED = 'updated'
 
 	// Postgres requires quoted "V" field since the schema was created with the quoted "V" field. 
-	 T
+	 
         if (this.client === 'pg'){
 		this.getBlobSizefn = 'length("V")'
 	}

--- a/engines/SQL.js
+++ b/engines/SQL.js
@@ -85,7 +85,22 @@ module.exports = class SQLEngine extends Component {
         // some column name aliases to adjust to default DB case
         let CREATED = 'created'
         let UPDATED = 'updated'
-                
+
+	/*Postgres requires "length" instead of len for bytea fields. Noticed failures during head operations. 
+	 The other option would be to create a postgres function called len() on setup create which wraps the length() operation.
+	 CREATE OR REPLACE FUNCTION len(byteafield bytea)
+	 RETURNS int AS
+	 $$
+	 BEGIN
+    		RETURN length(byteafield);
+	END;
+	$$
+	LANGUAGE plpgsql IMMUTABLE;
+	*/
+        if (this.client === 'pg'){
+		this.getBlobSizefn = "length(\"V\")"
+	}
+	    
         if (this.client === 'mssql') {
             this.getBlobSizeFn = 'len(V)'
             this.mergeStmt = `

--- a/engines/SQL.js
+++ b/engines/SQL.js
@@ -86,19 +86,10 @@ module.exports = class SQLEngine extends Component {
         let CREATED = 'created'
         let UPDATED = 'updated'
 
-	/*Postgres requires "length" instead of len for bytea fields. Noticed failures during head operations. 
-	 The other option would be to create a postgres function called len() on setup create which wraps the length() operation.
-	 CREATE OR REPLACE FUNCTION len(byteafield bytea)
-	 RETURNS int AS
-	 $$
-	 BEGIN
-    		RETURN length(byteafield);
-	END;
-	$$
-	LANGUAGE plpgsql IMMUTABLE;
-	*/
+	// Postgres requires quoted "V" field since the schema was created with the quoted "V" field. 
+	 T
         if (this.client === 'pg'){
-		this.getBlobSizefn = "length(\"V\")"
+		this.getBlobSizefn = 'length("V")'
 	}
 	    
         if (this.client === 'mssql') {


### PR DESCRIPTION
Postgres requires the "length" function vs "len" function as some SQL engines us, this patch would add the correct wrapping in the getBlobSizefn