### PR TITLE
docs: load Docker cluster secrets from protected files

### DIFF
--- a/Docker/LocalCluster.yaml
+++ b/Docker/LocalCluster.yaml
@@ -2,9 +2,8 @@
 
 # Before you start:
 # make sure your docker engine is in swarm mode
-# build a local cronicle-edge image: docker build -t cronicle:edge -f Dockerfile .
-# create cronicle secret: echo myPassword123 | docker secret create secret_key -
-# make sure secret_key is not numeric (e.g. 123456), it should contain at least 1 letter or special character
+# build a local cronicle-edge image: docker build -t cronicle:bundle -f Dockerfile .
+# create the external secret once: openssl rand -hex 32 | docker secret create secret_key -
 
 # start cluster:         docker stack deploy --compose-file  Docker/LocalCluster.yaml cron_stack
 # check status:          docker stack ps cron_stack
@@ -16,40 +15,36 @@ services:
   worker1:
     image: cronicle:bundle
     hostname: worker1
-    ports: 
-      - "3013:3012"
     networks:
       - cw
     deploy:
       replicas: 1
-    entrypoint: worker
+    command: worker
     environment:
-      - CRONICLE_secret_key = cronicle_secret_key
-    # secrets:
-    #   - source: "secret_key"
-    #     target: "secret_key"
-    #     uid: "0"
-    #     gid: "0"
-    #     mode: 0400
+      - CRONICLE_secret_key_file=/run/secrets/secret_key
+    secrets:
+      - source: "secret_key"
+        target: "secret_key"
+        uid: "0"
+        gid: "0"
+        mode: 0400
 
   worker2:
     image: cronicle:bundle
     hostname: worker2
-    ports: 
-      - "3014:3012"
     networks:
       - cw
     deploy:
       replicas: 1
-    entrypoint: worker
+    command: worker
     environment:
-      - CRONICLE_secret_key = cronicle_secret_key
-    # secrets:
-    #   - source: "secret_key"
-    #     target: "secret_key"
-    #     uid: "0"
-    #     gid: "0"
-    #     mode: 0400
+      - CRONICLE_secret_key_file=/run/secrets/secret_key
+    secrets:
+      - source: "secret_key"
+        target: "secret_key"
+        uid: "0"
+        gid: "0"
+        mode: 0400
  
   manager1:
     image: cronicle:bundle
@@ -57,29 +52,29 @@ services:
     ports: 
       - "3012:3012"
     volumes:
-      - cron_drive_fs:/data
+      - cron_drive_fs:/opt/cronicle/data
     networks:
       - cw
     deploy:
       replicas: 1
-    entrypoint: manager 
+    command: manager
     environment:
-      - CRONICLE_secret_key = cronicle_secret_key
-    # secrets:
-    #   - source: "secret_key"
-    #     target: "secret_key"
-    #     uid: "0"
-    #     gid: "0"
-    #     mode: 0400
+      - CRONICLE_secret_key_file=/run/secrets/secret_key
+    secrets:
+      - source: "secret_key"
+        target: "secret_key"
+        uid: "0"
+        gid: "0"
+        mode: 0400
 
 networks:
   cw:
     driver: overlay
     attachable: true
     
-# secrets:
-#   secret_key:
-#     external: true
+secrets:
+  secret_key:
+    external: true
 
 volumes:
   cron_drive_fs:

--- a/Docker/LocalClusterAnchor.yaml
+++ b/Docker/LocalClusterAnchor.yaml
@@ -11,8 +11,10 @@ x-node: &node
     resources:
       limits:
         memory: 8g
+  environment:
+    - "CRONICLE_secret_key_file=/run/secrets/secret_key"
   secrets:
-    - source: "cron_secret_key"
+    - source: "secret_key"
       target: "secret_key"
       uid: "0"
       gid: "0"
@@ -35,6 +37,7 @@ services:
         - "traefik.http.services.crond.loadbalancer.sticky.cookie=true"
     environment:
     - "CRONICLE_manager=1"
+    - "CRONICLE_secret_key_file=/run/secrets/secret_key"
 
 # ---------- workers --------------
 
@@ -67,5 +70,5 @@ networks:
       name: cron
 
 secrets:
-  cron_secret_key:
+  secret_key:
     external: true

