### PR TITLE
Add configurable OAuth-only login

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,6 +103,21 @@ Run your script in actual terminal emulator (using node-pty) in order to capture
 Can verify user via common oauth providers (github, google, authentik, microsof, keyclock, etc)
 Refer to [1.11.1 release notes](https://github.com/cronicle-edge/cronicle-edge/releases/tag/v1.11.1) for more details.
 
+The login page can be customized in the `oauth` section of `config.json`:
+
+```json
+"oauth": {
+  "enabled": true,
+  "button_label": "Login with Keycloak",
+  "only": true,
+  "auto_login": false
+}
+```
+
+`button_label` changes the OAuth button text. `only` hides the username/password form and local account actions, and rejects password login requests at the API. `auto_login` redirects unauthenticated visitors directly to the configured OAuth provider. All options preserve the existing login behavior by default.
+
+Verify the OAuth flow before enabling `only` or `auto_login`, as an unavailable or invalid provider configuration can prevent interactive access.
+
 ### Serve cronicle on custom base path
 Ever wanted to serve cronicle on ```https://myserver/cron``` ? Just set ```base_path = /cron``` in config.json or set ```CRONICLE_base_path=/cron``` variable 
 Refer to [1.10.1 release notes](https://github.com/cronicle-edge/cronicle-edge/releases/tag/v1.10.1) for more details.

--- a/htdocs/js/pages/Login.class.js
+++ b/htdocs/js/pages/Login.class.js
@@ -25,41 +25,51 @@ Class.subclass( Page.Base, "Page.Login", {
 			this.showRecoverPasswordForm();
 			return true;
 		}
+		else if (config.oauth && config.oauth_auto_login) {
+			this.doOauth();
+			return true;
+		}
 		
 		app.setWindowTitle('Login');
 		app.showTabBar(false);
 		
 		this.div.css({ 'padding-top':'75px', 'padding-bottom':'75px' });
 		var html = '';
+		var hide_local_login = config.oauth && config.oauth_only;
+		var oauth_button_label = escape_text_field_value(config.oauth_button_label || 'SSO');
 		
 		html += '<div class="inline_dialog_container">';
 			html += '<div class="dialog_title shade-light">User Login</div>';
-			html += '<div class="dialog_content">';
-				html += '<center><table style="margin:0px;">';
-					html += '<tr>';
-						html += '<td align="right" class="table_label">Username:</td>';
-						html += '<td align="left" class="table_value"><div><input type="text" name="username" id="fe_login_username" size="30" spellcheck="false" value="'+(app.getPref('username') || '')+'"/></div></td>';
-					html += '</tr>';
-					html += '<tr><td colspan="2"><div class="table_spacer"></div></td></tr>';
-					html += '<tr>';
-						html += '<td align="right" class="table_label">Password:</td>';
-						html += '<td align="left" class="table_value"><div><input type="' + app.get_password_type() + '" name="password" id="fe_login_password" size="30" spellcheck="false" value=""/>' + app.get_password_toggle_html() + '</div></td>';
-					html += '</tr>';
-					html += '<tr><td colspan="2"><div class="table_spacer"></div></td></tr>';
-				html += '</table></center>';
-			html += '</div>';
+			if (!hide_local_login) {
+				html += '<div class="dialog_content">';
+					html += '<center><table style="margin:0px;">';
+						html += '<tr>';
+							html += '<td align="right" class="table_label">Username:</td>';
+							html += '<td align="left" class="table_value"><div><input type="text" name="username" id="fe_login_username" size="30" spellcheck="false" value="'+(app.getPref('username') || '')+'"/></div></td>';
+						html += '</tr>';
+						html += '<tr><td colspan="2"><div class="table_spacer"></div></td></tr>';
+						html += '<tr>';
+							html += '<td align="right" class="table_label">Password:</td>';
+							html += '<td align="left" class="table_value"><div><input type="' + app.get_password_type() + '" name="password" id="fe_login_password" size="30" spellcheck="false" value=""/>' + app.get_password_toggle_html() + '</div></td>';
+						html += '</tr>';
+						html += '<tr><td colspan="2"><div class="table_spacer"></div></td></tr>';
+					html += '</table></center>';
+				html += '</div>';
+			}
 			
 			html += '<div class="dialog_buttons"><center><table><tr>';
-				if (config.free_accounts) {
-					html += '<td><div class="button" style="width:120px; font-weight:normal;" onMouseUp="$P().navCreateAccount()">Create Account...</div></td>';
+				if (!hide_local_login) {
+					if (config.free_accounts) {
+						html += '<td><div class="button" style="width:120px; font-weight:normal;" onMouseUp="$P().navCreateAccount()">Create Account...</div></td>';
+						html += '<td width="20">&nbsp;</td>';
+					}
+					html += '<td><div class="button" style="width:120px; font-weight:normal;" onMouseUp="$P().navPasswordRecovery()">Forgot Password...</div></td>';
 					html += '<td width="20">&nbsp;</td>';
+					html += '<td><div class="button" style="width:120px;" onMouseUp="$P().doLogin()"><i class="fa fa-sign-in">&nbsp;&nbsp;</i>Login</div></td>';
 				}
-				html += '<td><div class="button" style="width:120px; font-weight:normal;" onMouseUp="$P().navPasswordRecovery()">Forgot Password...</div></td>';
-				html += '<td width="20">&nbsp;</td>';
-				html += '<td><div class="button" style="width:120px;" onMouseUp="$P().doLogin()"><i class="fa fa-sign-in">&nbsp;&nbsp;</i>Login</div></td>';
 				if (config.oauth) {
-					html += '<td width="20">&nbsp;</td>';
-					html += '<td><div class="button" style="width:120px;" onMouseUp="$P().doOauth()"><i class="fa fa-sign-in">&nbsp;&nbsp;</i>SSO</div></td>';
+					if (!hide_local_login) html += '<td width="20">&nbsp;</td>';
+					html += '<td><div class="button" style="min-width:120px;" onMouseUp="$P().doOauth()"><i class="fa fa-sign-in">&nbsp;&nbsp;</i>' + oauth_button_label + '</div></td>';
 				}
 			html += '</tr></table></center></div>';
 		html += '</div>';
@@ -68,17 +78,19 @@ Class.subclass( Page.Base, "Page.Login", {
 		html += '</form>';
 		this.div.html( html );
 		
-		setTimeout( function() {
-			$( app.getPref('username') ? '#fe_login_password' : '#fe_login_username' ).focus();
-			
-			 $('#fe_login_username, #fe_login_password').keypress( function(event) {
-				if (event.keyCode == '13') { // enter key
-					event.preventDefault();
-					$P().doLogin();
-				}
-			} ); 
-			
-		}, 1 );
+		if (!hide_local_login) {
+			setTimeout( function() {
+				$( app.getPref('username') ? '#fe_login_password' : '#fe_login_username' ).focus();
+
+				 $('#fe_login_username, #fe_login_password').keypress( function(event) {
+					if (event.keyCode == '13') { // enter key
+						event.preventDefault();
+						$P().doLogin();
+					}
+				} );
+
+			}, 1 );
+		}
 
 		return true;
 	},

--- a/lib/api/config.js
+++ b/lib/api/config.js
@@ -50,6 +50,9 @@ module.exports = Class.create({
 				socket_io_transports: this.server.config.get('socket_io_transports') || 0,
 				base_path: base_path,
 				oauth: oauth.enabled || 0,
+				oauth_button_label: oauth.button_label || 'SSO',
+				oauth_only: (oauth.enabled && oauth.only) || 0,
+				oauth_auto_login: (oauth.enabled && oauth.auto_login) || 0,
 				live_log_page_size: this.server.config.get('live_log_page_size') || 8192
 			} ),
 			port: args.request.headers.ssl ? this.web.config.get('https_port') : this.web.config.get('http_port'),

--- a/lib/test.js
+++ b/lib/test.js
@@ -302,6 +302,29 @@ module.exports = {
 				test.done();
 			} );
 		},
+
+		function testAPIOAuthOnlyRejectsPasswordLogin(test) {
+			// oauth-only mode must reject even a valid local password
+			var oauth = server.config.get('oauth');
+			oauth.enabled = true;
+			oauth.only = true;
+
+			var params = {
+				username: "admin",
+				password: "admin"
+			};
+			request.json( api_url + '/user/login', params, function(err, resp, data) {
+				oauth.only = false;
+				oauth.enabled = false;
+
+				test.ok( !err, "No error requesting user/login API" );
+				test.ok( resp.statusCode == 200, "HTTP 200 from user/login API" );
+				test.ok( data.code == 'login', "Password login is rejected in OAuth-only mode" );
+				test.ok( !data.session_id, "No session_id in response" );
+
+				test.done();
+			} );
+		},
 		
 		function testAPIUserLogin(test) {
 			// login as admin (successfully), save session id for downstream tests
@@ -331,6 +354,9 @@ module.exports = {
 				
 				test.ok( !err, "No error requesting API" );
 				test.ok( resp.statusCode == 200, "HTTP 200 from API" );
+				test.ok( data.indexOf('"oauth_button_label":"SSO"') >= 0, "OAuth button label is included in client config" );
+				test.ok( data.indexOf('"oauth_only":0') >= 0, "OAuth-only mode defaults to disabled" );
+				test.ok( data.indexOf('"oauth_auto_login":0') >= 0, "OAuth auto-login defaults to disabled" );
 				
 				test.done();
 			} );

--- a/lib/user.js
+++ b/lib/user.js
@@ -789,6 +789,11 @@ module.exports = Class.create({
 	api_login: async function (args, callback) {
 		// user login, validate password, create new session
 		var self = this;
+		var oauth = self.server.config.get('oauth') || {};
+
+		if (oauth.enabled && oauth.only) {
+			return self.doError('login', "Password login is disabled. Use OAuth to sign in.", callback);
+		}
 
 		var params = args.params;
 

--- a/sample_conf/config.json
+++ b/sample_conf/config.json
@@ -76,6 +76,9 @@
 
 	"oauth": {
 		"enabled": false,
+		"button_label": "SSO",
+		"only": false,
+		"auto_login": false,
 		"insecure": false,
 		"client_id": "XXXXXXXXXX",
 		"client_secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",


### PR DESCRIPTION
## What changed

- `oauth.button_label` sets the OAuth/OIDC button text.
- `oauth.only` hides local login controls and rejects password login requests at `/api/user/login`.
- `oauth.auto_login` redirects unauthenticated visitors directly to OAuth/OIDC.

All options keep the current behavior by default.

## Why

OIDC deployments often need a provider-specific label and a way to enforce SSO without reverse-proxy or local frontend patches.

## Validation

- 55/55 unit tests passed (364 assertions).
- JavaScript syntax and sample config JSON validated.
- Login UI checked for default, custom label, OAuth-only, auto-login, and OAuth-disabled configurations.

Manual browser verification against a real provider is pending.
