### PR TITLE
fix(freebsd): fail safely when getnode is unsupported

### DIFF
--- a/bin/getnode.sh
+++ b/bin/getnode.sh
@@ -7,10 +7,15 @@ DEFAULT_VERSION="20.16.0"
 NODEJS_VERSION="${1:-$DEFAULT_VERSION}"
 
 get_arch () {
-	local arch
+	local arch os os_name
 	arch=$(uname -m)
-    os="linux"
-    if [[ "$(uname)" == "Darwin" ]]; then os="darwin"; fi 
+	os_name=$(uname -s)
+	if [[ "$os_name" == "FreeBSD" ]]; then
+		echo "Error: Node.js does not publish FreeBSD binaries. Install Node.js using the FreeBSD package manager." >&2
+		return 2
+	fi
+	os="linux"
+	if [[ "$os_name" == "Darwin" ]]; then os="darwin"; fi
 
 	[[ ! $arch ]] && return 1
 	case $arch in 
@@ -21,13 +26,14 @@ get_arch () {
 		ppc64el|ppc64le) binArch='ppc64le' ;; 
 		s390x)   binArch='s390x' ;; 
 		# .*386.*) binArch='amd32' ;;
-		*) return 2 ;;\
+		*) return 2 ;;
 	esac; 
-    echo "$os-$binArch"
+	echo "$os-$binArch"
 }
 
 # Define the download URL for the specified version of Node.js
-NODEJS_URL="https://nodejs.org/dist/v$NODEJS_VERSION/node-v$NODEJS_VERSION-$(get_arch).tar.xz"
+NODEJS_PLATFORM="$(get_arch)" || exit $?
+NODEJS_URL="https://nodejs.org/dist/v$NODEJS_VERSION/node-v$NODEJS_VERSION-$NODEJS_PLATFORM.tar.xz"
 
 # Specify the directory to store the downloaded Node.js archive
 TARGET_DIR="$HOMEDIR/nodejs"

--- a/bin/getnode.sh
+++ b/bin/getnode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 HOMEDIR="$(dirname "$(cd -- "$(dirname "$(readlink -f "$0")")" && (pwd -P 2>/dev/null || pwd))")"
 
 DEFAULT_VERSION="20.16.0"


### PR DESCRIPTION
## Summary

- stop `getnode.sh` before changing an existing installation when run on FreeBSD
- explain that Node.js must be installed through the FreeBSD package manager
- locate Bash through `PATH`, where FreeBSD packages install it

## Problem

Node.js does not publish FreeBSD binaries in its official release archive. On FreeBSD/amd64, `get_arch` returns no platform, but the script continues with a URL ending in `node-v20.16.0-.tar.xz`.

Before that download fails, the script removes the existing `nodejs` directory. It then continues after the failed download and can print `Node.js installed` with exit code 0.

## Fix

Detect FreeBSD while resolving the archive platform and return a clear error. Propagate that result before constructing the URL or removing the existing installation. Use `/usr/bin/env bash` because packaged Bash lives outside `/bin` on standard FreeBSD. Linux and macOS archive selection remains unchanged.

## Validation

- confirmed the target host reports `FreeBSD/amd64`
- reproduced the old behavior: invalid URL, existing-install sentinel deleted, exit code 0
- verified the fixed behavior: clear error, exit code 2, existing-install sentinel preserved
- verified Linux/x64 still resolves to `node-v20.16.0-linux-x64.tar.xz`
- verified `/usr/bin/env bash` on the FreeBSD target
- `npm test`: 55/55 tests passed, 364 assertions
- `bash -n bin/getnode.sh`
- `git diff --check`
