### PR TITLE
Changed CRONICLE_secret_key value in example bash script (Docker/Readme.md)

### DIFF
--- a/Docker/Readme.md
+++ b/Docker/Readme.md
@@ -24,7 +24,7 @@ For actual use:
 ```bash
 docker run -d --hostname manager1 --restart=always \
   -e CRONICLE_manager=1 \
-  -e CRONICLE_secret_key=123456 \
+  -e CRONICLE_secret_key=abcdefg \
   -p 3012:3012 \
   -v $HOME/data:/opt/cronicle/data \
   cronicle/cronicle:edge manager


### PR DESCRIPTION
The CRONICLE_secret_key cannot be int, or else it will keep looping the following error message, and the server cannot be initialized: 

```
[1750374767.56][2025-06-19 19:12:47][manager1][7][Cronicle][debug][1][Uncaught Exception: TypeError [ERR_INVALID_ARG_TYPE]: The "password" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received type number (123456)][TypeError [ERR_INVALID_ARG_TYPE]: The "password" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received type number (123456)     at check (node:internal/crypto/scrypt:83:14)     at Object.scryptSync (node:internal/crypto/scrypt:66:13)     at Object.startup (/opt/cronicle/bin/cronicle.js:227:3191)     at /opt/cronicle/bin/cronicle.js:9:4615     at /opt/cronicle/bin/cronicle.js:2:19013     at replenish (/opt/cronicle/bin/cronicle.js:2:7516)     at iterateeCallback (/opt/cronicle/bin/cronicle.js:2:7389)     at /opt/cronicle/bin/cronicle.js:2:7147     at wrapper (/opt/cronicle/bin/cronicle.js:56:22012)     at iteratorCallback (/opt/cronicle/bin/cronicle.js:56:24140)]
```
