### PR TITLE
fix(freebsd): locate Bash through PATH

### DIFF
--- a/bin/getnode.sh
+++ b/bin/getnode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 HOMEDIR="$(dirname "$(cd -- "$(dirname "$(readlink -f "$0")")" && (pwd -P 2>/dev/null || pwd))")"
 
 DEFAULT_VERSION="20.16.0"

--- a/bin/manager
+++ b/bin/manager
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 HOMEDIR="$(dirname "$(cd -- "$(dirname "$(readlink -f "$0")")" && (pwd -P 2>/dev/null || pwd))")"
 
 usage() {
@@ -104,6 +104,5 @@ fi
 
 #$HOMEDIR/bin/control.sh start
 exec $BINARY --echo --foreground --manager --color $color --debug $debug
-
 
 

--- a/bundle
+++ b/bundle
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 
@@ -518,4 +518,3 @@ if [ "$test" = 1 ]; then
   # remove test files
   rm $dist/bin/test.js
 fi
-


### PR DESCRIPTION
## Summary

- locate Bash through `PATH` in `getnode.sh`, `manager`, and `bundle`
- leave all script logic unchanged

## Why

FreeBSD does not include Bash in the base system, and the package installs it outside `/bin`. The fixed `/bin/bash` shebang therefore fails on a standard FreeBSD installation even when Bash is installed and available in `PATH`.

FreeBSD documents the packaged shell as `/usr/local/bin/bash`: https://docs.freebsd.org/en/books/handbook/basics/#shells

## Tests

- `bash -n bin/getnode.sh bin/manager bundle`
- `/usr/bin/env bash -c 'exit 0'`
- `git diff --check`
