### PR TITLE
Prevent disabled LDAP group users from reactivating

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -376,6 +376,62 @@ module.exports = {
 				});
 			});
 		},
+
+		function testGroupUserIgnoresLocalPasswordReset(test) {
+			var username = 'ldap_user_with_local_lock';
+			var userPath = 'users/' + username;
+			var oldGroups = server.config.get('groups');
+			var userComponent = server.User;
+			var oldLDAPAuth = userComponent.do_ldap_auth;
+			var ldapCalls = 0;
+			var groupUser = {
+				username: username,
+				active: 1,
+				ext_auth: true,
+				group_auth: true,
+				force_password_reset: 1,
+				email: 'ldap-user@example.invalid',
+				full_name: 'LDAP User',
+				privileges: { admin: 1 }
+			};
+
+			server.config.set('groups', { allow: 1 });
+			userComponent.do_ldap_auth = async function() {
+				ldapCalls++;
+				return {
+					username: username,
+					active: 1,
+					ext_auth: true,
+					email: 'ldap-user@example.invalid',
+					full_name: 'LDAP User',
+					privileges: { admin: 1 }
+				};
+			};
+
+			storage.put(userPath, groupUser, function(err) {
+				test.ok(!err, "LDAP group user with a local lock was stored");
+				userComponent.api_login({
+					params: { username: username, password: 'valid' },
+					ip: '127.0.0.1',
+					request: { headers: { 'user-agent': 'unit-test' } }
+				}, function(data) {
+					test.ok(data.code == 0, "LDAP group user ignored the local password reset lock");
+					test.ok(ldapCalls == 1, "LDAP authenticated the group user");
+					storage.get(userPath, function(err, storedUser) {
+						test.ok(!err, "LDAP group user still exists");
+						test.ok(!storedUser.force_password_reset, "Local password reset lock was not retained");
+
+						userComponent.do_ldap_auth = oldLDAPAuth;
+						server.config.set('groups', oldGroups);
+						var cleanupUser = function() {
+							storage.delete(userPath, function() { test.done(); });
+						};
+						if (data.session_id) storage.delete('sessions/' + data.session_id, cleanupUser);
+						else cleanupUser();
+					});
+				});
+			});
+		},
 		
 		function testAPIUserLogin(test) {
 			// login as admin (successfully), save session id for downstream tests

--- a/lib/test.js
+++ b/lib/test.js
@@ -325,6 +325,57 @@ module.exports = {
 				test.done();
 			} );
 		},
+
+		function testDisabledGroupUserCannotLogin(test) {
+			var username = 'disabled_ldap_user';
+			var userPath = 'users/' + username;
+			var oldGroups = server.config.get('groups');
+			var userComponent = server.User;
+			var oldLDAPAuth = userComponent.do_ldap_auth;
+			var ldapCalls = 0;
+			var disabledUser = {
+				username: username,
+				active: 0,
+				ext_auth: true,
+				group_auth: true,
+				email: 'disabled@example.invalid',
+				full_name: 'Disabled LDAP User',
+				privileges: { admin: 1 }
+			};
+
+			server.config.set('groups', { allow: 1 });
+			userComponent.do_ldap_auth = async function() {
+				ldapCalls++;
+				return {
+					username: username,
+					active: 1,
+					ext_auth: true,
+					email: 'disabled@example.invalid',
+					full_name: 'Disabled LDAP User',
+					privileges: { admin: 1 }
+				};
+			};
+
+			storage.put(userPath, disabledUser, function(err) {
+				test.ok(!err, "Disabled LDAP group user was stored");
+				userComponent.api_login({
+					params: { username: username, password: 'valid' },
+					ip: '127.0.0.1',
+					request: { headers: { 'user-agent': 'unit-test' } }
+				}, function(data) {
+					test.ok(data.code != 0, "Disabled LDAP group user login was rejected");
+					test.ok(ldapCalls == 0, "LDAP was not called for the disabled user");
+					storage.get(userPath, function(err, storedUser) {
+						test.ok(!err, "Disabled LDAP group user still exists");
+						test.ok(storedUser.active === 0, "Disabled LDAP group user remained disabled");
+
+						userComponent.do_ldap_auth = oldLDAPAuth;
+						server.config.set('groups', oldGroups);
+						storage.delete(userPath, function() { test.done(); });
+					});
+				});
+			});
+		},
 		
 		function testAPIUserLogin(test) {
 			// login as admin (successfully), save session id for downstream tests

--- a/lib/user.js
+++ b/lib/user.js
@@ -815,6 +815,14 @@ module.exports = Class.create({
 
 		let useGroupAuth = (user || {}).group_auth
 
+		// Keep local account controls authoritative over LDAP refreshes.
+		if (allowGroupAuth && useGroupAuth && user.force_password_reset) {
+			return self.doError('login', "Account is locked out.  Please reset your password to unlock it.", callback);
+		}
+		if (allowGroupAuth && useGroupAuth && !user.active) {
+			return self.doError('login', "User account is disabled: " + params.username, callback);
+		}
+
 		if (allowGroupAuth) {
 			if (!user || useGroupAuth) {
 				// create or verify LDAP group users

--- a/lib/user.js
+++ b/lib/user.js
@@ -815,10 +815,7 @@ module.exports = Class.create({
 
 		let useGroupAuth = (user || {}).group_auth
 
-		// Keep local account controls authoritative over LDAP refreshes.
-		if (allowGroupAuth && useGroupAuth && user.force_password_reset) {
-			return self.doError('login', "Account is locked out.  Please reset your password to unlock it.", callback);
-		}
+		// Preserve locally suspended LDAP group accounts before LDAP refresh.
 		if (allowGroupAuth && useGroupAuth && !user.active) {
 			return self.doError('login', "User account is disabled: " + params.username, callback);
 		}


### PR DESCRIPTION
## Summary

- reject locally disabled LDAP group users before refreshing their account
- keep the local `active` control authoritative while leaving password and lockout policy to LDAP/AD
- add regressions for disabled group users and stale local password-reset flags

## Why

Group-auth login refreshed and replaced the stored user before checking `active`. A disabled user with valid LDAP credentials could therefore be written back with `active: 1` and log in again.

The early check applies only to existing group-auth users while LDAP group authentication is enabled. A stale `force_password_reset` value does not block a group user or show a Cronicle password-reset message; LDAP/AD remains responsible for authenticating and locking directory accounts.

New LDAP users and local-password users keep their existing flow.

## Tests

- before the original fix: `55/56` tests passed; the regression showed that LDAP was called and the stored account became active
- current branch: `57/57` tests passed (`374` assertions)
- `node --check lib/user.js`
- `node --check lib/test.js`
- `git diff --check`
