### PR TITLE
fix: require canonical OAuth usernames

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -177,6 +177,25 @@ module.exports = {
 			test.ok( server.started > 0, 'Cronicle started up successfully');
 			test.done();
 		},
+
+		function testOAuthUsernameCollisionGuard(test) {
+			var userComponent = server.User;
+			var storedUser = { username: 'admin' };
+
+			test.ok(
+				userComponent.normalizeUsername('ad-min') == userComponent.normalizeUsername('admin'),
+				'Punctuation variants collide in the storage key'
+			);
+			test.ok(
+				!userComponent.oauthUsernameMatches(storedUser, 'ad-min'),
+				'OAuth identity must match the canonical stored username'
+			);
+			test.ok(
+				userComponent.oauthUsernameMatches(storedUser, 'ADMIN'),
+				'Canonical username comparison remains case-insensitive'
+			);
+			test.done();
+		},
 		
 		function testStorage(test) {
 			storage.get( 'users/admin', function(err, user) {

--- a/lib/user.js
+++ b/lib/user.js
@@ -116,6 +116,11 @@ module.exports = Class.create({
 		return username.toString().toLowerCase().replace(/\W+/g, '');
 	},
 
+	oauthUsernameMatches: function (user, username) {
+		return !!user && (typeof user.username === 'string') && (typeof username === 'string') &&
+			(user.username.toLowerCase() === username.toLowerCase());
+	},
+
 	api_create: function (args, callback) {
 		// create new user account
 		var self = this;
@@ -789,7 +794,7 @@ module.exports = Class.create({
 			// ==== Check if user exist in user database
 			user = await self.getUserAsync('users/' + self.normalizeUsername(userName));
 
-			if (!user) {
+			if (!self.oauthUsernameMatches(user, userName)) {
 				self.logError(3, 'Username does not exists:', userName);
 				return self.doError('login', "Username or password incorrect.", callback); // deliberately vague
 			}
@@ -801,7 +806,7 @@ module.exports = Class.create({
 				return self.doError('login', "User account is disabled: " + userName, callback);
 			}
 
-			params.username = userName
+			params.username = user.username
 		}
 
 		catch (e) {


### PR DESCRIPTION
## Summary

- require the OAuth identity to match the canonical username stored in the resolved user record
- keep the comparison case-insensitive
- create the session with the stored canonical username
- add regression coverage for punctuation-collision identities

## Why

Cronicle stores users under `normalizeUsername(username)`, which removes non-word characters. Distinct provider identities such as `ad-min` and `admin` therefore resolve to the same storage key. The OAuth callback previously accepted whichever record was returned and created a session using the provider-controlled spelling.

The issue and initial guard were proposed by a Codex Ultra security review. This version was manually re-analyzed, handles missing or non-string canonical usernames safely, adds an explicit collision regression, and is submitted for maintainer review in line with our prior discussion.

## Unchanged behavior

- Existing username storage keys and normalization remain unchanged.
- Case-only differences such as `ADMIN` and `admin` remain valid.
- Local password, LDAP, OIDC token validation, and logout behavior are unchanged.

## Tests

- verifies that `ad-min` and `admin` collide at the storage-key layer
- verifies that the OAuth guard rejects the punctuation variant
- verifies that canonical matching remains case-insensitive
- `npm ci`
- `npm test`: 92/92 passed, 377 assertions
- `node --check lib/user.js`
- `node --check lib/test.js`
- `git diff --check`
