### PR TITLE
fix: reject unsafe Docker attachment paths

### DIFF
--- a/bin/docker-attachment.js
+++ b/bin/docker-attachment.js
@@ -1,0 +1,15 @@
+const path = require('path');
+
+function normalizeDockerAttachmentName(name, reservedNames) {
+	if (typeof name !== 'string') throw new Error('Attachment filename must be a string');
+
+	const normalized = path.posix.normalize(name);
+	const unsafe = !normalized || (normalized === '.') || path.posix.isAbsolute(normalized) ||
+		name.includes('\\') || name.split('/').includes('..') || /[\0\r\n]/.test(name) ||
+		reservedNames.has(normalized);
+
+	if (unsafe) throw new Error('Invalid Docker attachment filename: ' + name);
+	return normalized;
+}
+
+module.exports = { normalizeDockerAttachmentName };

--- a/bin/docker-plugin.js
+++ b/bin/docker-plugin.js
@@ -6,6 +6,7 @@ const { Writable } = require('stream');
 const { EOL } = require('os');
 const path = require('path')
 const fs = require('fs')
+const { normalizeDockerAttachmentName } = require('./docker-attachment')
 
 // cronicle should send job json to stdin
 let job = {}
@@ -182,18 +183,24 @@ const dockerRun = async () => {
 
     // create tar archive for entrypoint script
     const pack = tar.pack()
+	const archiveNames = new Set([path.posix.basename(ENTRYPOINT_PATH)])
 
     pack.entry({ name: path.basename(ENTRYPOINT_PATH), mode: 0o755 }, script)
 
     if (job.chain_data) {
         pack.entry({ name: 'chain_data'}, JSON.stringify(job.chain_data))
+		archiveNames.add('chain_data')
     }
     
     // attach file
 	if(Array.isArray(job.files)) {
 		job.files.forEach((e)=> {
             if(e.name) { 
-                pack.entry({  name: e.name }, e.content || '')
+				let name
+				try { name = normalizeDockerAttachmentName(e.name, archiveNames) }
+				catch (err) { exit(err.message) }
+				archiveNames.add(name)
+				pack.entry({ name: name }, e.content || '')
 			}
 		})
 	}

--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -505,8 +505,9 @@ module.exports = Class.create({
 
 				// only allow customize event params (like script in shell plug) to users with edit priv
 				let canEdit = user.privileges.edit_events || user.privileges.create_events ||  user.privileges.admin
-				if(!canEdit && params.params) {
+				if(!canEdit) {
 					delete params.params;
+					delete params.files;
 				}
 
 				var job = Tools.mergeHashes(Tools.copyHash(event, true), params);

--- a/lib/test.js
+++ b/lib/test.js
@@ -3,6 +3,7 @@
 // Released under the MIT License
 
 var cp = require('child_process');
+var crypto = require('crypto');
 var fs = require('fs');
 var async = require('async');
 var moment = require('moment-timezone');
@@ -10,6 +11,7 @@ var moment = require('moment-timezone');
 var Tools = require('pixl-tools');
 var glob = Tools.glob;
 var PixlServer = require("pixl-server");
+var normalizeDockerAttachmentName = require('../bin/docker-attachment').normalizeDockerAttachmentName;
 
 // we need a few config files
 var config = require('../sample_conf/config.json');
@@ -175,6 +177,18 @@ module.exports = {
 		
 		function testServerStarted(test) {
 			test.ok( server.started > 0, 'Cronicle started up successfully');
+			test.done();
+		},
+
+		function testDockerAttachmentNames(test) {
+			var reserved = new Set(['cronicle.sh', 'chain_data']);
+			test.ok(normalizeDockerAttachmentName('reports/output.txt', reserved) == 'reports/output.txt', 'Relative attachment path is accepted');
+			['/etc/passwd', '../etc/passwd', 'reports/../secret', 'reports\\secret', 'bad\nname', 'cronicle.sh', 'chain_data'].forEach(function(name) {
+				var rejected = false;
+				try { normalizeDockerAttachmentName(name, reserved); }
+				catch (err) { rejected = true; }
+				test.ok(rejected, 'Unsafe attachment name is rejected: ' + name);
+			});
 			test.done();
 		},
 		
@@ -1077,6 +1091,40 @@ module.exports = {
 			} );
 		},
 		
+		function testEventTokenCannotOverrideDockerFiles(test) {
+			var self = this;
+			var salt = 'unit_test_file_token_salt';
+			var oldLaunch = cronicle.launchOrQueueJob;
+			var launchedJob = null;
+
+			storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: salt }, function(err) {
+				test.ok(!err, 'Event token was enabled');
+				var token = crypto.createHmac('sha1', server.config.get('secret_key'))
+					.update(self.event_id + salt)
+					.digest('hex');
+
+				cronicle.launchOrQueueJob = function(job, callback) {
+					launchedJob = job;
+					callback(null, []);
+				};
+
+				request.json(api_url + '/app/run_event', {
+					id: self.event_id,
+					token: token,
+					files: [{ name: '../etc/passwd', content: 'injected' }]
+				}, function(err, resp, data) {
+					cronicle.launchOrQueueJob = oldLaunch;
+					test.ok(!err, 'Event token request succeeded');
+					test.ok(data.code == 0, 'Event token launched the configured event');
+					test.ok(launchedJob && !('files' in launchedJob), 'Event token file override was ignored');
+
+					storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: '' }, function() {
+						test.done();
+					});
+				});
+			});
+		},
+
 		function testJobInProgress(test) {
 			// make sure job is in progress
 			var self = this;


### PR DESCRIPTION
## Summary

- normalize and validate Docker attachment names before adding them to the container archive
- reject absolute paths, parent traversal, backslashes, control characters, duplicate names, and collisions with generated entries
- prevent run-only users and event tokens from overriding an event's configured `files`
- add focused validator and event-token regressions

## Why

The Docker plugin previously passed `job.files[].name` directly to `tar-stream`. A crafted name could escape the intended archive layout or replace Cronicle-generated entries such as the entrypoint or `chain_data`. Separately, `run_event` merged top-level request fields into the job, so principals with only `run_events` could supply their own files.

The issue and initial patch were proposed by a Codex Ultra security review. This version was manually re-analyzed, extracts a testable validator, adds API-level regression coverage, and is submitted for maintainer review in line with our prior discussion.

## Unchanged behavior

- Editors can still configure safe relative attachment paths.
- Attachment contents and nested relative directories remain supported.
- The Docker entrypoint and optional `chain_data` archive entries are unchanged.
- Existing plugin-parameter customization rules remain unchanged.

## Tests

- accepts a safe nested relative path
- rejects absolute paths, parent traversal, backslashes, CR/LF, and reserved names
- verifies an event token cannot inject `files`
- `npm ci`
- `npm test`: 93/93 passed, 386 assertions
- `node --check` for all changed JavaScript files
- `git diff --check`
