### PR TITLE
Handle missing global/secrets in migrated Cronicle storage

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -584,7 +584,7 @@ module.exports = Class.create({
 						if (Array.isArray(itemCopy)) itemCopy.forEach(obj => delete obj.secret)
 					}
 					if (name == 'secrets') {
-						itemCopy.forEach(obj => delete obj.data)
+						if (Array.isArray(itemCopy)) itemCopy.forEach(obj => delete obj.data)
 					}	
 					args.resp[name] = itemCopy || [];
 					callback();

--- a/lib/job.js
+++ b/lib/job.js
@@ -118,7 +118,7 @@ module.exports = Class.create({
 			},
 			function (callback) {
 				self.storage.listFind('global/secrets', { id: 'globalenv' }, function (err, item) {
-					globalenv = item;
+					globalenv = item || {};
 					callback(err);
 				});
 			},


### PR DESCRIPTION
After migrating storage from classic Cronicle 0.9.x, the server crash-looped with `Emergency Shutdown` during login/session resume and when a scheduled job launched.

Classic 0.9.x storage can lack the `global/secrets` list and its `globalenv` item. Fresh Edge setups seed both from `sample_conf/setup.json`, but `bin/storage-cli.js setup` exits when `global/users` already exists ("Storage has already been set up"), so an existing dataset is not backfilled. A migrated 0.9.x dataset can therefore lack both records.

Two unguarded dereferences, each with an already-guarded sibling a few lines away:

**1. `lib/engine.js`, `beforeUserLogin`** — `listGet('global/secrets')` yields `null` when the list is absent, and the `secrets` branch calls `.forEach` on the copy directly. The `plugins`/`schedule` branch two lines above already wraps the identical call in `if (Array.isArray(itemCopy))`.

```
Emergency Shutdown: TypeError: Cannot read properties of null (reading 'forEach')
```

**2. `lib/job.js`, job launch** — `globalenv = item;` takes the `listFind` result unfiltered, and `globalenv.data` is read further down the same function. The next two fetches in that block, `cat_secret` and `plug_secret`, both already use `item || {}`.

```
Emergency Shutdown: TypeError: Cannot read properties of null (reading 'data')
```

This change mirrors the existing guards nearby: it only iterates the secrets result when it is an array and defaults a missing `globalenv` item to `{}`, matching how category and plugin secrets already degrade.

My deployment runs the bundled build, so the raw traces point into `bin/cronicle.js` rather than `lib/*.js`; the sites above are the corresponding source lines. The bundle is regenerated from `lib/` by the Docker build, so the source guards reach the shipped artifact.

Verification, done against a copy of the migrated dataset rather than the live instance:

- **before** — reproduced both crashes: the first on a valid session resume, the second at the next scheduler minute-tick that launched a job.
- **after** — creating the `global/secrets` list and adding a `globalenv` item, exactly as `setup.json` seeds them, stops both crashes. That is what pins the trigger to the missing records rather than to anything else in the migrated data.
- For the patch, I ran `node --check lib/engine.js && node --check lib/job.js` and `npm test` (55/55 pass on Node 22). I did not rebuild the bundle or run the patched code against the migrated dataset. The test suite seeds storage from `sample_conf/setup.json`, so it does not cover the missing-record case; I did not add a unit test.

Issue #13 concerns a separate admin-UI error and is unrelated to these crashes.
