### PR TITLE
Prevent params from logging to stdout

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -285,8 +285,8 @@ module.exports = Class.create({
 
 	safeJobLog: function(job) { // print less verbose, more readable job data on logging
 		if(!job) return ''
-		let excl = ["table", "secret", "env", "cat_secret", "plug_secret", "globalenv"]
-		return Object.keys(job).filter(e => ! excl.includes(e)).map(e => e + ': ' + ("params|workflow|perf".indexOf(e) > -1 ? JSON.stringify(job[e]) : job[e]) ).join(" | ")
+		let excl = ["table", "secret", "env", "cat_secret", "plug_secret", "globalenv", "params"];
+		return Object.keys(job).filter(e => ! excl.includes(e)).map(e => e + ': ' + ("workflow|perf".indexOf(e) > -1 ? JSON.stringify(job[e]) : job[e]) ).join(" | ")
 	},
 
 	// updateSecrets: function () { // cache secret data in memory


### PR DESCRIPTION
Similiar to https://github.com/cronicle-edge/cronicle-edge/pull/96 this change will hide potential Auth headers from the stdout log.

Without it, successful or failing jobs can easily leak Auth Headers to stdout which often is scraped with ELK / Loki in a k8s environment.

Simply added whole params object to exclude list, else it might be a bit ugly now using http-plugin logic here to search for the Auth header specifically. IMO `event_title` should be enough and details can still be viewed in real job run.

Prev:
![grafik](https://github.com/cronicle-edge/cronicle-edge/assets/7422353/e441abb3-651f-4eb6-bcf5-570566a13c4d)

With change:
![grafik](https://github.com/cronicle-edge/cronicle-edge/assets/7422353/97d1e5aa-2ea9-4c96-81fa-6a9bd5331749)
