### PR TITLE
fix(freebsd): restore job resource monitoring

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -2128,11 +2128,11 @@ module.exports = Class.create({
 	monitorServerResources: function (callback) {
 		// monitor local CPU and memory for all active jobs (once per minute)
 		// shell exec to get running process cpu and memory usage
-		// this works on at least: OS X, Fedora, Ubuntu and CentOS
+		// this works on at least: FreeBSD, OS X, Fedora, Ubuntu and CentOS
 		var self = this;
 		var now = Tools.timeNow();
 
-		var defCmd = '/bin/ps -eo "ppid pid %cpu rss"' 
+		var defCmd = '/bin/ps -axo ppid=,pid=,%cpu=,rss='
 		var kb = 1024
 
 		if(process.platform == 'win32') {

--- a/lib/job.js
+++ b/lib/job.js
@@ -2128,11 +2128,14 @@ module.exports = Class.create({
 	monitorServerResources: function (callback) {
 		// monitor local CPU and memory for all active jobs (once per minute)
 		// shell exec to get running process cpu and memory usage
-		// this works on at least: FreeBSD, OS X, Fedora, Ubuntu and CentOS
+		// this works on at least: OS X, Fedora, Ubuntu and CentOS
 		var self = this;
 		var now = Tools.timeNow();
 
-		var defCmd = '/bin/ps -axo ppid=,pid=,%cpu=,rss='
+		var defCmd = '/bin/ps -eo "ppid pid %cpu rss"'
+		if(process.platform == 'freebsd') {
+			defCmd = '/bin/ps -axo ppid=,pid=,%cpu=,rss='
+		}
 		var kb = 1024
 
 		if(process.platform == 'win32') {


### PR DESCRIPTION
## Summary

- keep the existing default `ps` command on Linux, macOS, and other platforms
- use the portable process query only on FreeBSD
- keep the existing output parser, Windows path, and `ps_monitor_cmd` override unchanged

## Problem

On FreeBSD, `/bin/ps -eo "ppid pid %cpu rss"` exits with an error. Cronicle then logs `Failed to exec ps` and does not update CPU or memory metrics for the server and active jobs.

## Fix

Keep `/bin/ps -eo "ppid pid %cpu rss"` as the default command. Only when `process.platform == 'freebsd'`, use `/bin/ps -axo ppid=,pid=,%cpu=,rss=`. The FreeBSD command selects all processes and emits the same four numeric fields without headers, so the existing parser remains unchanged.

## Validation

- verified the FreeBSD command on FreeBSD/amd64
- `npm ci`
- `npm test`: 55/55 tests passed, 364 assertions
- `node --check lib/job.js`
- `git diff --check`

The existing job lifecycle tests call `monitorServerResources` and verify that CPU and memory metrics are recorded.
