### PR TITLE
Fix 242: force error code to 1 for URL plugin HTTP errors

### DIFF
--- a/bin/url-plugin.js
+++ b/bin/url-plugin.js
@@ -122,7 +122,7 @@ stream.on('json', function(job) {
 			complete: 1
 		};
 		if (err) {
-			update.code = err.code || 1;
+			update.code = 1;
 			update.description = err.message || err;
 		}
 		else {


### PR DESCRIPTION
`url-plugin.js` set `update.code` to the raw HTTP status on error, and the core retry check requires `code < 255`, so retries never fired for real HTTP errors (404, 500, etc). 

Fixes #242