### PR TITLE
fix(freebsd): bundle native Level build

### DIFF
--- a/bundle
+++ b/bundle
@@ -305,8 +305,18 @@ if [ "$level" = 1 ]; then
    printf "      - bundling Level Engine\n"
    npm i level --no-save --loglevel silent 
    esbuild --bundle --log-level=$ESBuildLogLevel $minify --platform=node --outdir=$dist/bin/engines engines/Level.js
-   mkdir -p $dist/bin/engines/prebuilds/
-   cp -r node_modules/classic-level/prebuilds/linux-x64 $dist/bin/engines/prebuilds/
+   level_prebuild="node_modules/classic-level/prebuilds/$(node -p 'process.platform + "-" + process.arch')"
+   if [ -d "$level_prebuild" ]; then
+      mkdir -p "$dist/bin/engines/prebuilds/"
+      cp -r "$level_prebuild" "$dist/bin/engines/prebuilds/"
+   elif [ -d node_modules/classic-level/build/Release ]; then
+      # node-gyp-build uses this directory when no platform prebuild is available.
+      mkdir -p "$dist/bin/engines/build/"
+      cp -r node_modules/classic-level/build/Release "$dist/bin/engines/build/"
+   else
+      echo "classic-level native build not found"
+      exit 1
+   fi
 fi
 
 if [ "$lmdb" = 1 ]; then


### PR DESCRIPTION
## Summary

- Select the `classic-level` prebuild for the current Node.js platform and architecture.
- Fall back to the native `build/Release` output when no prebuild is available.
- Fail clearly if installation produced no native artifact.

## Why

On FreeBSD, `classic-level` is compiled from source into `build/Release`. The current bundle always copies `prebuilds/linux-x64`, so the bundled Level engine fails with:

`No native build was found for platform=freebsd arch=x64`

The native loader searches relative to the bundled engine. Copying the source-built `build/Release` directory preserves the artifact produced during installation.

Linux behavior remains unchanged: the matching `linux-x64` prebuild is still copied. Other platforms use their matching platform/architecture directory when available.

## Validation

- Reproduced the failure on FreeBSD x64 with Node.js 22.22.2.
- Verified that the source-built native addon loads successfully.
- Tested the final fallback block on FreeBSD x64.
- Tested prebuild, source-build fallback, and missing-artifact paths.
- `bash -n bundle`
- Full suite: 55/55 tests, 364 assertions.
- `git diff --check`
