### PR TITLE
allow one letter usernames

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -56,7 +56,7 @@ module.exports = Class.create({
 
 		// cache this from config
 		// this.usernameMatch new RegExp(this.config.get('valid_username_match'));
-		this.usernameMatch = /^[\w\.\-]+@?[\w\.\-]+$/  // alphanum or email like
+		this.usernameMatch = /^[\w\.\-]+@?[\w\.\-]*$/  // alphanum or email like
 		this.usernameBlock = new RegExp(this.config.get('block_username_match'), "i");
 
 		// startup complete


### PR DESCRIPTION
currently since the second capture block is * not +, it requires at least two letter for a username, which is unfortunate as i use a one letter username. 