### PR TITLE
Shell plugin: opt-in classic log timestamp format

### DIFF
--- a/bin/shell-plugin.js
+++ b/bin/shell-plugin.js
@@ -28,6 +28,14 @@ process.stdout.setEncoding('utf8');
 
 const stream = new JSONStream(process.stdin, process.stdout);
 
+// classic Cronicle log stamp (yyyy/mm/dd hh:mi:ss), in the runner's local timezone.
+// Kept dependency free on purpose: pulling pixl-tools in just for getDateArgs would
+// grow this bundle by ~100 KB, and it is spawned once per job.
+function classicStamp(d) {
+	const p2 = (n) => String(n).padStart(2, '0');
+	return `${String(d.getFullYear()).padStart(4, '0')}/${p2(d.getMonth() + 1)}/${p2(d.getDate())} ${p2(d.getHours())}:${p2(d.getMinutes())}:${p2(d.getSeconds())}`;
+}
+
 // detect "clear line" like sequences and return string after it.
 function trimAnimation(line) {
 		if(line.lastIndexOf('\x1b[0K') > -1)  return line.substring(line.lastIndexOf('\x1b[0K') + 4)
@@ -174,9 +182,11 @@ stream.on('json', function (job) {
           // otherwise just log it
 		  line = trimAnimation(line)
           if (job.params.annotate) {
-            // let dargs = Tools.getDateArgs(new Date());
-            // line = '[' + dargs.yyyy_mm_dd + ' ' + dargs.hh_mi_ss + '] ' + line;
-            line = `[${new Date().toISOString()}] ${line}`;
+            // any other value, including none at all on events predating this param,
+            // keeps the ISO-8601 UTC stamp
+            line = job.params.stamp_format === 'local'
+              ? `[${classicStamp(new Date())}] ${line}`
+              : `[${new Date().toISOString()}] ${line}`;
           }
 		  if(typeof line !== 'string') line = ''
           fs.appendFileSync(job.log_file, line.endsWith('\n') ? line : line + "\n");

--- a/bin/shell-plugin.js
+++ b/bin/shell-plugin.js
@@ -28,10 +28,14 @@ process.stdout.setEncoding('utf8');
 
 const stream = new JSONStream(process.stdin, process.stdout);
 
-// classic Cronicle log stamp (yyyy/mm/dd hh:mi:ss), in the runner's local timezone.
+// timestamp for annotated log lines. Anything but an enabled classic_stamp param -
+// including plugin records predating it, where parseInt sees undefined - keeps the
+// ISO-8601 UTC default; enabled switches to the classic Cronicle stamp
+// (yyyy/mm/dd hh:mi:ss) in the runner's local timezone.
 // Kept dependency free on purpose: pulling pixl-tools in just for getDateArgs would
 // grow this bundle by ~100 KB, and it is spawned once per job.
-function classicStamp(d) {
+function formatTimestamp(d, classic) {
+	if (!parseInt(classic)) return d.toISOString();
 	const p2 = (n) => String(n).padStart(2, '0');
 	return `${String(d.getFullYear()).padStart(4, '0')}/${p2(d.getMonth() + 1)}/${p2(d.getDate())} ${p2(d.getHours())}:${p2(d.getMinutes())}:${p2(d.getSeconds())}`;
 }
@@ -182,11 +186,7 @@ stream.on('json', function (job) {
           // otherwise just log it
 		  line = trimAnimation(line)
           if (job.params.annotate) {
-            // any other value, including none at all on events predating this param,
-            // keeps the ISO-8601 UTC stamp
-            line = job.params.stamp_format === 'local'
-              ? `[${classicStamp(new Date())}] ${line}`
-              : `[${new Date().toISOString()}] ${line}`;
+            line = `[${formatTimestamp(new Date(), job.params.classic_stamp)}] ${line}`;
           }
 		  if(typeof line !== 'string') line = ''
           fs.appendFileSync(job.log_file, line.endsWith('\n') ? line : line + "\n");

--- a/sample_conf/setup.json
+++ b/sample_conf/setup.json
@@ -44,6 +44,7 @@
 			"params": [
 				{ "id":"script", "type":"textarea", "rows":10, "title":"Script Source", "value": "#!/usr/bin/env bash\n\n# Enter your shell script code here\n# Press F11 to toggle full screen mode\n# To get workflow's job argument refer to $JOB_ARG env variable\n\n# am I windows?\necho $PSVersionTable\n\necho \"print integer with % to report progress (e.g. 20%)\"\n sleep 2; echo \"$(date)\"; echo 10%\n sleep 2; echo \"$(date)\"; echo 40%\n sleep 2; echo \"$(date)\"; echo 90%\n sleep 2\necho '{\"perf\":{\"step3\":55,\"step2\":30,\"step1\":20}}'" },
 				{ "id":"annotate", "type":"checkbox", "title":"Add Date/Time Stamps to Log", "value": 0 },
+				{ "id":"stamp_format", "type":"select", "title":"Date/Time Stamp Format", "items":["utc","local"], "value":"utc" },
 				{ "id":"json", "type":"checkbox", "title":"Interpret JSON in Output", "value": 0 },
 				{"type":"select","id":"lang","title":"syntax","items":["shell","powershell","javascript","python","perl","groovy","java","csharp","scala","sql","yaml","toml","dockerfile"],"value":"shell"},
 				{"type":"select","id":"theme","title":"theme","items":["default","light","gruvbox-dark","solarized light","solarized dark","darcula","ambiance","base16-dark","nord"],"value":"default"},

--- a/sample_conf/setup.json
+++ b/sample_conf/setup.json
@@ -44,7 +44,7 @@
 			"params": [
 				{ "id":"script", "type":"textarea", "rows":10, "title":"Script Source", "value": "#!/usr/bin/env bash\n\n# Enter your shell script code here\n# Press F11 to toggle full screen mode\n# To get workflow's job argument refer to $JOB_ARG env variable\n\n# am I windows?\necho $PSVersionTable\n\necho \"print integer with % to report progress (e.g. 20%)\"\n sleep 2; echo \"$(date)\"; echo 10%\n sleep 2; echo \"$(date)\"; echo 40%\n sleep 2; echo \"$(date)\"; echo 90%\n sleep 2\necho '{\"perf\":{\"step3\":55,\"step2\":30,\"step1\":20}}'" },
 				{ "id":"annotate", "type":"checkbox", "title":"Add Date/Time Stamps to Log", "value": 0 },
-				{ "id":"stamp_format", "type":"select", "title":"Date/Time Stamp Format", "items":["utc","local"], "value":"utc" },
+				{ "id":"classic_stamp", "type":"hidden", "title":"Use Classic (Local) Date/Time Stamps", "value": 0 },
 				{ "id":"json", "type":"checkbox", "title":"Interpret JSON in Output", "value": 0 },
 				{"type":"select","id":"lang","title":"syntax","items":["shell","powershell","javascript","python","perl","groovy","java","csharp","scala","sql","yaml","toml","dockerfile"],"value":"shell"},
 				{"type":"select","id":"theme","title":"theme","items":["default","light","gruvbox-dark","solarized light","solarized dark","darcula","ambiance","base16-dark","nord"],"value":"default"},


### PR DESCRIPTION
## Why

This follows on from the migration quirks discussed in #264.

When `annotate` is on, the shell plugin prefixes every job-log line with
`new Date().toISOString()` — a UTC, millisecond-precision stamp. Classic Cronicle 0.9.x
used a local-time `[yyyy/mm/dd hh:mi:ss]` prefix instead; that line remains commented out
directly above the ISO one in `bin/shell-plugin.js`, from the v1.7.1 rewrite.

After migrating an old instance, a single long-lived event therefore has job logs in two
different formats, split at the migration date, in two different timezones. Anything
reading those logs — manual inspection, a grep, or a log shipper with a timestamp pattern —
has to handle both. There is currently no way to choose.

This adds that choice without changing what anybody gets today.

## What changed

A `stamp_format` select on the shellplug definition in `sample_conf/setup.json`, with
`utc` (default, the current ISO-8601 stamp) and `local` (the classic
`[yyyy/mm/dd hh:mi:ss]`, in the runner's timezone), plus the branch in
`bin/shell-plugin.js` that reads it.

Two files, ~15 lines.

The default is not merely "the setup.json default" — the branch treats *anything other than
the literal string `local`* as the ISO stamp. That matters because plugin records live in
storage: an upgrading instance keeps its existing shellplug record, so the new param is
simply absent from every job it dispatches, and absent has to mean today's output. The same
holds for an unrecognised value.

Only `annotate` jobs are affected at all. With `annotate` off, nothing in this path runs.

I deliberately did not touch the sshx or kube plugins. Both adopted the same ISO stamp and
could take the same option, but I kept that as a separate change to make this one reviewable —
I can extend it if you would rather have all three land together.

### On not re-adding pixl-tools

The obvious implementation is to uncomment `const Tools = require('pixl-tools')` and use
`Tools.getDateArgs`, since that is what the commented-out line did. I did not, for one
measured reason: `bin/shell-plugin.js` is esbuild-bundled, so that require gets inlined.
In my build, the bundled plugin goes from 15,317 bytes to 115,987 bytes with pixl-tools
pulled in (that is the size of the already-bundled `bin/test-plugin.js`, which does
require it) — roughly 100 KB, on a script spawned once per job, to format one date.

Instead, I compute the two fields used by the classic line inline, and the bundle grows
by 234 bytes. To verify that the output is genuinely identical rather than merely similar,
I compared the helper against real `pixl-tools@2.0.2` `getDateArgs` over 200,006 timestamps
in each of five timezones (Europe/Berlin, UTC, America/New_York, Asia/Kolkata,
Australia/Lord_Howe, the last for its 30-minute offset): zero mismatches, with a
deliberately-mismatched pair in the same run to prove the comparison could fail.

The select uses plain string items, like every other select in that file. This matters
because the plugin admin editor round-trips select items through
`param.items.join(', ')` and `.split(/\,\s*/)`, so `[value, label]` pair items — which
`render_menu_options` does otherwise accept — would be flattened into four bogus entries
the first time somebody opened the plugin in the editor.

## Verification

I built the image from this branch and a second one from `main` at the same commit as a
control, then ran both as fresh-setup instances with `TZ=Europe/Berlin` (so local time is
UTC+2 and the two formats are distinguishable by more than punctuation). Each event runs
the same three-line script. I harvested job logs through `get_job_log`, then compared them
after normalising only the timestamps themselves and the job/host/title headers.

| case | stored params | result |
| --- | --- | --- |
| default | `stamp_format: "utc"` | `[2026-08-18T07:15:31.223Z] alpha` — identical to control |
| classic | `stamp_format: "local"` | `[2026/08/18 09:15:44] alpha` |
| upgraded instance | no `stamp_format` key at all | identical to control |
| unknown value | `stamp_format: "wat"` | identical to control |
| annotate off | `annotate: 0` | no prefix, identical to control |

Note the hours: `07` on the ISO stamps and `09` on the classic one, in the same container
in the same second — the local branch follows the timezone rather than printing UTC with
different punctuation.

The three "identical to control" rows are byte-for-byte equal to the clean-`main` image's
own output, not a visual comparison. Two positive controls ran alongside them, both
required to report *unequal*: the control's annotate-on log against its own annotate-off
log, and the un-normalised default log against the un-normalised control log — the second
one ensures that a normaliser quietly erasing the difference would fail the run rather
than pass it.

I also confirmed that the stored plugin record on the fresh instance carries the param in
the expected shape while the control's does not, and rendered the select through the shipped
`render_menu_options` from the served `common.min.js`, driven by the live plugin record
and the same value-resolution rule the event editor uses. It produces the dropdown with
`utc` preselected for a new event, `local` preselected once chosen, and `utc` for an event
whose params predate the option.

`npm test` (what the PR workflow runs): 55 of 55 passing, 364 assertions.

I did not perform a click-through in a real browser. The test instance was deliberately
bound to loopback only, and the browser available to me could not reach it. The render
check above exercises the real shipped function against the real record, but it is not the
same as somebody opening the event editor, and I would not claim otherwise.
