### PR TITLE
fix(auth): recover expired proxy sessions

### DIFF
--- a/htdocs/js/pages/Base.class.js
+++ b/htdocs/js/pages/Base.class.js
@@ -5,6 +5,17 @@ Class.subclass(Page, "Page.Base", {
 	requireLogin: function (args) {
 		// user must be logged into to continue
 		var self = this;
+		var session_reload_key = 'cronicle_resume_session_reload:' + window.location.pathname;
+		var session_reload_limit = 30000;
+
+		function show_session_error(resp) {
+			if (resp && (typeof(resp.code) == 'number')) {
+				app.doError("Network Error: " + resp.code + ": " + resp.description);
+			}
+			else {
+				app.doError("Error: " + ((resp && resp.description) || "Unknown error"));
+			}
+		}
 
 		if (!app.user) {
 			// require login
@@ -18,6 +29,10 @@ Class.subclass(Page, "Page.Base", {
 
             // check for session_id on the backend  (vs localStorage), it might be stored in cookie now (during oauth)
 			app.api.post('user/resume_session', {session_id: session_id}, function (resp) {
+					// A successful response proves the external proxy session is usable again.
+					try { window.sessionStorage.removeItem(session_reload_key); }
+					catch (storage_error) {;}
+
 					if (resp.user) {
 						Debug.trace("User Session Resume: " + resp.username + ": " + resp.session_id);
 						app.hideProgress();
@@ -33,6 +48,31 @@ Class.subclass(Page, "Page.Base", {
 						if (session_id) self.setPref('session_id', '');
 						setTimeout(function () { Nav.go('Login'); }, 1);
 					}
+				}, function (resp) {
+					// External auth proxies can reject expired AJAX sessions with HTTP 401.
+					// Retry once as a top-level request so their interactive login can run.
+					if (!resp || (typeof(resp.code) != 'number') || (resp.code != 401)) {
+						show_session_error(resp);
+						return;
+					}
+
+					var now = Date.now();
+					try {
+						var last_reload = parseInt(window.sessionStorage.getItem(session_reload_key), 10) || 0;
+						if (last_reload && ((now - last_reload) < session_reload_limit)) {
+							show_session_error(resp);
+							return;
+						}
+						window.sessionStorage.setItem(session_reload_key, now);
+					}
+					catch (storage_error) {
+						// Do not risk a reload loop when the browser blocks sessionStorage.
+						show_session_error(resp);
+						return;
+					}
+
+					Debug.trace("Session resume was rejected by an external auth proxy, reloading for authentication");
+					window.location.reload();
 				});
 
 			return false;

--- a/htdocs/js/pages/Base.class.js
+++ b/htdocs/js/pages/Base.class.js
@@ -8,12 +8,12 @@ Class.subclass(Page, "Page.Base", {
 		var session_reload_key = 'cronicle_resume_session_reload:' + window.location.pathname;
 		var session_reload_limit = 30000;
 
-		function show_session_error(resp) {
-			if (resp && (typeof(resp.code) == 'number')) {
-				app.doError("Network Error: " + resp.code + ": " + resp.description);
+		function show_session_error(err) {
+			if (err && (typeof(err.code) == 'number')) {
+				app.doError("Network Error: " + err.code + ": " + err.description);
 			}
 			else {
-				app.doError("Error: " + ((resp && resp.description) || "Unknown error"));
+				app.doError("Error: " + ((err && err.description) || "Unknown error"));
 			}
 		}
 
@@ -28,7 +28,9 @@ Class.subclass(Page, "Page.Base", {
 			Debug.trace("Recovering session using session_id or cookie");
 
             // check for session_id on the backend  (vs localStorage), it might be stored in cookie now (during oauth)
-			app.api.post('user/resume_session', {session_id: session_id}, function (resp) {
+			app.api.post('user/resume_session', {session_id: session_id}
+				// success response
+				, function (resp) {
 					// A successful response proves the external proxy session is usable again.
 					try { window.sessionStorage.removeItem(session_reload_key); }
 					catch (storage_error) {;}
@@ -48,11 +50,13 @@ Class.subclass(Page, "Page.Base", {
 						if (session_id) self.setPref('session_id', '');
 						setTimeout(function () { Nav.go('Login'); }, 1);
 					}
-				}, function (resp) {
+				}
+				// error response
+				, function (err) {
 					// External auth proxies can reject expired AJAX sessions with HTTP 401.
 					// Retry once as a top-level request so their interactive login can run.
-					if (!resp || (typeof(resp.code) != 'number') || (resp.code != 401)) {
-						show_session_error(resp);
+					if (!err || (typeof(err.code) != 'number') || (err.code != 401)) {
+						show_session_error(err);
 						return;
 					}
 
@@ -60,20 +64,21 @@ Class.subclass(Page, "Page.Base", {
 					try {
 						var last_reload = parseInt(window.sessionStorage.getItem(session_reload_key), 10) || 0;
 						if (last_reload && ((now - last_reload) < session_reload_limit)) {
-							show_session_error(resp);
+							show_session_error(err);
 							return;
 						}
 						window.sessionStorage.setItem(session_reload_key, now);
 					}
 					catch (storage_error) {
 						// Do not risk a reload loop when the browser blocks sessionStorage.
-						show_session_error(resp);
+						show_session_error(err);
 						return;
 					}
 
 					Debug.trace("Session resume was rejected by an external auth proxy, reloading for authentication");
 					window.location.reload();
-				});
+				}
+			);
 
 			return false;
 		}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"license": "MIT",
 	"main": "lib/main.js",
 	"scripts": {
-		"test": "pixl-unit lib/test.js test/oidc-logout.test.js",
+		"test": "pixl-unit lib/test.js test/oidc-logout.test.js test/session-recovery.test.js",
 		"boot": "pixl-boot install",
 		"unboot": "pixl-boot uninstall"
 	},

--- a/test/session-recovery.test.js
+++ b/test/session-recovery.test.js
@@ -1,0 +1,130 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const pageSource = fs.readFileSync(
+	path.join(__dirname, '../htdocs/js/pages/Base.class.js'),
+	'utf8'
+);
+
+function loadBasePage(sharedStorage, now, storageAvailable) {
+	let pageDefinition = null;
+	let successCallback = null;
+	let errorCallback = null;
+	let reloadCount = 0;
+	const errors = [];
+	const storage = {
+		getItem: function(key) {
+			if (!storageAvailable) throw new Error('sessionStorage unavailable');
+			return Object.prototype.hasOwnProperty.call(sharedStorage, key) ? sharedStorage[key] : null;
+		},
+		setItem: function(key, value) {
+			if (!storageAvailable) throw new Error('sessionStorage unavailable');
+			sharedStorage[key] = String(value);
+		},
+		removeItem: function(key) {
+			if (!storageAvailable) throw new Error('sessionStorage unavailable');
+			delete sharedStorage[key];
+		}
+	};
+	const sandboxApp = {
+		api: {
+			post: function(endpoint, params, success, error) {
+				assert.equal(endpoint, 'user/resume_session');
+				successCallback = success;
+				errorCallback = error;
+			}
+		},
+		config: {},
+		doError: function(message) { errors.push(message); },
+		getPref: function() { return ''; },
+		navAfterLogin: ''
+	};
+	const sandbox = {
+		Class: {
+			subclass: function(parent, name, definition) { pageDefinition = definition; }
+		},
+		Date: { now: function() { return now; } },
+		Debug: { trace: function() {} },
+		Nav: { go: function() {}, refresh: function() {} },
+		Page: {},
+		app: sandboxApp,
+		compose_query_string: function() { return ''; },
+		num_keys: function() { return 0; },
+		setTimeout: function(callback) { callback(); },
+		window: {
+			location: {
+				href: 'https://cron.example/#Home',
+				pathname: '/',
+				reload: function() { reloadCount++; }
+			},
+			sessionStorage: storage
+		}
+	};
+
+	vm.runInNewContext(pageSource, sandbox);
+	const result = pageDefinition.requireLogin.call({
+		ID: 'Home',
+		div: { hide: function() {} }
+	});
+	assert.equal(result, false);
+	assert.equal(typeof successCallback, 'function');
+	assert.equal(typeof errorCallback, 'function');
+
+	return {
+		errors: errors,
+		error: errorCallback,
+		getReloadCount: function() { return reloadCount; },
+		succeed: successCallback
+	};
+}
+
+module.exports = {
+	tests: [
+		function testExternalProxySessionRecovery(test) {
+			const sharedStorage = {};
+			const firstPage = loadBasePage(sharedStorage, 100000, true);
+			firstPage.error({ code: 401, description: 'Unauthorized' });
+			assert.equal(firstPage.getReloadCount(), 1);
+			assert.deepEqual(firstPage.errors, []);
+
+			// A new page lifecycle shares sessionStorage with the previous reload.
+			const reloadedPage = loadBasePage(sharedStorage, 100001, true);
+			reloadedPage.error({ code: 401, description: 'Unauthorized' });
+			assert.equal(reloadedPage.getReloadCount(), 0);
+			assert.deepEqual(reloadedPage.errors, ['Network Error: 401: Unauthorized']);
+
+			const serverErrorPage = loadBasePage(sharedStorage, 100002, true);
+			serverErrorPage.error({ code: 500, description: 'Server Error' });
+			assert.equal(serverErrorPage.getReloadCount(), 0);
+			assert.deepEqual(serverErrorPage.errors, ['Network Error: 500: Server Error']);
+
+			const applicationErrorPage = loadBasePage(sharedStorage, 100003, true);
+			applicationErrorPage.error({ code: 'login', description: 'Login failed' });
+			assert.equal(applicationErrorPage.getReloadCount(), 0);
+			assert.deepEqual(applicationErrorPage.errors, ['Error: Login failed']);
+
+			const stringStatusPage = loadBasePage(sharedStorage, 100004, true);
+			stringStatusPage.error({ code: '401', description: 'Application error' });
+			assert.equal(stringStatusPage.getReloadCount(), 0);
+			assert.deepEqual(stringStatusPage.errors, ['Error: Application error']);
+
+			const expiredGuardPage = loadBasePage(sharedStorage, 130001, true);
+			expiredGuardPage.error({ code: 401, description: 'Unauthorized' });
+			assert.equal(expiredGuardPage.getReloadCount(), 1);
+
+			const successPage = loadBasePage(sharedStorage, 130002, true);
+			successPage.succeed({ code: 0 });
+			const recoveredPage = loadBasePage(sharedStorage, 130003, true);
+			recoveredPage.error({ code: 401, description: 'Unauthorized' });
+			assert.equal(recoveredPage.getReloadCount(), 1);
+
+			const blockedStoragePage = loadBasePage({}, 130004, false);
+			blockedStoragePage.error({ code: 401, description: 'Unauthorized' });
+			assert.equal(blockedStoragePage.getReloadCount(), 0);
+			assert.deepEqual(blockedStoragePage.errors, ['Network Error: 401: Unauthorized']);
+			test.done();
+		}
+	]
+};


### PR DESCRIPTION
## Summary

- reload the current page once when `user/resume_session` receives an HTTP `401`
- keep the existing application and network error behavior for every other response
- use a tab-scoped 30-second guard to prevent a persistent proxy rejection from causing a reload loop
- add focused regression coverage for reload, loop prevention, guard cleanup, non-401 errors, and unavailable browser storage

## Why

External authentication proxies can reject an AJAX request after their own browser session expires, before the request reaches Cronicle. Cloudflare Access documents this behavior for requests carrying `X-Requested-With: XMLHttpRequest` and recommends either forcing a page refresh or displaying an expired-session message:

https://developers.cloudflare.com/cloudflare-one/access-controls/access-settings/session-management/#ajax

Cronicle's same-origin jQuery requests carry that header. The existing `resume_session` call has no failure recovery, so the browser can remain on a partially rendered application shell while a normal top-level navigation would allow the proxy to start its interactive login flow.

The API client reports HTTP statuses as numeric error codes, while Cronicle application errors use string codes. The new path therefore activates only for numeric `401`, reloads the same URL without accepting a redirect target from the response, and leaves Cronicle's normal missing or expired local-session flow unchanged. No deployment-specific configuration is required.

The reload timestamp is stored only in the current tab's `sessionStorage`. It is cleared after a successful `resume_session`; a second `401` within 30 seconds or unavailable storage falls back to the existing visible network error instead of reloading again.

## Tests

- before the implementation, the focused regression failed because `resume_session` registered no error callback
- `npx pixl-unit test/session-recovery.test.js`: `1/1` passed
- `npm test`: `92/92` passed (`374` assertions)
- `node --check htdocs/js/pages/Base.class.js`
- `node --check test/session-recovery.test.js`
- `git diff --check`
