### PR TITLE
fix: scrub SQL password from child job environments

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -98,6 +98,7 @@ module.exports = Class.create({
 		delete process.env["CRONICLE_Storage__RedisCluster__password"];
 		delete process.env["CRONICLE_sqlstring"];
 		delete process.env["CRONICLE_password"];
+		delete process.env["CRONICLE_sqlpassword"];
 		delete process.env["CRONICLE_postgres_password"];
 		delete process.env["CRONICLE_Storage__SQL__connection__password"];
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -78,6 +78,8 @@ module.exports = {
 	setUp: function (callback) {
 		// always called before tests start
 		var self = this;
+		process.env.CRONICLE_password = 'UNIT_TEST_PASSWORD';
+		process.env.CRONICLE_sqlpassword = 'UNIT_TEST_SQL_PASSWORD';
 		
 		// make sure another unit test isn't running
 		var pid = false;
@@ -175,6 +177,8 @@ module.exports = {
 		
 		function testServerStarted(test) {
 			test.ok( server.started > 0, 'Cronicle started up successfully');
+			test.ok( !process.env.CRONICLE_password, 'Generic password was removed from the process environment');
+			test.ok( !process.env.CRONICLE_sqlpassword, 'SQL password was removed from the process environment');
 			test.done();
 		},
 		


### PR DESCRIPTION
## Summary

- remove `CRONICLE_sqlpassword` from the manager process environment before child jobs are launched
- retain the existing scrub for `CRONICLE_password`
- cover both variables during a real test-server startup

## Why

`lib/main.js` accepts `CRONICLE_sqlpassword` when it constructs SQL storage credentials. The resolved storage password is scrubbed later, but the original `CRONICLE_sqlpassword` variable remained in `process.env`, so child job processes could inherit it.

The initial Codex Ultra security-review proposal identified the missing scrub, but replaced the existing `CRONICLE_password` deletion. This version was re-analyzed manually and adds the missing deletion instead, preserving both protections. It is submitted for maintainer review in line with our prior discussion.

## Unchanged behavior

- SQL storage configuration still reads `CRONICLE_sqlpassword` during startup.
- Existing secret, OAuth, storage, Redis, SFTP, PostgreSQL, and generic password scrubbing remains unchanged.
- No job or storage configuration format changes.

## Tests

- `npm ci`
- `npm test`: 91/91 passed, 376 assertions
- `node --check lib/engine.js`
- `node --check lib/test.js`
- `git diff --check`

The regression seeds both environment variables before server startup and verifies that the engine removes both.
