### PR TITLE
[FreeBSD] Fix control.sh process detection

### DIFF
--- a/bin/control.sh
+++ b/bin/control.sh
@@ -66,7 +66,7 @@ do
 			# make sure process is actually ours
 			PS=`ps -p $PID -o args= | sed 's/[ \t]*$//'`
 			
-			if [ "$PS" = "$NAME" ] ; then
+			if [ "$PS" = "$NAME" ] || [ "$PS" = "node: $NAME (node)" ] ; then
 				STATUS="$NAME running (pid $PID)"
 				RUNNING=1
 			else


### PR DESCRIPTION
FreeBSD 14.3 reports `process.title` as `node: Cronicle Server (node)`. `control.sh` only accepts `Cronicle Server`, so `status` and `stop` fail against a running server.

This accepts the FreeBSD form while keeping the PID file and `kill -0` checks unchanged.

Tested on a production Cronicle Edge 1.14.5 deployment:
- before: `status` reported a running server as stopped
- after: `status -> stop -> status -> start -> status` succeeded
- `sh -n bin/control.sh`

The same problem was reported to classic Cronicle in [jhuckaby/Cronicle#987](https://github.com/jhuckaby/Cronicle/issues/987). That repository's PR template says it generally does not merge pull requests, so I am submitting the tested fix to Edge.