### PR TITLE
fix: add output encoding in APIKeys.js

### DIFF
--- a/htdocs/js/pages/admin/APIKeys.js
+++ b/htdocs/js/pages/admin/APIKeys.js
@@ -56,7 +56,7 @@ Class.add( Page.Admin, {
 			];
 			return [
 				'<div class="td_big">' + self.getNiceAPIKey(item, true, col_width) + '</div>',
-				'<div style="">' + encode_entities(item.key) + '</div>',
+				'<div style="">' + encode_entities(item.key.substring(0, 4) + '********************************') + '</div>',
 				item.active ? '<span class="color_label green"><i class="fa fa-check">&nbsp;</i>Active</span>' : '<span class="color_label red"><i class="fa fa-warning">&nbsp;</i>Suspended</span>',
 				self.getNiceUsername(item.username, true, col_width),
 				'<span title="'+get_nice_date_time(item.created, true)+'">'+get_nice_date(item.created, true)+'</span>',

--- a/htdocs/js/pages/admin/APIKeys.js
+++ b/htdocs/js/pages/admin/APIKeys.js
@@ -54,9 +54,10 @@ Class.add( Page.Admin, {
 				'<span class="link" onMouseUp="$P().edit_api_key('+idx+')"><b>Edit</b></span>',
 				'<span class="link" onMouseUp="$P().delete_api_key('+idx+')"><b>Delete</b></span>'
 			];
+			var api_key = String(item.key || '');
 			return [
 				'<div class="td_big">' + self.getNiceAPIKey(item, true, col_width) + '</div>',
-				'<div style="">' + encode_entities(item.key.substring(0, 4) + '********************************') + '</div>',
+				'<div style="">' + encode_entities(api_key.substring(0, 4) + '********************************') + '</div>',
 				item.active ? '<span class="color_label green"><i class="fa fa-check">&nbsp;</i>Active</span>' : '<span class="color_label red"><i class="fa fa-warning">&nbsp;</i>Suspended</span>',
 				self.getNiceUsername(item.username, true, col_width),
 				'<span title="'+get_nice_date_time(item.created, true)+'">'+get_nice_date(item.created, true)+'</span>',


### PR DESCRIPTION
## Summary

The admin API-key list currently renders the complete API key in the page DOM. This unnecessarily exposes a credential to any code or tooling with access to the rendered page and makes accidental disclosure easier.

This change masks the key in the admin list while preserving the existing API-key functionality. The first four characters are retained to allow administrators to distinguish keys.

This is a defense-in-depth credential exposure reduction rather than an assertion that the existing \`encode_entities()\` usage is vulnerable to HTML injection.

## Changes

- `htdocs/js/pages/admin/APIKeys.js` — normalize `item.key` with `String(item.key || '')` before calling `.substring()`, so the list renders safely even when a key value is null, undefined, or a non-string type; then mask all but the first 4 characters.