### PR TITLE
fix(freebsd): use portable ps resource query

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -2128,11 +2128,11 @@ module.exports = Class.create({
 	monitorServerResources: function (callback) {
 		// monitor local CPU and memory for all active jobs (once per minute)
 		// shell exec to get running process cpu and memory usage
-		// this works on at least: OS X, Fedora, Ubuntu and CentOS
+		// this works on at least: FreeBSD, OS X, Fedora, Ubuntu and CentOS
 		var self = this;
 		var now = Tools.timeNow();
 
-		var defCmd = '/bin/ps -eo "ppid pid %cpu rss"' 
+		var defCmd = '/bin/ps -axo ppid=,pid=,%cpu=,rss='
 		var kb = 1024
 
 		if(process.platform == 'win32') {

--- a/lib/job.js
+++ b/lib/job.js
@@ -2132,7 +2132,7 @@ module.exports = Class.create({
 		var self = this;
 		var now = Tools.timeNow();
 
-		var defCmd = '/bin/ps -axo ppid=,pid=,%cpu=,rss='
+		var defCmd = '/bin/ps -ax -o ppid= -o pid= -o %cpu= -o rss='
 		var kb = 1024
 
 		if(process.platform == 'win32') {

--- a/lib/job.js
+++ b/lib/job.js
@@ -2128,12 +2128,17 @@ module.exports = Class.create({
 	monitorServerResources: function (callback) {
 		// monitor local CPU and memory for all active jobs (once per minute)
 		// shell exec to get running process cpu and memory usage
-		// this works on at least: FreeBSD, OS X, Fedora, Ubuntu and CentOS
+		// this works on at least: OS X, Fedora, Ubuntu and CentOS
 		var self = this;
 		var now = Tools.timeNow();
 
-		var defCmd = 'LC_ALL=C /bin/ps -ax -o ppid= -o pid= -o %cpu= -o rss='
+		var defCmd = '/bin/ps -eo "ppid pid %cpu rss"'
 		var kb = 1024
+
+		if(process.platform == 'freebsd') {
+			// FreeBSD -e prints the environment instead of selecting all processes.
+			defCmd = 'LC_ALL=C /bin/ps -ax -o ppid= -o pid= -o %cpu= -o rss='
+		}
 
 		if(process.platform == 'win32') {
 			//defCmd = 'powershell -c "get-cimInstance -ClassName Win32_PerfFormattedData_PerfProc_Process | % { $_.CreatingProcessID, $_.idprocess, $_.PercentProcessorTime, ($_.WorkingSetPrivate/1024) -join \' \' }"';

--- a/lib/job.js
+++ b/lib/job.js
@@ -2132,7 +2132,7 @@ module.exports = Class.create({
 		var self = this;
 		var now = Tools.timeNow();
 
-		var defCmd = '/bin/ps -ax -o ppid= -o pid= -o %cpu= -o rss='
+		var defCmd = 'LC_ALL=C /bin/ps -ax -o ppid= -o pid= -o %cpu= -o rss='
 		var kb = 1024
 
 		if(process.platform == 'win32') {


### PR DESCRIPTION
## Summary

- keep the existing `/bin/ps -eo "ppid pid %cpu rss"` query on Linux, macOS, and other established platforms
- use the FreeBSD-specific query only when `process.platform == 'freebsd'`
- request each FreeBSD numeric column with a separate `-o` option and normalize its locale with `LC_ALL=C`
- keep the existing process parser unchanged

## Why

On FreeBSD 14.3, `-e` adds environment information instead of selecting all processes, so the original command does not provide the complete process tree needed for CPU and memory monitoring. A localized FreeBSD `%CPU` value can also use a decimal comma, while the existing parser expects a decimal point.

`LC_ALL=C /bin/ps -ax -o ppid= -o pid= -o %cpu= -o rss=` returns the four headerless numeric columns expected by the parser. The platform guard leaves the longstanding command and behavior untouched everywhere else.

## Tests

- Production FreeBSD S21 with a Polish numeric locale: the FreeBSD command produced `29` parsed rows and found the current Node process with CPU and memory values.
- Linux: the unchanged default command produced `978` rows accepted by the existing parser.
- Full suite: `55/55` tests passed (`364` assertions).
- `node --check lib/job.js`
- `git diff --check`
