### PR TITLE
fix: handle missing LDAP credentials without crashing

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -177,6 +177,16 @@ module.exports = {
 			test.ok( server.started > 0, 'Cronicle started up successfully');
 			test.done();
 		},
+
+		function testLDAPMissingCredentialsDoesNotCrash(test) {
+			server.User.do_ldap_auth('admin', false, false, false).then(function(result) {
+				test.ok( result === undefined, 'Missing LDAP credentials return without authenticating');
+				test.done();
+			}).catch(function(err) {
+				test.ok( false, 'Missing LDAP credentials must not throw: ' + err.message);
+				test.done();
+			});
+		},
 		
 		function testStorage(test) {
 			storage.get( 'users/admin', function(err, user) {

--- a/lib/user.js
+++ b/lib/user.js
@@ -208,13 +208,13 @@ module.exports = Class.create({
 	},
 
 	do_ldap_auth: async function(username, password, returnUserObject, verifyGroup) { //
+		const self = this;
 
 		if(!username || !password) { // sanity check
 			self.logDebug(3, "LDAP login failed", "Missing username or password")
 			return;
 		}
 	
-		const self = this;
 		const defaultUserFilter = '(samAccountName={{user}})';
 	
 		let ad_domain = self.server.config.get('ad_domain');  // e.g. corp.company.com or MYDOMAIN, this is mandatory for simple AD auth


### PR DESCRIPTION
## Summary

- initialize the LDAP method context before the missing-credential guard
- return cleanly for a falsy username or password instead of rejecting with `ReferenceError`
- add a regression test for the asynchronous error path

## Why

`do_ldap_auth()` logged through `self` before `const self = this` was initialized. A request with a falsy credential therefore rejected with a temporal-dead-zone `ReferenceError` instead of following the existing missing-credential path.

The issue and minimal line move were initially proposed by a Codex Ultra security review. This version was manually re-analyzed, adds regression coverage, and is submitted for maintainer review in line with our prior discussion.

## Unchanged behavior

- Valid LDAP credentials continue through the same simple-bind and group-auth flows.
- Missing credentials still do not authenticate a user.
- LDAP configuration and account persistence are unchanged.

## Tests

- regression: missing credentials resolve without authentication instead of rejecting
- `npm ci`
- `npm test`: 92/92 passed, 375 assertions
- `node --check lib/user.js`
- `node --check lib/test.js`
- `git diff --check`
