### PR TITLE
fix: validate API input types before use

### DIFF
--- a/lib/api/admin.js
+++ b/lib/api/admin.js
@@ -60,6 +60,10 @@ module.exports = Class.create({
 		const self = this;
 		let params = args.params;
 		if (!this.requiremanager(args, callback)) return;
+
+		if (!this.validateOptionalParams(params, {
+			hostname: [ 'string', /.*/ ]
+		}, callback)) return;
 		
 		if (!this.requireParams(params, {
 			hostname: /\S/
@@ -150,6 +154,10 @@ module.exports = Class.create({
 		const self = this;
 		let params = args.params;
 		if (!this.requiremanager(args, callback)) return;
+
+		if (!this.validateOptionalParams(params, {
+			hostname: [ 'string', /.*/ ]
+		}, callback)) return;
 		
 		if (!this.requireParams(params, {
 			hostname: /\S/

--- a/lib/api/apikey.js
+++ b/lib/api/apikey.js
@@ -84,6 +84,11 @@ module.exports = Class.create({
 		var self = this;
 		var params = args.params;
 		if (!this.requiremanager(args, callback)) return;
+
+		if (!this.validateOptionalParams(params, {
+			title: [ 'string', /.*/ ],
+			description: [ 'string', /.*/ ]
+		}, callback)) return;
 		
 		if (!this.requireParams(params, {
 			title: /\S/,
@@ -139,6 +144,11 @@ module.exports = Class.create({
 		var self = this;
 		var params = args.params;
 		if (!this.requiremanager(args, callback)) return;
+
+		if (!this.validateOptionalParams(params, {
+			title: [ 'string', /.*/ ],
+			description: [ 'string', /.*/ ]
+		}, callback)) return;
 		
 		if (!this.requireParams(params, {
 			id: /^\w+$/

--- a/lib/api/category.js
+++ b/lib/api/category.js
@@ -42,6 +42,10 @@ module.exports = Class.create({
 		var self = this;
 		var cat = args.params;
 		if (!this.requiremanager(args, callback)) return;		
+
+		if (!this.validateOptionalParams(cat, {
+			title: [ 'string', /.*/ ]
+		}, callback)) return;
 	
 		if (!this.requireParams(cat, {
 			title: /\S/,
@@ -121,6 +125,10 @@ module.exports = Class.create({
 		var self = this;
 		var params = args.params;
 		if (!this.requiremanager(args, callback)) return;
+
+		if (!this.validateOptionalParams(params, {
+			title: [ 'string', /.*/ ]
+		}, callback)) return;
 		
 		if (!this.requireParams(params, {
 			id: /^\w+$/

--- a/lib/api/confkey.js
+++ b/lib/api/confkey.js
@@ -68,6 +68,10 @@ module.exports = Class.create({
 		let params = args.params;
 		if (!this.requiremanager(args, callback)) return;
 
+		if (!this.validateOptionalParams(params, {
+			title: [ 'string', /.*/ ]
+		}, callback)) return;
+
 		if (!this.requireParams(params, {
 			title: /\S/,
 			key: /\S/
@@ -134,6 +138,10 @@ module.exports = Class.create({
 		const self = this;
 		let params = args.params;
 		if (!this.requiremanager(args, callback)) return;
+
+		if (!this.validateOptionalParams(params, {
+			title: [ 'string', /.*/ ]
+		}, callback)) return;
 
 		if (!this.requireParams(params, {
 			id: /^\w+$/,

--- a/lib/api/group.js
+++ b/lib/api/group.js
@@ -20,6 +20,10 @@ module.exports = Class.create({
 		var self = this;
 		var group = args.params;
 		if (!this.requiremanager(args, callback)) return;
+
+		if (!this.validateOptionalParams(group, {
+			title: [ 'string', /.*/ ]
+		}, callback)) return;
 		
 		if (!this.requireParams(group, {
 			title: /\S/,
@@ -69,6 +73,10 @@ module.exports = Class.create({
 		var self = this;
 		var params = args.params;
 		if (!this.requiremanager(args, callback)) return;
+
+		if (!this.validateOptionalParams(params, {
+			title: [ 'string', /.*/ ]
+		}, callback)) return;
 		
 		if (!this.requireParams(params, {
 			id: /^\w+$/

--- a/lib/api/plugin.js
+++ b/lib/api/plugin.js
@@ -41,6 +41,11 @@ module.exports = Class.create({
 		var plugin = args.params;
 		if (!this.requiremanager(args, callback)) return;
 
+		if (!this.validateOptionalParams(plugin, {
+			title: [ 'string', /.*/ ],
+			command: [ 'string', /.*/ ]
+		}, callback)) return;
+
 		if (!this.requireParams(plugin, {
 			title: /\S/,
 			command: /\S/
@@ -109,6 +114,11 @@ module.exports = Class.create({
 		var self = this;
 		var params = args.params;
 		if (!this.requiremanager(args, callback)) return;
+
+		if (!this.validateOptionalParams(params, {
+			title: [ 'string', /.*/ ],
+			command: [ 'string', /.*/ ]
+		}, callback)) return;
 
 		if (!this.requireParams(params, {
 			id: /^\w+$/
@@ -279,6 +289,9 @@ module.exports = Class.create({
 		
 		for (var idx = 0, len = params.length; idx < len; idx++) {
 			var param = params[idx];
+			if (!Tools.isaHash(param)) {
+				return this.doError('plugin', "Plugin Parameter entry is invalid (must be an object).", callback);
+			}
 			if (!param.id || (typeof(param.id) != 'string') || !param.id.match(/^\w+$/)) {
 				return this.doError('plugin', "Plugin Parameter ID is invalid (must be alphanumeric).", callback);
 			}

--- a/lib/test.js
+++ b/lib/test.js
@@ -276,6 +276,154 @@ module.exports = {
 				test.done();
 			} );
 		},
+
+		function testAPIInputTypesDoNotCrashBeforeAuthentication(test) {
+			// All of these handlers inspect titles before loading the user session.
+			// Invalid JSON types must produce API errors, not uncaught TypeErrors.
+			var handlers = [
+				{ name: 'create_api_key', params: { key: 'unit_api_key', active: 1 } },
+				{ name: 'update_api_key', params: { id: 'unit_api_key' } },
+				{ name: 'create_category', params: { max_children: 0 } },
+				{ name: 'update_category', params: { id: 'unit_category' } },
+				{ name: 'create_server_group', params: { regexp: '^unit$' } },
+				{ name: 'update_server_group', params: { id: 'unit_group' } },
+				{ name: 'create_plugin', params: { command: 'bin/shell-plugin.js', params: [] } },
+				{ name: 'update_plugin', params: { id: 'unit_plugin' } },
+				{ name: 'create_conf_key', params: { key: 'unit value' } },
+				{ name: 'update_conf_key', params: { id: 'unit_conf_key' } },
+				{ name: 'create_event', params: { enabled: 1, category: 'unit', target: 'unit', plugin: 'unit' } },
+				{ name: 'update_event', params: { id: 'unit_event' } }
+			];
+			var invalid_titles = [
+				{ label: 'object with non-callable toString', value: { toString: null } },
+				{ label: 'plain object', value: {} },
+				{ label: 'array', value: [] },
+				{ label: 'null', value: null }
+			];
+			var cases = [];
+
+			handlers.forEach(function(handler) {
+				invalid_titles.forEach(function(variant) {
+					cases.push({
+						name: handler.name,
+						label: 'invalid title (' + variant.label + ')',
+						params: Tools.mergeHashes(handler.params, { title: variant.value }),
+						expected_code: 'api'
+					});
+				});
+
+				cases.push({
+					name: handler.name,
+					label: 'valid string title',
+					params: Tools.mergeHashes(handler.params, { title: 'Valid unit title' }),
+					expected_code: 'session'
+				});
+			});
+
+			[ 'create_api_key', 'update_api_key' ].forEach(function(name) {
+				var handler = handlers.filter(function(item) { return item.name == name; })[0];
+				[ { toString: null }, {} ].forEach(function(description, idx) {
+					cases.push({
+						name: name,
+						label: 'invalid API key description object ' + (idx + 1),
+						params: Tools.mergeHashes(handler.params, {
+							title: 'Valid unit title',
+							description: description
+						}),
+						expected_code: 'api'
+					});
+				});
+			});
+
+			cases.push({
+				name: 'create_api_key',
+				label: 'required parameter with non-callable toString',
+				params: { title: 'Valid unit title', key: { toString: null }, active: 1 },
+				expected_code: 'api'
+			});
+			cases.push({
+				name: 'create_plugin',
+				label: 'invalid plugin command object',
+				params: { title: 'Valid unit title', command: {}, params: [] },
+				expected_code: 'api'
+			});
+			cases.push({
+				name: 'update_plugin',
+				label: 'invalid plugin command object',
+				params: { id: 'unit_plugin', title: 'Valid unit title', command: {} },
+				expected_code: 'api'
+			});
+
+			var invalid_plugin_params = [
+				{ label: 'null element', value: [ null ], description: /^Plugin Parameter entry is invalid/ },
+				{ label: 'non-object element', value: [ 'invalid' ], description: /^Plugin Parameter entry is invalid/ },
+				{ label: 'nested array element', value: [ [] ], description: /^Plugin Parameter entry is invalid/ },
+				{ label: 'non-array container', value: {}, description: /^Plugin params is not an array/ }
+			];
+			[ 'create_plugin', 'update_plugin' ].forEach(function(name) {
+				var handler = handlers.filter(function(item) { return item.name == name; })[0];
+				invalid_plugin_params.forEach(function(variant) {
+					cases.push({
+						name: name,
+						label: 'invalid Plugin params (' + variant.label + ')',
+						params: Tools.mergeHashes(handler.params, {
+							title: 'Valid unit title',
+							params: variant.value
+						}),
+						expected_code: 'plugin',
+						expected_description: variant.description
+					});
+				});
+			});
+
+			var invalid_hostnames = [
+				{ label: 'plain object', value: {} },
+				{ label: 'array', value: [] },
+				{ label: 'null', value: null },
+				{ label: 'object with non-callable toString', value: { toString: null } }
+			];
+			[ 'add_server', 'remove_server' ].forEach(function(name) {
+				invalid_hostnames.forEach(function(variant) {
+					cases.push({
+						name: name,
+						label: 'invalid hostname (' + variant.label + ')',
+						params: { hostname: variant.value },
+						expected_code: 'api',
+						expected_description: /^Malformed parameter type: hostname/
+					});
+				});
+				cases.push({
+					name: name,
+					label: 'valid string hostname',
+					params: { hostname: 'worker.example.invalid' },
+					expected_code: 'session'
+				});
+			});
+
+			async.eachSeries(cases, function(item, callback) {
+				request.json( api_url + '/app/' + item.name, item.params, function(err, resp, data) {
+					var context = item.name + ': ' + item.label;
+					test.ok( !err, context + ' returned an HTTP response' );
+					test.ok( resp && (resp.statusCode == 200), context + ' returned HTTP 200' );
+					test.ok( data && (data.code == item.expected_code), context + ' returned controlled ' + item.expected_code + ' error' );
+					if (item.expected_description) {
+						test.ok( data && item.expected_description.test(data.description || ''), context + ' returned the expected validation error' );
+					}
+					else if (item.expected_code == 'api') {
+						test.ok( data && /^(Malformed|Null) parameter/.test(data.description || ''), context + ' described a malformed parameter' );
+					}
+					callback();
+				} );
+			}, function() {
+				// A final successful request proves the server remained alive after every payload.
+				request.json( api_url + '/app/ping', {}, function(err, resp, data) {
+					test.ok( !err, 'API server remained reachable after invalid input cases' );
+					test.ok( resp && (resp.statusCode == 200), 'API server still returned HTTP 200' );
+					test.ok( data && (data.code == 0), 'API server still handled a valid request' );
+					test.done();
+				} );
+			} );
+		},
 		
 		function testAPILoginBadUsername(test) {
 			// login with unknown username

--- a/lib/user.js
+++ b/lib/user.js
@@ -2232,7 +2232,17 @@ module.exports = Class.create({
 				this.doError('api', "Null parameter: " + key, callback);
 				return false;
 			}
-			if (!params[key].toString().match(regexp)) {
+
+			var value = '';
+			try {
+				value = String(params[key]);
+			}
+			catch (err) {
+				this.doError('api', "Malformed parameter: " + key, callback);
+				return false;
+			}
+
+			if (!value.match(regexp)) {
 				this.doError('api', "Malformed parameter: " + key, callback);
 				return false;
 			}


### PR DESCRIPTION
## Problem

Several API handlers used caller-controlled values as strings before authentication completed.  Malformed JSON values could throw from `.toString()`, `.match()`, `.toLowerCase()`, or plugin-parameter traversal and terminate the server process without a valid session.

## Change

- Make the shared required-parameter conversion fail with a controlled API error when string conversion throws.
- Require string types for API-key/category/group/config-key/plugin titles and other values that are consumed as strings.
- Validate server hostnames before lowercasing them.
- Reject non-object plugin parameter entries before reading their fields.

Valid string inputs and the existing authorization order remain unchanged.

## Validation

- Real unauthenticated HTTP regressions cover create/update handlers, malformed plugin parameter arrays, and add/remove server hostnames.
- Each valid-shape control request reaches the expected session error, and a final `/ping` proves the process remains alive.
- Full `npm test`: 93/93 tests, 704 assertions.
- `node --check` and `git diff --check`: pass.

The issue and initial patch were proposed by a Codex Ultra security review. This version was manually re-analyzed, expands the fix to every reproduced pre-authentication sink, adds real regression coverage, and is submitted for maintainer review in line with our prior discussion.
