### PR TITLE
fix(freebsd): use portable bash shebangs

### DIFF
--- a/bin/manager
+++ b/bin/manager
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 HOMEDIR="$(dirname "$(cd -- "$(dirname "$(readlink -f "$0")")" && (pwd -P 2>/dev/null || pwd))")"
 
 usage() {

--- a/bundle
+++ b/bundle
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
## Summary

Use `#!/usr/bin/env bash` for the two Bash entrypoints that still hardcode `/bin/bash`.

## Problem

FreeBSD does not include Bash in the base system. The package installs it under `/usr/local/bin/bash`, so `bundle` and `bin/manager` can fail before execution even when Bash is installed.

Both scripts use Bash-specific syntax, so changing them to `/bin/sh` would not be correct. Resolving Bash through `PATH` matches the existing script examples in this repository and works on FreeBSD, Linux, and macOS.

`bin/getnode.sh` is handled separately in #252 to avoid overlapping changes.

## Validation

- `bash -n bundle bin/manager`
- both files passed `bash -n` through `/usr/bin/env bash` on FreeBSD
- both executable help paths resolve the new shebang locally
- `git diff --check`

No JavaScript or runtime behavior is changed.