--- a/Docker/Readme.md
+++ b/Docker/Readme.md
@@ -22,9 +22,10 @@ For actual use:
 - you can specify secret_key via env variable. CRONICLE_manager=1 will start up cronicle right away (only use on single manager node/cluster)
 
 ```bash
+export CRONICLE_SECRET_KEY="$(openssl rand -hex 32)" # generate once, store securely, and reuse
 docker run -d --hostname manager1 --restart=always \
   -e CRONICLE_manager=1 \
-  -e CRONICLE_secret_key=123456 \
+  -e CRONICLE_secret_key="$CRONICLE_SECRET_KEY" \
   -p 3012:3012 \
   -v $HOME/data:/opt/cronicle/data \
   cronicle/cronicle:edge manager

--- a/Docker/Readme.md
+++ b/Docker/Readme.md
@@ -19,17 +19,27 @@ For actual use:
 - for persistant volume you only need to map *data* folder
 - to run cronicle "as a service" use *restart=always* option
 - you may optionally use *--net=host* parameter if interacting with cronicle nodes on other machines (in this case don't use hostname parameter, it should be the same as your host)
-- you can specify secret_key via env variable. CRONICLE_manager=1 will start up cronicle right away (only use on single manager node/cluster)
+- `CRONICLE_manager=1` starts Cronicle immediately (only use it on a single-manager node/cluster)
 
 ```bash
-export CRONICLE_SECRET_KEY="$(openssl rand -hex 32)" # generate once, store securely, and reuse
+install -d -m 0700 "$HOME/.config/cronicle" "$HOME/data"
+if [ ! -s "$HOME/.config/cronicle/secret_key" ]; then
+  (umask 077; openssl rand -hex 32 > "$HOME/.config/cronicle/secret_key")
+fi
+chmod 0600 "$HOME/.config/cronicle/secret_key"
 docker run -d --hostname manager1 --restart=always \
   -e CRONICLE_manager=1 \
-  -e CRONICLE_secret_key="$CRONICLE_SECRET_KEY" \
+  -e CRONICLE_secret_key_file=/run/secrets/cronicle_secret_key \
   -p 3012:3012 \
-  -v $HOME/data:/opt/cronicle/data \
+  -v "$HOME/data:/opt/cronicle/data" \
+  --mount type=bind,source="$HOME/.config/cronicle/secret_key",target=/run/secrets/cronicle_secret_key,readonly \
   cronicle/cronicle:edge manager
 ```
+
+The key file must be reused by every node that belongs to the cluster.  Keep a
+protected backup: replacing it after data has been written makes encrypted
+values unreadable.  A file mount keeps the key value out of `docker inspect`
+environment output.
 
 # Running cronicle in swarm mode (as service)
 If you have multiple machines it's a good idea to set up a swarm cluster. It's still could be useful on a single node too, since you'll get access to secret management, and will be able easily update/roll back cronicle version.
@@ -38,16 +48,18 @@ If you have multiple machines it's a good idea to set up a swarm cluster. It's s
 
  ```bash
  docker network create --driver overlay cron
- mkdir -p /var/data/cronicle/v1/data # could be anything, but should be in line with step 3 (--mount arg)
+ sudo install -d -m 0700 /var/data/cronicle/v1/data # run on the manager node; keep this in line with step 3 (--mount arg)
  ```
  
 
-## step 2 - create secrets (optional)
+## step 2 - create secrets
 
 ```bash
-echo -n "MyCronSecretKey" | docker secret create secret_key -
+openssl rand -hex 32 | docker secret create secret_key -
 docker secret create cronicle.key /path/to/key.pem
 ```
+Create `secret_key` only once and reuse that external Docker secret for every
+node.  Do not pass its value through a service environment variable.
 The key is used for data encryption. Use bin/cms (openssl wrapper) to generate one:
  ```
   bin/cms new cronicle > /path/to/key.pem
@@ -62,6 +74,7 @@ The key is used for data encryption. Use bin/cms (openssl wrapper) to generate o
    --mount  type=bind,source=/var/data/cronicle/v1/data,destination=/opt/cronicle/data \
    --network cron  \
    -e CRONICLE_manager=1  \
+   -e CRONICLE_secret_key_file=/run/secrets/secret_key  \
    cronicle/cronicle:edge-1.0.0 manager
 ```
 
@@ -90,6 +103,7 @@ If secret is meant to be accessed by non-root user then just specify it as ```--
    --secret  source=secret_key,target=secret_key,uid=0,mode=0400  \
    --secret  source=cronicle.key,target=cronicle.key,uid=0,mode=0400  \
    --network cron  \
