### PR TITLE
fix: restrict unprivileged run_event overrides

### DIFF
--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -415,15 +415,29 @@ module.exports = Class.create({
 
 	api_run_event: function (args, callback) {
 		// run event manually (via "Run" button in UI or by API Key)
-		// can include any event overrides in params (such as 'now')
+		// can include authorized runtime overrides such as now, arg and post_data
 		var self = this;
 		if (!this.requiremanager(args, callback)) return;
 
-		// default behavor: merge post params and query together
-		// alt behavior (post_data): store post params into post_data
-		var params = Tools.copyHash(args.query, true);
-		if (args.query.post_data) params.post_data = args.params;
-		else Tools.mergeHashInto(params, args.params);
+		// Default behavior: merge request params and query using own properties only.
+		// Never assign prototype-control keys into a normal object.
+		// Alt behavior (post_data): keep the request body as opaque plugin input.
+		var params = {};
+		var blocked_keys = [ '__proto__', 'prototype', 'constructor' ];
+		var mergeRequestFields = function(source) {
+			if (!source || (typeof source != 'object')) return true;
+			var keys = Object.keys(source);
+			for (var idx = 0; idx < keys.length; idx++) {
+				var key = keys[idx];
+				if (blocked_keys.indexOf(key) >= 0) return false;
+				params[key] = source[key];
+			}
+			return true;
+		};
+
+		if (!mergeRequestFields(args.query)) return this.doError('api', "Malformed request parameter", callback);
+		if (Object.prototype.hasOwnProperty.call(args.query, 'post_data') && args.query.post_data) params.post_data = args.params;
+		else if (!mergeRequestFields(args.params)) return this.doError('api', "Malformed request parameter", callback);
 
 		var criteria = {};
 		if (params.id) criteria.id = params.id;
@@ -484,6 +498,14 @@ module.exports = Class.create({
 				delete params.chain_data;
 				// The memo is also internal scheduler state, never caller input.
 				delete params.memo;
+				// Remove caller-supplied authentication and provenance fields.
+				delete params.api_key;
+				delete params.token;
+				delete params.username;
+				delete params.source;
+				delete params.source_id;
+				delete params.source_event;
+				delete params.source_log;
 
 				let privs = user.privileges || {}
 				let canEdit = privs.edit_events || privs.create_events || privs.admin
@@ -506,8 +528,7 @@ module.exports = Class.create({
 						if (key.match(/^(\w+)\/(\w+)$/)) {
 							var parent_key = RegExp.$1;
 							var sub_key = RegExp.$2;
-							var blocked_key = [ '__proto__', 'prototype', 'constructor' ];
-							if ((blocked_key.indexOf(parent_key) >= 0) || (blocked_key.indexOf(sub_key) >= 0)) {
+							if ((blocked_keys.indexOf(parent_key) >= 0) || (blocked_keys.indexOf(sub_key) >= 0)) {
 								return self.doError('api', "Malformed nested parameter", callback);
 							}
 							if (!Object.prototype.hasOwnProperty.call(params, parent_key)) params[parent_key] = {};
@@ -528,6 +549,10 @@ module.exports = Class.create({
 				}
 
 				var job = Tools.mergeHashes(Tools.copyHash(event, true), params);
+				// Also discard stale provenance stored by older event records.
+				[ 'api_key', 'token', 'username', 'source', 'source_id', 'source_event', 'source_log' ].forEach(function(key) {
+					delete job[key];
+				});
 				if (user.key) {
 					// API Key
 					job.source = "API Key (" + user.title + ")";

--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -482,34 +482,49 @@ module.exports = Class.create({
 				delete params.secret;
 				// Chain data is internal scheduler state, never caller input.
 				delete params.chain_data;
+				// The memo is also internal scheduler state, never caller input.
+				delete params.memo;
 
 				let privs = user.privileges || {}
+				let canEdit = privs.edit_events || privs.create_events || privs.admin
 				// only admin can set debug_sudo option
 				if(!privs.admin) delete params.debug_sudo
 				
-				// allow for &params/foo=bar and the like
-				for (var key in params) {
-					if (key.match(/^(\w+)\/(\w+)$/)) {
-						var parent_key = RegExp.$1;
-						var sub_key = RegExp.$2;
-						if (!params[parent_key]) params[parent_key] = {};
-						params[parent_key][sub_key] = params[key];
-						delete params[key];
-					}
-				}
-
-				// allow sparsely populated event params in request
-				if (params.params && event.params) {
-					for (var key in event.params) {
-						if (!(key in params.params)) params.params[key] = event.params[key];
-					}
-				}
-
-				// Only editors may customize plugin parameters or the job memo.
-				let canEdit = user.privileges.edit_events || user.privileges.create_events ||  user.privileges.admin
+				// Run-only callers may supply only the documented ad-hoc runtime inputs.
+				// Everything else must come from the stored event that passed RBAC above.
 				if(!canEdit) {
-					delete params.params;
-					delete params.memo;
+					let runtimeParams = {};
+					[ 'now', 'arg', 'args', 'post_data' ].forEach(function(key) {
+						if (Object.prototype.hasOwnProperty.call(params, key)) runtimeParams[key] = params[key];
+					});
+					params = runtimeParams;
+				}
+				else {
+					// Allow editors to use &params/foo=bar and similar nested overrides,
+					// without permitting prototype-chain writes.
+					for (var key in params) {
+						if (key.match(/^(\w+)\/(\w+)$/)) {
+							var parent_key = RegExp.$1;
+							var sub_key = RegExp.$2;
+							var blocked_key = [ '__proto__', 'prototype', 'constructor' ];
+							if ((blocked_key.indexOf(parent_key) >= 0) || (blocked_key.indexOf(sub_key) >= 0)) {
+								return self.doError('api', "Malformed nested parameter", callback);
+							}
+							if (!Object.prototype.hasOwnProperty.call(params, parent_key)) params[parent_key] = {};
+							if (!params[parent_key] || (typeof params[parent_key] != 'object') || Tools.isaArray(params[parent_key])) {
+								return self.doError('api', "Malformed nested parameter container: " + parent_key, callback);
+							}
+							params[parent_key][sub_key] = params[key];
+							delete params[key];
+						}
+					}
+
+					// allow sparsely populated event params in editor requests
+					if (params.params && event.params) {
+						for (var key in event.params) {
+							if (!(key in params.params)) params.params[key] = event.params[key];
+						}
+					}
 				}
 
 				var job = Tools.mergeHashes(Tools.copyHash(event, true), params);

--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -480,6 +480,8 @@ module.exports = Class.create({
 				delete params.session_id;
 				delete params.uid;
 				delete params.secret;
+				// Chain data is internal scheduler state, never caller input.
+				delete params.chain_data;
 
 				let privs = user.privileges || {}
 				// only admin can set debug_sudo option
@@ -503,10 +505,11 @@ module.exports = Class.create({
 					}
 				}
 
-				// only allow customize event params (like script in shell plug) to users with edit priv
+				// Only editors may customize plugin parameters or the job memo.
 				let canEdit = user.privileges.edit_events || user.privileges.create_events ||  user.privileges.admin
-				if(!canEdit && params.params) {
+				if(!canEdit) {
 					delete params.params;
+					delete params.memo;
 				}
 
 				var job = Tools.mergeHashes(Tools.copyHash(event, true), params);

--- a/lib/test.js
+++ b/lib/test.js
@@ -3,6 +3,7 @@
 // Released under the MIT License
 
 var cp = require('child_process');
+var crypto = require('crypto');
 var fs = require('fs');
 var async = require('async');
 var moment = require('moment-timezone');
@@ -968,6 +969,42 @@ module.exports = {
 				}, 1000 * 5 );
 				
 			} );
+		},
+
+		function testEventTokenCannotInjectChainArguments(test) {
+			var self = this;
+			var salt = 'unit_test_token_salt';
+			var oldLaunch = cronicle.launchOrQueueJob;
+			var launchedJob = null;
+
+			storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: salt }, function(err) {
+				test.ok(!err, "Event token was enabled");
+				var token = crypto.createHmac('sha1', server.config.get('secret_key'))
+					.update(self.event_id + salt)
+					.digest('hex');
+
+				cronicle.launchOrQueueJob = function(job, callback) {
+					launchedJob = job;
+					callback(null, []);
+				};
+
+				request.json(api_url + '/app/run_event', {
+					id: self.event_id,
+					token: token,
+					chain_data: { args: ['injected'] },
+					memo: 'args:injected'
+				}, function(err, resp, data) {
+					cronicle.launchOrQueueJob = oldLaunch;
+					test.ok(!err, "Event token request succeeded");
+					test.ok(data.code == 0, "Event token launched the configured event");
+					test.ok(launchedJob && !('chain_data' in launchedJob), "Event token chain data was ignored");
+					test.ok(launchedJob && !('memo' in launchedJob), "Event token memo was ignored");
+
+					storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: '' }, function() {
+						test.done();
+					});
+				});
+			});
 		},
 		
 		function testJobInProgress(test) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -1092,119 +1092,213 @@ module.exports = {
 			var self = this;
 			var salt = 'unit_test_token_salt';
 			var oldLaunch = cronicle.launchOrQueueJob;
+			var oldLaunchJob = cronicle.launchJob;
+			var oldEventQueueCount = cronicle.eventQueue[this.event_id];
+			var queuePath = 'global/event_queue/' + this.event_id;
+			var originalEvent = null;
 			var launchedJob = null;
 			var allowedNow = Tools.timeNow(true) - 60;
+			var finished = false;
+
+			function captureLaunch(job, callback) {
+				launchedJob = job;
+				callback(null, []);
+			}
+
+			function restoreEventQueueCount() {
+				if (typeof(oldEventQueueCount) == 'undefined') delete cronicle.eventQueue[self.event_id];
+				else cronicle.eventQueue[self.event_id] = oldEventQueueCount;
+			}
 
 			function finish() {
+				if (finished) return;
+				finished = true;
 				cronicle.launchOrQueueJob = oldLaunch;
-				storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: '' }, function(err) {
-					test.ok(!err, "Event token fixture was restored");
-					test.done();
+				cronicle.launchJob = oldLaunchJob;
+				restoreEventQueueCount();
+				storage.listDelete(queuePath, true, function() {
+					var restore = {
+						salt: originalEvent && originalEvent.salt ? originalEvent.salt : '',
+						queue: originalEvent && originalEvent.queue ? originalEvent.queue : false,
+						queue_max: originalEvent && originalEvent.queue_max ? originalEvent.queue_max : 0
+					};
+					storage.listFindUpdate('global/schedule', { id: self.event_id }, restore, function(err) {
+						test.ok(!err, "Event token and queue fixtures were restored");
+						test.done();
+					});
 				});
 			}
 
-			storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: salt }, function(err) {
-				test.ok(!err, "Event token was enabled");
-				if (err) return finish();
-				var token = crypto.createHmac('sha1', server.config.get('secret_key'))
-					.update(self.event_id + salt)
-					.digest('hex');
-
-				cronicle.launchOrQueueJob = function(job, callback) {
-					launchedJob = job;
-					callback(null, []);
-				};
-
+			function runEditorChecks() {
+				cronicle.launchOrQueueJob = captureLaunch;
+				launchedJob = null;
 				request.json(api_url + '/app/run_event', {
 					id: self.event_id,
-					token: token,
-					now: allowedNow,
-					arg: 'allowed-argument',
-					args: 'allowed-argument',
-					post_data: { allowed: true },
-					chain_data: { args: ['injected'] },
-					memo: 'args:injected',
-					plugin: 'attacker_plugin',
-					workflow: [{ id: 'attacker_event' }],
-					target: 'attacker-target',
-					chain: 'attacker_event',
-					chain_error: 'attacker_event',
-					options: { wf_start_from_step: 99 },
-					files: [{ name: 'payload.sh', content: 'malicious' }],
-					params: { script: 'echo attacker-override' },
-					notify_fail: 'attacker@example.com',
-					debug_sudo: 1,
-					source: 'attacker',
-					source_id: 'attacker',
-					'__proto__/polluted': 'yes'
+					session_id: session_id,
+					chain_data: { args: ['editor-injected'] },
+					memo: 'args:editor-injected',
+					source: 'editor-injected',
+					source_id: 'editor-injected',
+					source_event: 'editor-injected',
+					source_log: 'javascript:alert(1)',
+					username: 'editor-injected',
+					api_key: 'editor_injected',
+					params: { script: 'echo editor-override' }
 				}, function(err, resp, data) {
-					test.ok(!err, "Event token request succeeded");
-					test.ok(data.code == 0, "Event token launched the configured event");
-					test.ok(launchedJob && !('chain_data' in launchedJob), "Event token chain data was ignored");
-					test.ok(launchedJob && !('memo' in launchedJob), "Event token memo was ignored");
-					test.ok(launchedJob && launchedJob.plugin != 'attacker_plugin', "Event token plugin override was ignored");
-					test.ok(launchedJob && launchedJob.target != 'attacker-target', "Event token target override was ignored");
-					test.ok(launchedJob && launchedJob.chain != 'attacker_event', "Event token success-chain override was ignored");
-					test.ok(launchedJob && launchedJob.chain_error != 'attacker_event', "Event token error-chain override was ignored");
-					test.ok(launchedJob && !launchedJob.workflow, "Event token workflow override was ignored");
-					test.ok(launchedJob && !launchedJob.options, "Event token workflow options override was ignored");
-					test.ok(launchedJob && !launchedJob.files, "Event token file override was ignored");
-					test.ok(launchedJob && (!launchedJob.params || launchedJob.params.script != 'echo attacker-override'), "Event token plugin parameters were ignored");
-					test.ok(launchedJob && launchedJob.notify_fail != 'attacker@example.com', "Event token notification override was ignored");
-					test.ok(launchedJob && !launchedJob.debug_sudo, "Event token debug_sudo override was ignored");
-					test.ok(launchedJob && launchedJob.source == 'Event Token', "Server-derived source was preserved");
-					test.ok(launchedJob && launchedJob.now == allowedNow, "Event token current-time override remained available");
-					test.ok(launchedJob && launchedJob.arg == 'allowed-argument', "Event token job argument remained available");
-					test.ok(launchedJob && launchedJob.args == 'allowed-argument', "Event token args alias remained available");
-					test.ok(launchedJob && launchedJob.post_data && launchedJob.post_data.allowed, "Event token POST data remained available");
-					test.ok(!({}).polluted, "Run-only nested input did not modify Object.prototype");
+					test.ok(!err, "Editor request succeeded");
+					test.ok(data.code == 0, "Editor launched the configured event");
+					test.ok(launchedJob && !('chain_data' in launchedJob), "Editor chain data was ignored");
+					test.ok(launchedJob && !('memo' in launchedJob), "Editor memo was ignored");
+					test.ok(launchedJob && launchedJob.params && launchedJob.params.script == 'echo editor-override', "Editor plugin parameters remain customizable");
+					test.ok(launchedJob && launchedJob.source == 'Manual (admin)', "Editor source was derived by the server");
+					test.ok(launchedJob && launchedJob.username == 'admin', "Editor username was derived by the server");
+					test.ok(launchedJob && !('source_id' in launchedJob), "Editor source ID override was ignored");
+					test.ok(launchedJob && !('source_event' in launchedJob), "Editor source event override was ignored");
+					test.ok(launchedJob && !('source_log' in launchedJob), "Editor source log override was ignored");
+					test.ok(launchedJob && !('api_key' in launchedJob), "Editor API key override was ignored");
 
 					launchedJob = null;
 					request.json(api_url + '/app/run_event', {
 						id: self.event_id,
 						session_id: session_id,
-						chain_data: { args: ['editor-injected'] },
-						memo: 'args:editor-injected',
-						source: 'editor-injected',
-						source_id: 'editor-injected',
-						source_event: 'editor-injected',
-						source_log: 'javascript:alert(1)',
-						username: 'editor-injected',
-						api_key: 'editor_injected',
-						params: { script: 'echo editor-override' }
+						'__proto__/polluted': 'yes'
 					}, function(err, resp, data) {
-						test.ok(!err, "Editor request succeeded");
-						test.ok(data.code == 0, "Editor launched the configured event");
-						test.ok(launchedJob && !('chain_data' in launchedJob), "Editor chain data was ignored");
-						test.ok(launchedJob && !('memo' in launchedJob), "Editor memo was ignored");
-						test.ok(launchedJob && launchedJob.params && launchedJob.params.script == 'echo editor-override', "Editor plugin parameters remain customizable");
-						test.ok(launchedJob && launchedJob.source == 'Manual (admin)', "Editor source was derived by the server");
-						test.ok(launchedJob && launchedJob.username == 'admin', "Editor username was derived by the server");
-						test.ok(launchedJob && !('source_id' in launchedJob), "Editor source ID override was ignored");
-						test.ok(launchedJob && !('source_event' in launchedJob), "Editor source event override was ignored");
-						test.ok(launchedJob && !('source_log' in launchedJob), "Editor source log override was ignored");
-						test.ok(launchedJob && !('api_key' in launchedJob), "Editor API key override was ignored");
+						test.ok(!err, "Malformed editor nested request returned a response");
+						test.ok(data.code == 'api', "Prototype-chain nested request was rejected");
+						test.ok(!launchedJob, "Rejected nested request did not launch a job");
+						test.ok(!({}).polluted, "Editor nested input did not modify Object.prototype");
+
+						launchedJob = null;
+						var prototypePayload = JSON.parse('{"id":"' + self.event_id + '","session_id":"' + session_id + '","__proto__":{"target":"attacker-target","plugin":"attacker_plugin","debug_sudo":1}}');
+						request.json(api_url + '/app/run_event', prototypePayload, function(err, resp, data) {
+							test.ok(!err, "Raw prototype payload returned a response");
+							test.ok(data.code == 'api', "Raw prototype-control key was rejected");
+							test.ok(!launchedJob, "Raw prototype payload did not launch a job");
+							test.ok(!({}).polluted, "Raw prototype payload did not modify Object.prototype");
+							finish();
+						});
+					});
+				});
+			}
+
+			function runDurableQueueCheck(token) {
+				storage.listDelete(queuePath, true, function() {
+					storage.listFindUpdate('global/schedule', { id: self.event_id }, { queue: 1, queue_max: 5 }, function(err) {
+						test.ok(!err, "Durable event queue fixture was enabled");
+						if (err) return runEditorChecks();
+
+						cronicle.launchOrQueueJob = oldLaunch;
+						cronicle.launchJob = function(job, callback) {
+							callback(new Error('Intentional capacity failure for durable queue regression'));
+						};
+
+						request.json(api_url + '/app/run_event', {
+							id: self.event_id,
+							token: token,
+							repeat: -1,
+							enabled: false
+						}, function(err, resp, data) {
+							cronicle.launchJob = oldLaunchJob;
+							test.ok(!err, "Queued event-token request succeeded");
+							test.ok(data && data.code == 0, "Launch failure was converted into an event queue entry");
+							test.ok(data && data.ids && data.ids.length == 0 && data.queue, "Queued response reported no launched jobs");
+
+							async.retry({ times: 20, interval: 25 }, function(callback) {
+								storage.listGet(queuePath, 0, 0, function(err, items) {
+									if (!err && items && items.length) return callback(null, items);
+									callback(err || new Error('Queued record is not durable yet'));
+								});
+							}, function(queueErr, items) {
+								test.ok(!queueErr, "Launch failure persisted an event queue record");
+								var queuedEvent = items && items[0];
+								test.ok(!!queuedEvent, "Persisted event queue record was readable");
+								test.ok(queuedEvent && queuedEvent.repeat === originalEvent.repeat, "Persisted event used the configured repeat value");
+								test.ok(queuedEvent && queuedEvent.repeat !== -1, "Caller repeat override was not persisted");
+								test.ok(queuedEvent && queuedEvent.enabled === originalEvent.enabled, "Caller enabled override was not persisted");
+
+								storage.listDelete(queuePath, true, function() {
+									restoreEventQueueCount();
+									runEditorChecks();
+								});
+							});
+						});
+					});
+				});
+			}
+
+			storage.listFind('global/schedule', { id: self.event_id }, function(err, event) {
+				test.ok(!err && !!event, "Original event fixture was loaded");
+				if (err || !event) return finish();
+				originalEvent = Tools.copyHash(event, true);
+
+				storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: salt }, function(err) {
+					test.ok(!err, "Event token was enabled");
+					if (err) return finish();
+					var token = crypto.createHmac('sha1', server.config.get('secret_key'))
+						.update(self.event_id + salt)
+						.digest('hex');
+
+					cronicle.launchOrQueueJob = captureLaunch;
+					request.json(api_url + '/app/run_event', {
+						id: self.event_id,
+						token: token,
+						now: allowedNow,
+						arg: 'allowed-argument',
+						args: 'allowed-argument',
+						post_data: { allowed: true },
+						repeat: 1,
+						enabled: false,
+						chain_data: { args: ['injected'] },
+						memo: 'args:injected',
+						plugin: 'attacker_plugin',
+						workflow: [{ id: 'attacker_event' }],
+						target: 'attacker-target',
+						chain: 'attacker_event',
+						chain_error: 'attacker_event',
+						options: { wf_start_from_step: 99 },
+						files: [{ name: 'payload.sh', content: 'malicious' }],
+						params: { script: 'echo attacker-override' },
+						notify_fail: 'attacker@example.com',
+						debug_sudo: 1,
+						source: 'attacker',
+						source_id: 'attacker',
+						'__proto__/polluted': 'yes'
+					}, function(err, resp, data) {
+						test.ok(!err, "Event token request succeeded");
+						test.ok(data.code == 0, "Event token launched the configured event");
+						test.ok(launchedJob && !('chain_data' in launchedJob), "Event token chain data was ignored");
+						test.ok(launchedJob && !('memo' in launchedJob), "Event token memo was ignored");
+						test.ok(launchedJob && launchedJob.plugin != 'attacker_plugin', "Event token plugin override was ignored");
+						test.ok(launchedJob && launchedJob.target != 'attacker-target', "Event token target override was ignored");
+						test.ok(launchedJob && launchedJob.chain != 'attacker_event', "Event token success-chain override was ignored");
+						test.ok(launchedJob && launchedJob.chain_error != 'attacker_event', "Event token error-chain override was ignored");
+						test.ok(launchedJob && !launchedJob.workflow, "Event token workflow override was ignored");
+						test.ok(launchedJob && !launchedJob.options, "Event token workflow options were ignored");
+						test.ok(launchedJob && !launchedJob.files, "Event token file override was ignored");
+						test.ok(launchedJob && (!launchedJob.params || launchedJob.params.script != 'echo attacker-override'), "Event token plugin parameters were ignored");
+						test.ok(launchedJob && launchedJob.notify_fail != 'attacker@example.com', "Event token notification override was ignored");
+						test.ok(launchedJob && !launchedJob.debug_sudo, "Event token debug_sudo override was ignored");
+						test.ok(launchedJob && launchedJob.repeat === originalEvent.repeat, "Positive repeat override was ignored");
+						test.ok(launchedJob && launchedJob.enabled === originalEvent.enabled, "Enabled override was ignored");
+						test.ok(launchedJob && launchedJob.source == 'Event Token', "Server-derived source was preserved");
+						test.ok(launchedJob && launchedJob.now == allowedNow, "Event token current-time override remained available");
+						test.ok(launchedJob && launchedJob.arg == 'allowed-argument', "Event token job argument remained available");
+						test.ok(launchedJob && launchedJob.args == 'allowed-argument', "Event token args alias remained available");
+						test.ok(launchedJob && launchedJob.post_data && launchedJob.post_data.allowed, "Event token POST data remained available");
+						test.ok(!({}).polluted, "Run-only nested input did not modify Object.prototype");
 
 						launchedJob = null;
 						request.json(api_url + '/app/run_event', {
 							id: self.event_id,
-							session_id: session_id,
-							'__proto__/polluted': 'yes'
+							token: token,
+							repeat: -1,
+							enabled: false
 						}, function(err, resp, data) {
-							test.ok(!err, "Malformed editor nested request returned a response");
-							test.ok(data.code == 'api', "Prototype-chain nested request was rejected");
-							test.ok(!launchedJob, "Rejected nested request did not launch a job");
-							test.ok(!({}).polluted, "Editor nested input did not modify Object.prototype");
-
-							launchedJob = null;
-							var prototypePayload = JSON.parse('{"id":"' + self.event_id + '","session_id":"' + session_id + '","__proto__":{"target":"attacker-target","plugin":"attacker_plugin","debug_sudo":1}}');
-							request.json(api_url + '/app/run_event', prototypePayload, function(err, resp, data) {
-								test.ok(!err, "Raw prototype payload returned a response");
-								test.ok(data.code == 'api', "Raw prototype-control key was rejected");
-								test.ok(!launchedJob, "Raw prototype payload did not launch a job");
-								test.ok(!({}).polluted, "Raw prototype payload did not modify Object.prototype");
-								finish();
-							});
+							test.ok(!err, "Negative repeat event-token request succeeded");
+							test.ok(data && data.code == 0, "Negative repeat did not alter launch authorization");
+							test.ok(launchedJob && launchedJob.repeat === originalEvent.repeat, "Negative repeat override was ignored");
+							test.ok(launchedJob && launchedJob.enabled === originalEvent.enabled, "Negative repeat request could not disable the job");
+							runDurableQueueCheck(token);
 						});
 					});
 				});

--- a/lib/test.js
+++ b/lib/test.js
@@ -971,14 +971,24 @@ module.exports = {
 			} );
 		},
 
-		function testEventTokenCannotInjectChainArguments(test) {
+		function testRunEventRejectsUnprivilegedEventOverrides(test) {
 			var self = this;
 			var salt = 'unit_test_token_salt';
 			var oldLaunch = cronicle.launchOrQueueJob;
 			var launchedJob = null;
+			var allowedNow = Tools.timeNow(true) - 60;
+
+			function finish() {
+				cronicle.launchOrQueueJob = oldLaunch;
+				storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: '' }, function(err) {
+					test.ok(!err, "Event token fixture was restored");
+					test.done();
+				});
+			}
 
 			storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: salt }, function(err) {
 				test.ok(!err, "Event token was enabled");
+				if (err) return finish();
 				var token = crypto.createHmac('sha1', server.config.get('secret_key'))
 					.update(self.event_id + salt)
 					.digest('hex');
@@ -991,17 +1001,73 @@ module.exports = {
 				request.json(api_url + '/app/run_event', {
 					id: self.event_id,
 					token: token,
+					now: allowedNow,
+					arg: 'allowed-argument',
+					args: 'allowed-argument',
+					post_data: { allowed: true },
 					chain_data: { args: ['injected'] },
-					memo: 'args:injected'
+					memo: 'args:injected',
+					plugin: 'attacker_plugin',
+					workflow: [{ id: 'attacker_event' }],
+					target: 'attacker-target',
+					chain: 'attacker_event',
+					chain_error: 'attacker_event',
+					options: { wf_start_from_step: 99 },
+					files: [{ name: 'payload.sh', content: 'malicious' }],
+					params: { script: 'echo attacker-override' },
+					notify_fail: 'attacker@example.com',
+					debug_sudo: 1,
+					source: 'attacker',
+					source_id: 'attacker',
+					'__proto__/polluted': 'yes'
 				}, function(err, resp, data) {
-					cronicle.launchOrQueueJob = oldLaunch;
 					test.ok(!err, "Event token request succeeded");
 					test.ok(data.code == 0, "Event token launched the configured event");
 					test.ok(launchedJob && !('chain_data' in launchedJob), "Event token chain data was ignored");
 					test.ok(launchedJob && !('memo' in launchedJob), "Event token memo was ignored");
+					test.ok(launchedJob && launchedJob.plugin != 'attacker_plugin', "Event token plugin override was ignored");
+					test.ok(launchedJob && launchedJob.target != 'attacker-target', "Event token target override was ignored");
+					test.ok(launchedJob && launchedJob.chain != 'attacker_event', "Event token success-chain override was ignored");
+					test.ok(launchedJob && launchedJob.chain_error != 'attacker_event', "Event token error-chain override was ignored");
+					test.ok(launchedJob && !launchedJob.workflow, "Event token workflow override was ignored");
+					test.ok(launchedJob && !launchedJob.options, "Event token workflow options override was ignored");
+					test.ok(launchedJob && !launchedJob.files, "Event token file override was ignored");
+					test.ok(launchedJob && (!launchedJob.params || launchedJob.params.script != 'echo attacker-override'), "Event token plugin parameters were ignored");
+					test.ok(launchedJob && launchedJob.notify_fail != 'attacker@example.com', "Event token notification override was ignored");
+					test.ok(launchedJob && !launchedJob.debug_sudo, "Event token debug_sudo override was ignored");
+					test.ok(launchedJob && launchedJob.source == 'Event Token', "Server-derived source was preserved");
+					test.ok(launchedJob && launchedJob.now == allowedNow, "Event token current-time override remained available");
+					test.ok(launchedJob && launchedJob.arg == 'allowed-argument', "Event token job argument remained available");
+					test.ok(launchedJob && launchedJob.args == 'allowed-argument', "Event token args alias remained available");
+					test.ok(launchedJob && launchedJob.post_data && launchedJob.post_data.allowed, "Event token POST data remained available");
+					test.ok(!({}).polluted, "Run-only nested input did not modify Object.prototype");
 
-					storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: '' }, function() {
-						test.done();
+					launchedJob = null;
+					request.json(api_url + '/app/run_event', {
+						id: self.event_id,
+						session_id: session_id,
+						chain_data: { args: ['editor-injected'] },
+						memo: 'args:editor-injected',
+						params: { script: 'echo editor-override' }
+					}, function(err, resp, data) {
+						test.ok(!err, "Editor request succeeded");
+						test.ok(data.code == 0, "Editor launched the configured event");
+						test.ok(launchedJob && !('chain_data' in launchedJob), "Editor chain data was ignored");
+						test.ok(launchedJob && !('memo' in launchedJob), "Editor memo was ignored");
+						test.ok(launchedJob && launchedJob.params && launchedJob.params.script == 'echo editor-override', "Editor plugin parameters remain customizable");
+
+						launchedJob = null;
+						request.json(api_url + '/app/run_event', {
+							id: self.event_id,
+							session_id: session_id,
+							'__proto__/polluted': 'yes'
+						}, function(err, resp, data) {
+							test.ok(!err, "Malformed editor nested request returned a response");
+							test.ok(data.code == 'api', "Prototype-chain nested request was rejected");
+							test.ok(!launchedJob, "Rejected nested request did not launch a job");
+							test.ok(!({}).polluted, "Editor nested input did not modify Object.prototype");
+							finish();
+						});
 					});
 				});
 			});

--- a/lib/test.js
+++ b/lib/test.js
@@ -1165,6 +1165,12 @@ module.exports = {
 						session_id: session_id,
 						chain_data: { args: ['editor-injected'] },
 						memo: 'args:editor-injected',
+						source: 'editor-injected',
+						source_id: 'editor-injected',
+						source_event: 'editor-injected',
+						source_log: 'javascript:alert(1)',
+						username: 'editor-injected',
+						api_key: 'editor_injected',
 						params: { script: 'echo editor-override' }
 					}, function(err, resp, data) {
 						test.ok(!err, "Editor request succeeded");
@@ -1172,6 +1178,12 @@ module.exports = {
 						test.ok(launchedJob && !('chain_data' in launchedJob), "Editor chain data was ignored");
 						test.ok(launchedJob && !('memo' in launchedJob), "Editor memo was ignored");
 						test.ok(launchedJob && launchedJob.params && launchedJob.params.script == 'echo editor-override', "Editor plugin parameters remain customizable");
+						test.ok(launchedJob && launchedJob.source == 'Manual (admin)', "Editor source was derived by the server");
+						test.ok(launchedJob && launchedJob.username == 'admin', "Editor username was derived by the server");
+						test.ok(launchedJob && !('source_id' in launchedJob), "Editor source ID override was ignored");
+						test.ok(launchedJob && !('source_event' in launchedJob), "Editor source event override was ignored");
+						test.ok(launchedJob && !('source_log' in launchedJob), "Editor source log override was ignored");
+						test.ok(launchedJob && !('api_key' in launchedJob), "Editor API key override was ignored");
 
 						launchedJob = null;
 						request.json(api_url + '/app/run_event', {
@@ -1183,7 +1195,16 @@ module.exports = {
 							test.ok(data.code == 'api', "Prototype-chain nested request was rejected");
 							test.ok(!launchedJob, "Rejected nested request did not launch a job");
 							test.ok(!({}).polluted, "Editor nested input did not modify Object.prototype");
-							finish();
+
+							launchedJob = null;
+							var prototypePayload = JSON.parse('{"id":"' + self.event_id + '","session_id":"' + session_id + '","__proto__":{"target":"attacker-target","plugin":"attacker_plugin","debug_sudo":1}}');
+							request.json(api_url + '/app/run_event', prototypePayload, function(err, resp, data) {
+								test.ok(!err, "Raw prototype payload returned a response");
+								test.ok(data.code == 'api', "Raw prototype-control key was rejected");
+								test.ok(!launchedJob, "Raw prototype payload did not launch a job");
+								test.ok(!({}).polluted, "Raw prototype payload did not modify Object.prototype");
+								finish();
+							});
 						});
 					});
 				});


### PR DESCRIPTION
## Problem

`app/run_event` merged caller-controlled query/body fields into the stored event.  A principal allowed to run, but not edit, an event could therefore override execution fields outside the documented ad-hoc inputs.  The same merge also accepted prototype-control keys from raw JSON.

## Change

- Restrict run-only callers to `now`, `arg`, `args`, and opaque `post_data`.
- Preserve the existing nested override behavior for users who can edit events.
- Treat `chain_data` and `memo` as scheduler-owned state for every role, incorporating the maintainer feedback on this PR.
- Strip caller-supplied authentication and provenance fields, then derive provenance on the server.
- Merge own properties only and reject `__proto__`, `prototype`, and `constructor` at the request boundary.

## Compatibility

The normal UI Run Now flow, workflow child arguments, GitHub/event-token `post_data`, and API-key authentication remain supported.  Stored event configuration remains the source of execution policy for run-only principals.

## Validation

- Real HTTP regressions cover event-token and run-only override attempts, editor compatibility, raw JSON prototype payloads, and server-derived provenance.
- Repeat regressions cover positive and negative caller values plus `enabled=false`; a real launch-capacity failure verifies the durable `global/event_queue/<id>` record retains the stored event policy instead of caller input.
- Full `npm test`: 93/93 tests, 432 assertions.
- `node --check` and `git diff --check`: pass.

The issues and initial patches were proposed by a Codex Ultra security review, including the repeat-loop report in [frankii91/cronicle-edge#16](https://github.com/frankii91/cronicle-edge/pull/16). This version was manually re-analyzed, covers the complete run-only override boundary instead of adding a field-specific guard, adds real launch and durable-queue regression coverage, and is submitted for maintainer review in line with our prior discussion.