+   -e CRONICLE_secret_key_file=/run/secrets/secret_key  \
    cronicle/cronicle:edge-1.0.0 worker
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -17,13 +17,18 @@ Images:
  docker run -it --rm -p 3012:3012 ghcr.io/cronicle-edge/cronicle-edge:main manager
 
 # typical local setup
- # Generate this once, store it securely, and reuse it for every cluster node.
- export CRONICLE_SECRET_KEY="$(openssl rand -hex 32)"
- mkdir -p $HOME/cron && docker run -d --name cron \
+ # Create the directory and key file once.  Never replace secret_key after Cronicle has stored data.
+ install -d -m 0700 "$HOME/.config/cronicle" "$HOME/cron"
+ if [ ! -s "$HOME/.config/cronicle/secret_key" ]; then
+   (umask 077; openssl rand -hex 32 > "$HOME/.config/cronicle/secret_key")
+ fi
+ chmod 0600 "$HOME/.config/cronicle/secret_key"
+ docker run -d --name cron \
  --hostname manager1 \
  -p 3012:3012 --restart always  \
- -v $HOME/cron:/opt/cronicle/data  \
- -e CRONICLE_secret_key="$CRONICLE_SECRET_KEY"  \
+ -v "$HOME/cron:/opt/cronicle/data"  \
+ --mount type=bind,source="$HOME/.config/cronicle/secret_key",target=/run/secrets/cronicle_secret_key,readonly \
+ -e CRONICLE_secret_key_file=/run/secrets/cronicle_secret_key  \
  cronicle/edge:v1.13.3 manager 
 ```
 
@@ -57,8 +62,8 @@ bundle script will also print instruction how to setup cronicle as service.
 
 ## Try multinode setup with Docker swarm
 ```bash
-# before deploying stack, set up a secret_key as docker secret, e.g.:
-# echo 123456 | docker secret create secret_key -
+# Before deploying the stack, create this external secret once and keep it:
+openssl rand -hex 32 | docker secret create secret_key -
 docker stack deploy --compose-file  Docker/LocalCluster.yaml cron_stack
 # then go to admin/servers and add nodes called worker1 and worker2 manually
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -17,11 +17,13 @@ Images:
  docker run -it --rm -p 3012:3012 ghcr.io/cronicle-edge/cronicle-edge:main manager
 
 # typical local setup
+ # Generate this once, store it securely, and reuse it for every cluster node.
+ export CRONICLE_SECRET_KEY="$(openssl rand -hex 32)"
  mkdir -p $HOME/cron && docker run -d --name cron \
  --hostname manager1 \
  -p 3012:3012 --restart always  \
  -v $HOME/cron:/opt/cronicle/data  \
- -e CRONICLE_secret_key=mysecretKey  \
+ -e CRONICLE_secret_key="$CRONICLE_SECRET_KEY"  \
  cronicle/edge:v1.13.3 manager 
 ```
 


### PR DESCRIPTION
## Problem

The Docker examples exposed reusable cluster keys through service/container environment variables, included weak literal secret examples, and created persistent data directories without owner-only permissions.  The local Swarm sample also overrode the image entrypoint, exposed worker ports, and mounted the manager volume at the wrong path.

## Change

- Generate the Cronicle key once with `openssl rand`, store it as a protected `0600` file, and load it through `CRONICLE_secret_key_file`.
- Use an external Docker secret on every manager and worker in the Swarm examples.
- Create bind-mount data directories with mode `0700` and quote host paths.
- Preserve the image's `tini` entrypoint by using `command`, mount manager data at `/opt/cronicle/data`, and publish only the manager port.
- Document that replacing the key after encrypted data exists makes that data unreadable.

## Scope

This PR fixes the non-S3 examples only.  `Docker/LocalCluster.s3.yaml` is intentionally left to the existing S3 stack repair in #263; its credential model still needs a coordinated follow-up rather than a competing partial patch.

## Validation

- Both sample stacks pass `docker stack config`.
- A real `cronicle/cronicle:edge` container loaded a bind-mounted `0600` key, served the status API, and accepted HMAC authentication derived from that key.
- The secret value was absent from `docker inspect`; repeated setup preserved the original key and `0700`/`0600` modes.
- Full `npm test`: 92/92 tests, 375 assertions.
- Bash syntax, YAML parsing, EOL-aware diff check: pass.

The issue and initial patch were proposed by a Codex Ultra security review. This version was manually re-analyzed, adds real validation coverage, and is submitted for maintainer review in line with our prior discussion.
