### PR TITLE
fix: encode persisted schedule data safely

### DIFF
--- a/htdocs/js/app.js
+++ b/htdocs/js/app.js
@@ -937,8 +937,11 @@ function summarize_event_timing_short(timing) {
 
 function summarize_event_timing(timing, timezone, extra) {
 	// summarize event timing into human-readable string
+	// Fail safe for records persisted before ticks became API-validated.
+	if (typeof extra !== 'string') extra = '';
 	if (!timing && extra) {
-		return `<span title="${'Extra Ticks: ' + extra.toString().split(/[\,\;\|]/).filter(e => e).join(', ')}">On Demand +</span>`
+		let xtitle = 'Extra Ticks: ' + extra.split(/[\,\;\|]/).filter(e => e).join(', ')
+		return `<span title="${encode_attrib_entities(xtitle)}">On Demand +</span>`
 	}
 	if (!timing) { return "On demand" };	
 	
@@ -1069,8 +1072,8 @@ function summarize_event_timing(timing, timezone, extra) {
 	}
 	
 	if(extra) {
-		let xtitle = extra.toString().split(/[\,\;\|]/).filter(e=>e).join(', ')
-		return `<span title="Extra Ticks: ${xtitle}">${output} +</span>`
+		let xtitle = extra.split(/[\,\;\|]/).filter(e=>e).join(', ')
+		return `<span title="Extra Ticks: ${encode_attrib_entities(xtitle)}">${output} +</span>`
 	}
 	
 	return output

--- a/htdocs/js/home-worker.js
+++ b/htdocs/js/home-worker.js
@@ -118,7 +118,7 @@ onmessage = function (e) {
 
 		// -------  EXTRA TICKS ---------
 
-		if (item.ticks) { // this should be in line with checkEventTicks function on scheduler.js
+		if (typeof item.ticks === 'string' && item.ticks) { // this should be in line with checkEventTicks function on scheduler.js
 			let currDate = getFMT(tz).format(Date.now()).substring(0, 10) // yyyy-mm-dd @ tz
 			let ticks = []
 			item.ticks.split(/[\,\|]/).map(e => e.trim()).filter(e => e).forEach(t => {

--- a/htdocs/js/pages/History.class.js
+++ b/htdocs/js/pages/History.class.js
@@ -27,6 +27,18 @@ Class.subclass( Page.Base, "Page.History", {
 		
 		return true;
 	},
+
+	render_job_status: function(job) {
+		if (job.code == 0) {
+			return '<span class="color_label green"><i class="fa fa-check">&nbsp;</i>Success</span>';
+		}
+
+		var errorTitle = typeof job.description === 'string' ? job.description.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "") : " ";
+		errorTitle = encode_attrib_entities(errorTitle);
+		var color = (job.code == 255) ? 'yellow' : 'red';
+		var label = (job.code == 255) ? 'Warning' : 'Error';
+		return `<span class="color_label ${color}" title="${errorTitle}"><i class="fa fa-warning">&nbsp;</i>${label}</span>`;
+	},
 	
 	gosub_history: function(args) {
 		// show history
@@ -128,12 +140,7 @@ Class.subclass( Page.Base, "Page.History", {
 			var job_link = '<div class="td_big">--</div>';
 			if (job.id) job_link = `<div class="td_big">${href}` + self.getNiceJob('<b>' + job.id + '</b>') + '</a></div>';
 			
-			// error title - clear from escape characters and tags
-			var errorTitle = typeof job.description === 'string' ? job.description.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "").replace(/"/g, "&quot;") : " " 
-			if(errorTitle.indexOf('<') > -1) errorTitle = encode_entities(errorTitle) // sometime error message contains <>
-
-			var jobStatus = (job.code == 0) ? '<span class="color_label green"><i class="fa fa-check">&nbsp;</i>Success</span>' : `<span class="color_label red" title="${errorTitle}"><i class="fa fa-warning">&nbsp;</i>Error</span>`
-			if(job.code == 255) {jobStatus = `<span class="color_label yellow" title="${errorTitle}"><i class="fa fa-warning">&nbsp;</i>Warning</span>`}
+			var jobStatus = self.render_job_status(job)
 			
 			var tds = [
 				job_link,				
@@ -852,9 +859,7 @@ Class.subclass( Page.Base, "Page.History", {
 			if (job.cpu) cpu_avg = short_float( (job.cpu.total || 0) / (job.cpu.count || 1) );
 			if (job.mem) mem_avg = short_float( (job.mem.total || 0) / (job.mem.count || 1) );
 			
-			var errorTitle = job.description ? job.description.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "") : " " 
-			var jobStatusHist = (job.code == 0) ? '<span class="color_label green"><i class="fa fa-check">&nbsp;</i>Success</span>' : `<span title="${errorTitle}" class="color_label red"><i class="fa fa-warning">&nbsp;</i>Error</span>`
-			if(job.code == 255) {jobStatusHist = `<span title="${errorTitle}" class="color_label yellow"><i class="fa fa-warning">&nbsp;</i>Warning</span>`}
+			var jobStatusHist = self.render_job_status(job)
 
 			let job_expired = time_now() > job.expires_at
 			let href = job_expired ? '' : '<a href="#JobDetails?id='+job.id+'">'

--- a/htdocs/js/pages/Schedule.class.js
+++ b/htdocs/js/pages/Schedule.class.js
@@ -144,9 +144,18 @@ Class.subclass(Page.Base, "Page.Schedule", {
 
 	},
 
+	get_safe_text_value: function (value) {
+		// Rendering fallback for records persisted before API validation existed.
+		// Structured values are never stringified because hostile or malformed
+		// objects may not implement a safe toString() method.
+		if (typeof value === 'string') return value;
+		if ((typeof value === 'number') || (typeof value === 'boolean')) return String(value);
+		return '';
+	},
+
 	render_file_list: function () {
 		let cols = ['File Name', ' '];
-		let files = this.event.files || []
+		let files = Array.isArray(this.event.files) ? this.event.files : []
 
 		if (files.length === 0) {
 			document.getElementById('fe_ee_pp_file_list').innerHTML = ''
@@ -156,11 +165,13 @@ Class.subclass(Page.Base, "Page.Schedule", {
 		let table = '<table id="wf_event_list_table" class="data_table"><tr><th>' + cols.join('</th><th>').replace(/\s+/g, '&nbsp;') + '</th></tr>';
 
 		for (var idx = 0, len = files.length; idx < len; idx++) {
+			let file = files[idx] || {}
+			let fileName = this.get_safe_text_value(file.name)
 			let actions = ` 
 			   <span class="link" onMouseUp = "$P().file_edit(${idx})" > <b>Edit</b></span> | 
 			   <span class="link" onMouseUp = "$P().file_delete(${idx})" > <b>Delete</b></span>
 			   `
-			table += `<tr><td id><b>${encode_entities(files[idx].name)}</b></td><td>${actions}</td> </tr>`
+			table += `<tr><td id><b>${encode_entities(fileName)}</b></td><td>${actions}</td> </tr>`
 
 		}
 
@@ -172,7 +183,7 @@ Class.subclass(Page.Base, "Page.Schedule", {
 	file_add: function () {
 
 		let self = this;
-		if (!self.event.files) self.event.files = []
+		if (!Array.isArray(self.event.files)) self.event.files = []
 		let files = self.event.files
 
 		// FILE EDITOR ON SHELLPLUG'
@@ -192,7 +203,8 @@ Class.subclass(Page.Base, "Page.Schedule", {
 
 				let name = $("#fe_ee_pp_file_name").val()
 
-				if (!name || files.map(e => e.name).indexOf(name) > -1) {
+				let existingNames = files.map(file => self.get_safe_text_value(file && file.name))
+				if (!name || existingNames.indexOf(name) > -1) {
 					app.showMessage('error', "Invalid Name")
 				}
 				else {
@@ -219,14 +231,16 @@ Class.subclass(Page.Base, "Page.Schedule", {
 		if (!Array.isArray(self.event.files)) return // sanity check
 		let file = self.event.files[i]
 		if (!file) return // sanity check
+		let fileName = self.get_safe_text_value(file.name)
+		let fileContent = self.get_safe_text_value(file.content)
 
 		let html = '<table>' +
-			get_form_table_row('Name', `<input type="text" id="fe_ee_pp_file_name" size="40" value="${file.name}" spellcheck="false">`) +
+			get_form_table_row('Name', `<input type="text" id="fe_ee_pp_file_name" size="40" value="${escape_text_field_value(fileName)}" spellcheck="false">`) +
 			get_form_table_spacer() +
-			get_form_table_row('Content', `<textarea style="padding-right:20px"  id="fe_ee_pp_file_content" rows="36" cols="110">${file.content}</textarea>`)
+			get_form_table_row('Content', `<textarea style="padding-right:20px"  id="fe_ee_pp_file_content" rows="36" cols="110">${escape_text_field_value(fileContent)}</textarea>`)
 		html += '</table>'
 
-		setTimeout(() => self.setFileEditor(file.name), 30) // editor needs to wait for a bit for modal window to render
+		setTimeout(() => self.setFileEditor(fileName), 30) // editor needs to wait for a bit for modal window to render
 
 		app.confirm(html, '', "Save", function (result) {
 			app.clearError();
@@ -264,14 +278,23 @@ Class.subclass(Page.Base, "Page.Schedule", {
 	 * @typedef {Object} WFEvent
 	 * @property {string} id
 	 * @property {string} title
-	 * @property {string} arg
-	 * @property {boolean} wait
-	 * @property {boolean} disabled
+	 * @property {string|number|boolean|null} arg
+	 * @property {boolean|number} wait Boolean or numeric 0/1
+	 * @property {boolean|number} disabled Boolean or numeric 0/1
 	 */
+	render_wf_event_options: function (events, selected_id) {
+		let self = this;
+		return (Array.isArray(events) ? events : []).map(function (event) {
+			let id = self.get_safe_text_value(event && event.id);
+			let title = (event && event.title != null) ? self.get_safe_text_value(event.title) : id;
+			let selected = (id == selected_id) ? ' selected="selected"' : '';
+			return `<option value="${escape_text_field_value(id)}"${selected}>${encode_entities(title)}</option>`;
+		}).join('');
+	},
 
 	render_wf_event_list: function () {
 		let cols = ['#', "Run", '@', 'Id', 'Title', 'Argument', ' '];
-		let wf_events = this.event.workflow || []
+		let wf_events = Array.isArray(this.event.workflow) ? this.event.workflow : []
 
 		let table = '<table id="wf_event_list_table" class="data_table"><tr><th>' + cols.join('</th><th>').replace(/\s+/g, '&nbsp;') + '</th></tr>';
 
@@ -279,9 +302,9 @@ Class.subclass(Page.Base, "Page.Schedule", {
 			table += '<tr><td></td><td></td><td></td><td></td><td><b>No event found</b></td><td></td></tr>'
 		}
 		// '<input type="checkbox" style="cursor:pointer" onChange="$P().change_event_enabled(' + idx + ')" ' + (item.enabled ? 'checked="checked"' : '') + '/>',
-		let schedTitles = {};
+		let schedTitles = Object.create(null);
 		(app.schedule || []).forEach(e => {
-			schedTitles[e.id] = e.title
+			schedTitles[this.get_safe_text_value(e.id)] = e.title
 		});
 
 		let startFrom = parseInt($("#wf_start_from_step :selected").val());
@@ -293,12 +316,14 @@ Class.subclass(Page.Base, "Page.Schedule", {
 		   <span class="link" onMouseUp = "$P().wf_event_delete(${idx})" > <b>Delete</b></span>
 		   `
 
-			let wfe = wf_events[idx]
-			let eventId = `<span class="link" style="font-weight:bold; white-space:nowrap;"><a href="#Schedule?sub=edit_event&id=${wfe.id}" target="_blank">${wfe.id}</a></span>`
-			let title = `${schedTitles[wfe.id] || '<span style="color:red">[Unknown]</span>'}`.substring(0, 40)
-			let arg = wfe.arg || ''
-			if (arg.length > 40) arg = arg.substring(0, 37) + '...'
-			let argInfo = wfe.arg ? `<span title="refer to JOB_ARG env variable"><u>${encode_entities(arg)}<u></span>` : '-'
+			let wfe = wf_events[idx] || {}
+			let rawId = this.get_safe_text_value(wfe.id)
+			let eventId = `<span class="link" style="font-weight:bold; white-space:nowrap;"><a href="#Schedule?sub=edit_event&id=${encodeURIComponent(rawId)}" target="_blank">${encode_entities(rawId)}</a></span>`
+			let hasTitle = Object.prototype.hasOwnProperty.call(schedTitles, rawId)
+			let title = hasTitle ? encode_entities(this.get_safe_text_value(schedTitles[rawId]).substring(0, 40)) : '<span style="color:red">[Unknown]</span>'
+			let rawArg = this.get_safe_text_value(wfe.arg)
+			let arg = rawArg.length > 40 ? rawArg.substring(0, 37) + '...' : rawArg
+			let argInfo = rawArg ? `<span title="refer to JOB_ARG env variable"><u>${encode_entities(arg)}<u></span>` : '-'
 
 			table += `<tr class="${wfe.disabled ? 'disabled' : ''}">
 	     <td>${idx + 1}</td>
@@ -390,7 +415,8 @@ Class.subclass(Page.Base, "Page.Schedule", {
 		if (!self.event.workflow) self.event.workflow = []
 		let wf = self.event.workflow
 		let opts = self.event.options || {}
-		let event_menu = render_menu_options(all_events, wf.length > 0 ? wf[wf.length - 1].id : all_events[0].id)
+		let selected_id = wf.length > 0 ? wf[wf.length - 1].id : (all_events[0] ? all_events[0].id : '')
+		let event_menu = self.render_wf_event_options(all_events, selected_id)
 
 		let el_style = 'width: 240px; font-size:16px;'
 		let html = '<table>' +  //<option value="">(Select Event)</option>
@@ -428,12 +454,12 @@ Class.subclass(Page.Base, "Page.Schedule", {
 		// show dialog to edit or add wf event
 		let self = this;
 		let evt = self.event.workflow[idx] //self.wf.event_list[idx]
-		let event_list = render_menu_options([evt], evt.id)
+		let event_list = self.render_wf_event_options([evt], evt.id)
 		let el_style = 'width: 240px;  font-size:16px;'
 		let html = '<table>' +
 			get_form_table_row('Event', `<select id="fe_ee_pp_wf_select_event" style="${el_style}" disabled>${event_list}</select>`) +
 			get_form_table_spacer() +
-			get_form_table_row('Job Argument', `<input type="text" id="fe_ee_pp_wf_evt_arg" size="30" value="${evt.arg}" spellcheck="false"/>`) +
+			get_form_table_row('Job Argument', `<input type="text" id="fe_ee_pp_wf_evt_arg" size="30" value="${escape_text_field_value(evt.arg)}" spellcheck="false"/>`) +
 			'</table>'
 
 		app.confirm('<i class="fa fa-clock-o">&nbsp;&nbsp;</i>Edit Event Options', html, "OK", function (result) {
@@ -862,6 +888,7 @@ Class.subclass(Page.Base, "Page.Schedule", {
 		var htmlTab = this.getBasicTable2(events, cols, 'event', function (item, idx) {
 
 			let actions;
+			let extraTicks = self.get_safe_text_value(item.ticks)
 
 			if (isGrid) {
 				actions = [
@@ -933,7 +960,7 @@ Class.subclass(Page.Base, "Page.Schedule", {
 			}
 
 			// for timing     
-			let niceTiming = summarize_event_timing(item.timing, item.timezone, (inactiveTitle || isGrid) ? null : item.ticks)
+			let niceTiming = summarize_event_timing(item.timing, item.timezone, (inactiveTitle || isGrid) ? null : extraTicks)
 			let gridTiming = niceTiming.length > 20 ? summarize_event_timing_short(item.timing) : niceTiming
 			let gridTimingTitle = niceTiming;
 
@@ -959,8 +986,8 @@ Class.subclass(Page.Base, "Page.Schedule", {
 			if (inactiveTitle) {
 				gridTiming = `<s>${gridTiming}</s>`
 				gridTimingTitle = `${inactiveTitle}<br><s>${niceTiming}</s>`
-				niceTiming = `<span title="${inactiveTitle}"><s>${niceTiming}</s>`
-				if (item.ticks) niceTiming += `<span title="Extra Ticks: ${item.ticks}"> <b>+</b> </>`
+				niceTiming = `<span title="${encode_attrib_entities(inactiveTitle)}"><s>${niceTiming}</s>`
+				if (extraTicks) niceTiming += `<span title="Extra Ticks: ${encode_attrib_entities(extraTicks)}"> <b>+</b> </>`
 
 
 			}
@@ -1032,8 +1059,8 @@ Class.subclass(Page.Base, "Page.Schedule", {
 
 			// timing title in grid view
 
-			if (item.ticks) {
-				gridTimingTitle += `<br><br>Extra ticks: ${item.ticks}`
+			if (extraTicks) {
+				gridTimingTitle += `<br><br>Extra ticks: ${extraTicks}`
 				gridTiming += "+"
 			}
 
@@ -1076,7 +1103,7 @@ Class.subclass(Page.Base, "Page.Schedule", {
 			<div class="flex-container">
 			  <div style="padding-left:5px">${actions.join(' ')}</div>	
 			  <div style="text-overflow:ellipsis;overflow:hidden;white-space: nowrap;">		 
-			  <span title="${gridTimingTitle}" style="overflow:hidden;text-overflow: ellipsis;white-space:nowrap">${gridTiming}</span> 
+			  <span title="${encode_attrib_entities(gridTimingTitle)}" style="overflow:hidden;text-overflow: ellipsis;white-space:nowrap">${gridTiming}</span>
 			  </div>		 
 		    </div>
 			</div>
@@ -1778,6 +1805,17 @@ Class.subclass(Page.Base, "Page.Schedule", {
 		$('#fe_ee_secret').attr('placeholder', '')
 	},
 
+	render_event_ticks_input: function (event) {
+		let ticks = this.get_safe_text_value(event.ticks);
+		return `<input type="text" id="fe_ee_ticks" size="50" value="${escape_text_field_value(ticks)}" autocomplete="one-time-code" placeholder="e.g. 3PM|16:45|2020-01-01 09:30" spellcheck="false" onchange="$P().parseTicks()"/>`;
+	},
+
+	render_event_secret_input: function (event) {
+		let preview = this.get_safe_text_value(event.secret_preview);
+		let placeholder = preview ? '[' + preview + ']' : '';
+		return `<textarea  style="width:620px; height:45px;resize:vertical;" id="fe_ee_secret" oninput="$P().set_event_secret(this.value)" placeholder="${escape_text_field_value(placeholder)}" spellcheck="false"></textarea>`;
+	},
+
 	get_event_edit_html: function () {
 		// get html for editing a event (or creating a new one)
 		var html = '';
@@ -1950,7 +1988,7 @@ Class.subclass(Page.Base, "Page.Schedule", {
 			<fieldset style="padding:10px 10px 0 10px; margin-bottom:5px;${time_options_exp ? '' : 'display:none;'}"><legend class="link addme" onMouseUp="$P().collapse_fieldset($(this))"><i class="fa fa-minus-square-o">&nbsp;</i>Timing Options</legend>
 		     <div class="plugin_params_label">Extra Ticks: </div>
 		     <div class="plugin_params_content">
-		      <input type="text" id="fe_ee_ticks" size="50" value="${event.ticks || ''}" autocomplete="one-time-code" placeholder="e.g. 3PM|16:45|2020-01-01 09:30" spellcheck="false" onchange="$P().parseTicks()"/>
+		      ${this.render_event_ticks_input(event)}
 		      <span class="link addme" style="padding-left:4px; font-size:13px;" onMouseUp="$P().parseTicks()"> check &nbsp;&nbsp;|</span>
 		      <span class="link addme" style="padding-left:0px; font-size:13px;" onMouseUp="$P().ticks_add_now()">add timestamp</span>		   
 		      <div class="caption" style="margin-top:6px;">Optional extra minute ticks (extends regular schedule). Separate by comma or pipe.<br> Use HH:mm fromat for daily recurring or YYYY-MM-DD HH:mm for onetime ticks</div>
@@ -1981,8 +2019,7 @@ Class.subclass(Page.Base, "Page.Schedule", {
 		}
 
 		// Secret
-		let sph = event.secret_preview ? '[' + event.secret_preview + ']' : '';
-		html += get_form_table_row('Secret', `<textarea  style="width:620px; height:45px;resize:vertical;" id="fe_ee_secret" oninput="$P().set_event_secret(this.value)" placeholder="${sph}" spellcheck="false"></textarea>`);
+		html += get_form_table_row('Secret', this.render_event_secret_input(event));
 		html += get_form_table_caption("Specify KEY=VALUE pairs to set ENV variables. Some plugins require KEY prefix (e.g. DOCKER_ or SSH_ ) to pass it to job runtime.");
 		html += get_form_table_spacer();
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -283,6 +283,96 @@ module.exports = Class.create({
 			return false;
 		}
 
+		// Extra ticks are edited and consumed as a delimited string.  Reject
+		// objects here rather than relying on implicit toString() calls in the
+		// scheduler or UI.
+		if (("ticks" in event) && (typeof event.ticks != 'string')) {
+			this.doError('api', "Malformed event parameter: ticks (must be string)", callback);
+			return false;
+		}
+
+		// File entries originate in the event editor as complete name/content
+		// pairs.  Both fields remain required strings; there is no supported
+		// legacy representation with an omitted content or name field.
+		if ("files" in event) {
+			if (!Array.isArray(event.files)) {
+				this.doError('api', "Malformed event parameter: files (must be array)", callback);
+				return false;
+			}
+
+			for (var file_idx = 0; file_idx < event.files.length; file_idx++) {
+				var event_file = event.files[file_idx];
+				if (!event_file || (typeof event_file != 'object') || Array.isArray(event_file)) {
+					this.doError('api', "Malformed event file at index " + file_idx + " (must be object)", callback);
+					return false;
+				}
+
+				var file_proto = Object.getPrototypeOf(event_file);
+				if ((file_proto !== Object.prototype) && (file_proto !== null)) {
+					this.doError('api', "Malformed event file at index " + file_idx + " (must be plain object)", callback);
+					return false;
+				}
+
+				if ((typeof event_file.name != 'string') || (typeof event_file.content != 'string')) {
+					this.doError('api', "Malformed event file at index " + file_idx + " (name and content must be strings)", callback);
+					return false;
+				}
+			}
+		}
+
+		// workflow steps are persisted as part of the event, and several UI views
+		// render their metadata.  Validate the container and structural fields at
+		// the API boundary, while retaining the scalar argument values and boolean
+		// representations accepted by existing workflows.
+		if ("workflow" in event) {
+			if (!Array.isArray(event.workflow)) {
+				this.doError('api', "Malformed event parameter: workflow (must be array)", callback);
+				return false;
+			}
+
+			for (var workflow_idx = 0; workflow_idx < event.workflow.length; workflow_idx++) {
+				var workflow_step = event.workflow[workflow_idx];
+				if (!workflow_step || (typeof workflow_step != 'object') || Array.isArray(workflow_step)) {
+					this.doError('api', "Malformed workflow step at index " + workflow_idx + " (must be object)", callback);
+					return false;
+				}
+
+				var workflow_proto = Object.getPrototypeOf(workflow_step);
+				if ((workflow_proto !== Object.prototype) && (workflow_proto !== null)) {
+					this.doError('api', "Malformed workflow step at index " + workflow_idx + " (must be plain object)", callback);
+					return false;
+				}
+
+				if ((typeof workflow_step.id != 'string') || !workflow_step.id.match(RE_ALPHANUM)) {
+					this.doError('api', "Malformed workflow step id at index " + workflow_idx, callback);
+					return false;
+				}
+
+				if (("title" in workflow_step) && (typeof workflow_step.title != 'string')) {
+					this.doError('api', "Malformed workflow step title at index " + workflow_idx + " (must be string)", callback);
+					return false;
+				}
+
+				if ("arg" in workflow_step) {
+					var arg_type = typeof workflow_step.arg;
+					if ((workflow_step.arg !== null) && !arg_type.match(/^(string|number|boolean)$/)) {
+						this.doError('api', "Malformed workflow step arg at index " + workflow_idx + " (must be scalar)", callback);
+						return false;
+					}
+				}
+
+				for (var bool_idx = 0; bool_idx < 2; bool_idx++) {
+					var bool_key = bool_idx ? 'disabled' : 'wait';
+					if (!(bool_key in workflow_step)) continue;
+					var bool_value = workflow_step[bool_key];
+					if ((typeof bool_value != 'boolean') && (bool_value !== 0) && (bool_value !== 1)) {
+						this.doError('api', "Malformed workflow step " + bool_key + " at index " + workflow_idx + " (must be boolean or 0/1)", callback);
+						return false;
+					}
+				}
+			}
+		}
+
 		// timing (can be falsey, or object)
 		if (event.timing) {
 			if (typeof (event.timing) != 'object') {

--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -14,6 +14,31 @@ module.exports = Class.create({
 	// Events:
 	//
 
+	prepareEventSecret: function(event, markEncrypted) {
+		// Never trust encrypted material or its display-only preview from an API
+		// caller.  The preview must always be derived from the plaintext value
+		// handled in this request, otherwise it becomes persisted UI input.
+		delete event.secret;
+		delete event.secret_preview;
+
+		if (Object.prototype.hasOwnProperty.call(event, 'secret_value')) {
+			if (event.secret_value && (typeof event.secret_value === 'string')) {
+				event.secret_preview = Object.keys(dotenv.parse(event.secret_value)).join('|');
+				event.secret = this.encryptObject(event.secret_value);
+				if (markEncrypted) event.encrypted = true;
+			}
+			else if (markEncrypted) {
+				// On update, an explicitly empty value removes an existing secret.
+				// On create there is nothing to remove, so keep the fields absent.
+				event.secret = undefined;
+				event.secret_preview = undefined;
+			}
+		}
+
+		delete event.secret_value;
+		return event;
+	},
+
 	api_get_schedule: function (args, callback) {
 		// get list of scheduled events (with pagination)
 		var self = this;
@@ -123,13 +148,8 @@ module.exports = Class.create({
 			if (!event.timezone) event.timezone = self.tz;
 			if (!event.params) event.params = {};
 
-			// set secret
-			delete event.secret 
-			if(event.secret_value && typeof event.secret_value === 'string') {
-				event.secret_preview = Object.keys(dotenv.parse(event.secret_value)).join('|')
-				event.secret = self.encryptObject(event.secret_value)				
-			}
-			delete event.secret_value
+			// set secret and derive the display-only preview server-side
+			self.prepareEventSecret(event, false);
 
 			if (user.key) {
 				// API Key
@@ -221,21 +241,8 @@ module.exports = Class.create({
 
 				var prevState = event.enabled
 
-				// update secret
-                delete params.secret 
-				if(params.hasOwnProperty('secret_value')) { // if user edited secret in textbox
-					if(params.secret_value && typeof params.secret_value === 'string') { // if set a value
-						// size is a number of valid KV lines
-						params.secret_preview = Object.keys(dotenv.parse(params.secret_value)).join('|')
-						params.secret = self.encryptObject(params.secret_value)
-						params.encrypted = true 
-					}
-					else { // otherwise unset secret
-						params.secret = undefined
-						params.secret_preview = undefined
-					}
-				} 
-				delete params.secret_value
+				// update secret and derive the display-only preview server-side
+				self.prepareEventSecret(params, true);
 
 				// make sure that only timing or interval exist, not both
 				if(parseInt(params.interval) > 0) {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -297,8 +297,8 @@ module.exports = Class.create({
 	},
 
 	checkEventTicks: function checkTicks(tickString, cursor, tz) {
-		if(!tickString) return false
-		return tickString.toString().trim().replace(/\s+/g, ' ').split(/[\,\|]/).map(e => e.trim()).filter(e => e)
+		if(!tickString || typeof tickString !== 'string') return false
+		return tickString.trim().replace(/\s+/g, ' ').split(/[\,\|]/).map(e => e.trim()).filter(e => e)
 		.map(e => moment.tz(e.trim().length < 9 ? moment().tz(tz).format('YYYY-MM-DD') + ' ' + e : e, 'YYYY-MM-DD HH:mm A', tz).unix())
 		.includes(cursor)
 	},

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"license": "MIT",
 	"main": "lib/main.js",
 	"scripts": {
-		"test": "pixl-unit lib/test.js test/oidc-logout.test.js",
+		"test": "pixl-unit lib/test.js test/oidc-logout.test.js test/schedule-output-encoding.test.js",
 		"boot": "pixl-boot install",
 		"unboot": "pixl-boot uninstall"
 	},

--- a/test/schedule-output-encoding.test.js
+++ b/test/schedule-output-encoding.test.js
@@ -1,0 +1,610 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const he = require('he');
+const htmlParser = require('xss/lib/parser');
+
+const Api = require('../lib/api');
+const EventApi = require('../lib/api/event');
+const Scheduler = require('../lib/scheduler');
+
+const ROOT = path.resolve(__dirname, '..');
+const ATTACK = `x"' onmouseover=x data-pwn=x><svg>`;
+const FILE_ATTACK = `file"' onmouseover=x data-pwn=x><svg>`;
+const CONTENT_ATTACK = `first\n</textarea><img src=x onerror=x>\n"'`;
+
+const tests = [];
+
+function test(name, callback) {
+	const wrapped = function(testHandle) {
+		Promise.resolve().then(callback).then(function() {
+			testHandle.done();
+		}).catch(function(err) {
+			testHandle.ok(false, name + ': ' + (err && err.stack || err));
+			testHandle.done();
+		});
+	};
+	Object.defineProperty(wrapped, 'name', {
+		value: name.replace(/[^A-Za-z0-9]+/g, '_'),
+		configurable: true
+	});
+	tests.push(wrapped);
+}
+
+function encodeEntities(text) {
+	if (text == null) return '';
+	if (text && text.replace) {
+		text = text.replace(/\&/g, '&amp;');
+		text = text.replace(/</g, '&lt;');
+		text = text.replace(/>/g, '&gt;');
+	}
+	return text;
+}
+
+function encodeAttribEntities(text) {
+	text = encodeEntities(text);
+	if (text && text.replace) {
+		text = text.replace(/"/g, '&quot;');
+		text = text.replace(/'/g, '&apos;');
+	}
+	return text;
+}
+
+function escapeTextFieldValue(text) {
+	if ((text === undefined) || (text === null)) text = '';
+	return encodeAttribEntities(String(text));
+}
+
+function parseTags(html) {
+	const tags = [];
+	htmlParser.parseTag(html, function(sourcePosition, position, tag, raw, closing) {
+		if (!closing && tag) {
+			const attrSource = raw
+				.replace(/^<\s*[^\s/>]+/, '')
+				.replace(/\/?>$/, '');
+			const attrs = Object.create(null);
+			htmlParser.parseAttr(attrSource, function(name, value) {
+				attrs[name] = he.decode(value || '', { isAttributeValue: true });
+				return name + '="' + value + '"';
+			});
+			tags.push({ tag, attrs, raw });
+		}
+		return raw;
+	}, function(text) { return text; });
+	return tags;
+}
+
+function assertNoInjectedMarkup(html) {
+	const tags = parseTags(html);
+	assert.equal(tags.some((item) => item.tag === 'svg' || item.tag === 'img'), false, html);
+	assert.equal(tags.some((item) => Object.prototype.hasOwnProperty.call(item.attrs, 'onmouseover')), false, html);
+	assert.equal(tags.some((item) => Object.prototype.hasOwnProperty.call(item.attrs, 'data-pwn')), false, html);
+	return tags;
+}
+
+function loadPage(relativePath) {
+	let methods;
+	const context = {
+		console,
+		Page: { Base: {} },
+		Class: {
+			subclass: function(base, name, definition) { methods = definition; }
+		},
+		encode_entities: encodeEntities,
+		encode_attrib_entities: encodeAttribEntities,
+		escape_text_field_value: escapeTextFieldValue
+	};
+	vm.runInNewContext(fs.readFileSync(path.join(ROOT, relativePath), 'utf8'), context, {
+		filename: relativePath
+	});
+	return { methods, context };
+}
+
+function getTag(tags, name, predicate) {
+	const tag = tags.find((item) => item.tag === name && (!predicate || predicate(item)));
+	assert.ok(tag, 'Expected <' + name + '> in rendered HTML');
+	return tag;
+}
+
+function makeSchedulePage() {
+	return loadPage('htdocs/js/pages/Schedule.class.js');
+}
+
+function renderScheduleView(mode, ticks, inactive) {
+	const loaded = makeSchedulePage();
+	const methods = loaded.methods;
+	const context = loaded.context;
+	const event = {
+		id: 'safe_event', title: 'Safe Event', enabled: 1,
+		category: 'cat', plugin: 'plug', target: 'group',
+		modified: 1, timing: null, ticks: ticks
+	};
+	if (inactive) event.start_time = Date.now() + 3600000;
+
+	let rendered = '';
+	context.get_inner_window_size = () => ({ width: 1200, height: 800 });
+	context.graphlib = {
+		Graph: function() { this.setNode = function() {}; this.setEdge = function() {}; },
+		alg: { findCycles: () => [] }
+	};
+	context.find_object = (items, criteria) => (items || []).find((item) => {
+		return Object.keys(criteria).every((key) => item[key] == criteria[key]);
+	}) || null;
+	context.copy_object = (object) => Object.assign({}, object);
+	context.render_menu_options = () => '';
+	context.summarize_event_timing = () => 'On demand';
+	context.summarize_event_timing_short = () => 'On demand';
+	context.summarize_event_interval = () => 'Interval';
+	context.summarize_repeat_interval = () => 'Repeat';
+	context.get_text_from_seconds = () => 'now';
+	context.moment = { tz: () => ({ format: () => 'time' }) };
+	context.setTimeout = () => {};
+	context.$ = () => ({ keypress: () => {} });
+	context.app = {
+		schedule: [event],
+		categories: [{ id: 'cat', title: 'Category', enabled: 1 }],
+		plugins: [{ id: 'plug', title: 'Plugin', enabled: 1 }],
+		server_groups: [{ id: 'group', title: 'Group' }],
+		filter: { schedule: {} },
+		state: { jobCodes: {} },
+		activeJobs: {},
+		tz: 'UTC', hh24: true,
+		getPref: (key) => key === 'event_view' ? mode : '',
+		hasPrivilege: () => false,
+		isAdmin: () => false,
+		setWindowTitle: () => {}
+	};
+
+	const page = {
+		alt_sort: 1,
+		get_safe_text_value: methods.get_safe_text_value,
+		div: {
+			removeClass: () => {},
+			html: (html) => { rendered = html; }
+		},
+		render_target_menu_options: () => '',
+		getNiceEvent: () => 'Safe Event',
+		getNiceCategory: () => 'Category',
+		getNicePlugin: () => 'Plugin',
+		getNiceGroup: () => 'Group',
+		getBasicTable2: function(events, cols, type, rowRenderer) {
+			return '<table>' + events.map((item, idx) => {
+				const row = rowRenderer(item, idx);
+				return row ? '<tr><td>' + row[5] + '</td></tr>' : '';
+			}).join('') + '</table>';
+		},
+		update_job_last_runs: () => {}
+	};
+
+	methods.gosub_events.call(page, {});
+	return rendered;
+}
+
+function makeApiValidationHarness() {
+	const api = Object.create(Api.prototype);
+	api.validateOptionalParams = () => true;
+	api.doError = function(code, description, callback) {
+		api.lastError = description;
+		if (callback) callback({ code: 1, description });
+	};
+	return api;
+}
+
+function makeEventApiHarness() {
+	const api = Object.create(EventApi.prototype);
+	api.requiremanager = () => true;
+	api.requireParams = () => true;
+	api.requireValidEventData = () => true;
+	api.requireValidUser = () => true;
+	api.requirePrivilege = () => true;
+	api.requireCategoryPrivilege = () => true;
+	api.requireGroupPrivilege = () => true;
+	api.validateUnique = async () => 0;
+	api.loadSession = (args, callback) => callback(null, {}, { username: 'admin' });
+	api.getUniqueID = () => 'new_event';
+	api.encryptObject = (value) => ({ encrypted: value });
+	api.getClientInfo = () => ({});
+	api.logDebug = () => {};
+	api.logTransaction = () => {};
+	api.logActivity = () => {};
+	api.updateClientData = () => {};
+	api.authSocketEmit = () => {};
+	api.getAllActiveJobs = () => ({});
+	api.eventQueue = {};
+	api.state = { cursors: {} };
+	api.tz = 'UTC';
+	return api;
+}
+
+function createEvent(api, params) {
+	return new Promise((resolve, reject) => {
+		api.storage = {
+			listFind: (path, criteria, callback) => callback(null, { id: 'general' }),
+			listUnshift: (path, event, callback) => {
+				api.savedEvent = Object.assign({}, event);
+				callback(null);
+			}
+		};
+		api.api_create_event({ params }, (response) => {
+			if (response.code) reject(new Error(response.description || 'create failed'));
+			else resolve(response);
+		});
+	});
+}
+
+function updateEvent(api, params) {
+	return new Promise((resolve, reject) => {
+		const stored = {
+			id: params.id, title: params.title, category: 'general', target: 'group',
+			enabled: 1, secret_preview: 'EXISTING'
+		};
+		api.storage = {
+			listFind: (path, criteria, callback) => {
+				if (path === 'global/schedule') callback(null, stored);
+				else callback(null, { id: 'general' });
+			},
+			listFindUpdate: (path, criteria, patch, callback) => {
+				api.savedPatch = Object.assign({}, patch);
+				callback(null);
+			}
+		};
+		api.api_update_event({ params }, (response) => {
+			if (response.code) reject(new Error(response.description || 'update failed'));
+			else resolve(response);
+		});
+	});
+}
+
+test('Workflow list, options and edit dialog keep hostile metadata inside its original DOM nodes', () => {
+	const loaded = makeSchedulePage();
+	const methods = loaded.methods;
+	const context = loaded.context;
+	const sink = { innerHTML: '' };
+	context.document = { getElementById: () => sink };
+	context.$ = () => ({ val: () => '1' });
+	context.app = {
+		schedule: [{ id: ATTACK, title: ATTACK }],
+		confirm: function() {
+			context.dialogHtml = Array.from(arguments).find((value) => typeof value === 'string' && value.indexOf('<table>') >= 0);
+		},
+		clearError: () => {}
+	};
+	context.get_form_table_row = (label, value) => value;
+	context.get_form_table_spacer = () => '';
+	context.Dialog = { hide: () => {} };
+
+	const page = {
+		event: { workflow: [{ id: ATTACK, title: ATTACK, arg: ATTACK, disabled: false }] },
+		get_safe_text_value: methods.get_safe_text_value,
+		render_wf_event_options: methods.render_wf_event_options,
+		render_wf_event_list: methods.render_wf_event_list
+	};
+	methods.render_wf_event_list.call(page);
+	let tags = assertNoInjectedMarkup(sink.innerHTML);
+	const anchor = getTag(tags, 'a');
+	assert.equal(anchor.attrs.href, '#Schedule?sub=edit_event&id=' + encodeURIComponent(ATTACK));
+	assert.equal((sink.innerHTML.match(/<a\b/g) || []).length, 1);
+	assert.equal((sink.innerHTML.match(/<tr\b/g) || []).length, 2);
+
+	const options = methods.render_wf_event_options.call(page, page.event.workflow, ATTACK);
+	tags = assertNoInjectedMarkup(options);
+	const option = getTag(tags, 'option');
+	assert.equal(option.attrs.value, ATTACK);
+	assert.equal(he.decode(options.match(/>([\s\S]*)<\/option>/)[1]), ATTACK);
+	assert.equal((options.match(/<option\b/g) || []).length, 1);
+
+	methods.wf_event_edit.call(page, 0);
+	tags = assertNoInjectedMarkup(context.dialogHtml);
+	const input = getTag(tags, 'input', (item) => item.attrs.id === 'fe_ee_pp_wf_evt_arg');
+	assert.equal(input.attrs.value, ATTACK);
+	assert.equal(getTag(tags, 'option').attrs.value, ATTACK);
+});
+
+test('Event file editor preserves hostile filename and textarea content without creating attributes or nodes', () => {
+	const loaded = makeSchedulePage();
+	const methods = loaded.methods;
+	const context = loaded.context;
+	context.get_form_table_row = (label, value) => value;
+	context.get_form_table_spacer = () => '';
+	context.setTimeout = () => {};
+	context.app = {
+		confirm: function() {
+			context.dialogHtml = Array.from(arguments).find((value) => typeof value === 'string' && value.indexOf('<table>') >= 0);
+		},
+		clearError: () => {}
+	};
+	context.Dialog = { hide: () => {} };
+	const page = {
+		event: { files: [{ name: FILE_ATTACK, content: CONTENT_ATTACK }] },
+		get_safe_text_value: methods.get_safe_text_value,
+		setFileEditor: () => {}, render_file_list: () => {}
+	};
+
+	methods.file_edit.call(page, 0);
+	const tags = assertNoInjectedMarkup(context.dialogHtml);
+	const input = getTag(tags, 'input', (item) => item.attrs.id === 'fe_ee_pp_file_name');
+	assert.equal(input.attrs.value, FILE_ATTACK);
+	assert.equal((context.dialogHtml.match(/<textarea\b/g) || []).length, 1);
+	const textareaText = context.dialogHtml.match(/<textarea\b[^>]*>([\s\S]*?)<\/textarea>/)[1];
+	assert.equal(he.decode(textareaText), CONTENT_ATTACK);
+});
+
+test('History error and warning tooltips encode both quote types after ANSI removal', () => {
+	const loaded = loadPage('htdocs/js/pages/History.class.js');
+	const methods = loaded.methods;
+	for (const code of [1, 255]) {
+		const html = methods.render_job_status({ code, description: '\u001b[31m' + ATTACK + '\u001b[0m' });
+		const tags = assertNoInjectedMarkup(html);
+		const outer = getTag(tags, 'span', (item) => item.attrs.title !== undefined);
+		assert.equal(outer.attrs.title, ATTACK);
+	}
+	assert.match(methods.receive_history.toString(), /render_job_status\(job\)/);
+	assert.match(methods.receive_event_history.toString(), /render_job_status\(job\)/);
+});
+
+test('On-demand and timed extra-tick summaries encode hostile tooltip text', () => {
+	const source = fs.readFileSync(path.join(ROOT, 'htdocs/js/app.js'), 'utf8');
+	const start = source.indexOf('function summarize_event_timing(');
+	const end = source.indexOf('\nfunction detect_num_interval', start);
+	assert.ok(start >= 0 && end > start);
+	const context = {
+		encode_attrib_entities: encodeAttribEntities,
+		app: { tz: 'UTC', hh24: true }
+	};
+	vm.runInNewContext(source.slice(start, end), context, { filename: 'summarize_event_timing.js' });
+
+	for (const timing of [null, {}]) {
+		const html = context.summarize_event_timing(timing, null, ATTACK);
+		const tags = assertNoInjectedMarkup(html);
+		assert.equal(getTag(tags, 'span').attrs.title, 'Extra Ticks: ' + ATTACK);
+	}
+	assert.equal(context.summarize_event_timing(null, null, { toString: null }), 'On demand');
+});
+
+test('Inactive and grid schedule tooltips encode extra ticks at their final attribute sinks', () => {
+	const inactiveHtml = renderScheduleView('details', ATTACK, true);
+	let tags = assertNoInjectedMarkup(inactiveHtml);
+	assert.ok(tags.some((item) => item.tag === 'span' && item.attrs.title === 'Extra Ticks: ' + ATTACK));
+
+	const gridHtml = renderScheduleView('grid', ATTACK, false);
+	tags = assertNoInjectedMarkup(gridHtml);
+	assert.ok(tags.some((item) => item.tag === 'span' && item.attrs.title === 'On demand<br><br>Extra ticks: ' + ATTACK));
+
+	const corruptHtml = renderScheduleView('grid', { toString: null }, false);
+	tags = assertNoInjectedMarkup(corruptHtml);
+	assert.equal(tags.some((item) => item.attrs.title && item.attrs.title.includes('Extra ticks:')), false);
+});
+
+test('Extra-tick value and secret-preview placeholder round-trip without new DOM structure', () => {
+	const methods = makeSchedulePage().methods;
+	let html = methods.render_event_ticks_input({ ticks: ATTACK });
+	let tags = assertNoInjectedMarkup(html);
+	assert.equal(tags.length, 1);
+	assert.equal(getTag(tags, 'input').attrs.value, ATTACK);
+
+	html = methods.render_event_secret_input({ secret_preview: ATTACK });
+	tags = assertNoInjectedMarkup(html);
+	assert.equal(tags.length, 1);
+	assert.equal(getTag(tags, 'textarea').attrs.placeholder, '[' + ATTACK + ']');
+});
+
+test('Workflow API validation accepts compatible values and rejects malformed structure', () => {
+	let api = makeApiValidationHarness();
+	const workflow = [
+		{ id: 'step_one', title: ATTACK, arg: ATTACK, wait: true, disabled: 0 },
+		{ id: 'step2', arg: 42, wait: 1, disabled: false },
+		{ id: 'step3', arg: null, wait: false, disabled: 1 }
+	];
+	assert.equal(api.requireValidEventData({ workflow }, () => {}), true);
+	assert.equal(workflow[0].arg, ATTACK);
+	assert.equal(workflow[1].arg, 42);
+
+	const invalid = [
+		{ workflow: {} },
+		{ workflow: { length: 0 } },
+		{ workflow: [[]] },
+		{ workflow: [new Date(0)] },
+		{ workflow: [{ id: ATTACK }] },
+		{ workflow: [{ id: 'step', wait: 2 }] },
+		{ workflow: [{ id: 'step', disabled: '0' }] },
+		{ workflow: [{ id: 'step', arg: {} }] }
+	];
+	for (const event of invalid) {
+		api = makeApiValidationHarness();
+		assert.equal(api.requireValidEventData(event, () => {}), false, JSON.stringify(event));
+		assert.ok(api.lastError);
+	}
+});
+
+test('Event API rejects non-string ticks and malformed file entries', () => {
+	let api = makeApiValidationHarness();
+	const valid = {
+		ticks: ATTACK,
+		files: [{ name: FILE_ATTACK, content: CONTENT_ATTACK }]
+	};
+	assert.equal(api.requireValidEventData(valid, () => {}), true);
+	assert.equal(valid.ticks, ATTACK);
+	assert.equal(valid.files[0].name, FILE_ATTACK);
+	assert.equal(valid.files[0].content, CONTENT_ATTACK);
+
+	const invalid = [
+		{ ticks: { toString: null } },
+		{ files: 'not-an-array' },
+		{ files: [{ name: {}, content: 'safe' }] },
+		{ files: [{ name: 'safe', content: {} }] },
+		{ files: [{ name: 'legacy-without-content' }] },
+		{ files: [new Date(0)] }
+	];
+	for (const event of invalid) {
+		api = makeApiValidationHarness();
+		assert.equal(api.requireValidEventData(event, () => {}), false);
+		assert.ok(api.lastError);
+	}
+});
+
+test('Renderers fail safe for malformed persisted ticks and file values', () => {
+	const loaded = makeSchedulePage();
+	const methods = loaded.methods;
+	const context = loaded.context;
+	const malformed = { toString: null };
+
+	let html = methods.render_event_ticks_input({ ticks: malformed });
+	let tags = assertNoInjectedMarkup(html);
+	assert.equal(getTag(tags, 'input').attrs.value, '');
+
+	context.get_form_table_row = (label, value) => value;
+	context.get_form_table_spacer = () => '';
+	context.setTimeout = () => {};
+	context.app = {
+		confirm: function() {
+			context.dialogHtml = Array.from(arguments).find((value) => typeof value === 'string' && value.indexOf('<table>') >= 0);
+		},
+		clearError: () => {}
+	};
+	context.Dialog = { hide: () => {} };
+	const page = {
+		event: { files: [{ name: malformed, content: malformed }] },
+		get_safe_text_value: methods.get_safe_text_value,
+		setFileEditor: () => {}, render_file_list: () => {}
+	};
+	methods.file_edit.call(page, 0);
+	tags = assertNoInjectedMarkup(context.dialogHtml);
+	assert.equal(getTag(tags, 'input').attrs.value, '');
+	const textareaText = context.dialogHtml.match(/<textarea\b[^>]*>([\s\S]*?)<\/textarea>/)[1];
+	assert.equal(textareaText, '');
+
+	const fileList = { innerHTML: 'not-cleared' };
+	context.document = { getElementById: () => fileList };
+	page.event.files = 'malformed-list';
+	methods.render_file_list.call(page);
+	assert.equal(fileList.innerHTML, '');
+
+	page.event.files = [{ name: malformed, content: malformed }];
+	methods.render_file_list.call(page);
+	assertNoInjectedMarkup(fileList.innerHTML);
+
+	const scheduler = Object.create(Scheduler.prototype);
+	assert.equal(scheduler.checkEventTicks(malformed, 0, 'UTC'), false);
+});
+
+test('Home worker onmessage ignores malformed legacy ticks without aborting prediction', () => {
+	let posted;
+	const context = {
+		console,
+		Date,
+		Intl,
+		postMessage: (events) => { posted = events; }
+	};
+	vm.runInNewContext(fs.readFileSync(path.join(ROOT, 'htdocs/js/home-worker.js'), 'utf8'), context, {
+		filename: 'htdocs/js/home-worker.js'
+	});
+
+	context.onmessage({
+		data: {
+			default_tz: 'UTC',
+			schedule: [{
+				id: 'legacy_ticks', enabled: 1, catch_up: 0,
+				timezone: 'UTC', ticks: { toString: null }, timing: false
+			}],
+			state: { cursors: {} },
+			categories: [],
+			plugins: []
+		}
+	});
+
+	assert.ok(Array.isArray(posted));
+	assert.equal(posted.length, 0);
+});
+
+test('File Add Save callback normalizes non-arrays and tolerates null or malformed legacy entries', () => {
+	const loaded = makeSchedulePage();
+	const methods = loaded.methods;
+	const context = loaded.context;
+	let dialogCallback;
+	let nextName = 'safe.txt';
+	let nextContent = 'safe content';
+	let renderCount = 0;
+	let errors = 0;
+
+	context.get_form_table_row = (label, value) => value;
+	context.get_form_table_spacer = () => '';
+	context.setTimeout = () => {};
+	context.$ = (selector) => ({
+		val: () => selector === '#fe_ee_pp_file_name' ? nextName : nextContent
+	});
+	context.Dialog = { hide: () => {} };
+	context.app = {
+		confirm: (html, title, button, callback) => { dialogCallback = callback; },
+		clearError: () => {},
+		showMessage: () => { errors++; }
+	};
+
+	let page = {
+		event: { files: { malformed: true } },
+		get_safe_text_value: methods.get_safe_text_value,
+		setFileEditor: () => {},
+		render_file_list: () => { renderCount++; }
+	};
+	methods.file_add.call(page);
+	assert.ok(Array.isArray(page.event.files));
+	dialogCallback(true);
+	assert.equal(page.event.files.length, 1);
+	assert.equal(page.event.files[0].name, nextName);
+	assert.equal(page.event.files[0].content, nextContent);
+
+	nextName = 'second.txt';
+	nextContent = 'second content';
+	page = {
+		event: { files: [null, { name: { toString: null }, content: '' }] },
+		get_safe_text_value: methods.get_safe_text_value,
+		setFileEditor: () => {},
+		render_file_list: () => { renderCount++; }
+	};
+	methods.file_add.call(page);
+	dialogCallback(true);
+	assert.equal(page.event.files.length, 3);
+	assert.equal(page.event.files[2].name, nextName);
+	assert.equal(page.event.files[2].content, nextContent);
+	assert.equal(errors, 0);
+	assert.equal(renderCount, 2);
+});
+
+test('Create and update APIs discard caller-controlled secret previews', async () => {
+	let api = makeEventApiHarness();
+	await createEvent(api, {
+		title: 'Create', enabled: 1, category: 'general', target: 'group', plugin: 'testplug',
+		secret_preview: ATTACK
+	});
+	assert.equal(Object.prototype.hasOwnProperty.call(api.savedEvent, 'secret_preview'), false);
+	assert.equal(Object.prototype.hasOwnProperty.call(api.savedEvent, 'secret'), false);
+
+	api = makeEventApiHarness();
+	await updateEvent(api, { id: 'existing', title: 'Existing', secret_preview: ATTACK });
+	assert.equal(Object.prototype.hasOwnProperty.call(api.savedPatch, 'secret_preview'), false);
+	assert.equal(Object.prototype.hasOwnProperty.call(api.savedPatch, 'secret'), false);
+
+	const derived = { secret_preview: ATTACK, secret_value: 'FIRST=1\nSECOND=2' };
+	api.prepareEventSecret(derived, true);
+	assert.equal(derived.secret_preview, 'FIRST|SECOND');
+	assert.deepEqual(derived.secret, { encrypted: 'FIRST=1\nSECOND=2' });
+	assert.equal(derived.encrypted, true);
+	assert.equal(Object.prototype.hasOwnProperty.call(derived, 'secret_value'), false);
+
+	const emptyCreate = { secret_preview: ATTACK, secret_value: '' };
+	api.prepareEventSecret(emptyCreate, false);
+	assert.equal(Object.prototype.hasOwnProperty.call(emptyCreate, 'secret_preview'), false);
+	assert.equal(Object.prototype.hasOwnProperty.call(emptyCreate, 'secret'), false);
+
+	const emptyUpdate = { secret_preview: ATTACK, secret_value: '' };
+	api.prepareEventSecret(emptyUpdate, true);
+	assert.equal(Object.prototype.hasOwnProperty.call(emptyUpdate, 'secret_preview'), true);
+	assert.equal(emptyUpdate.secret_preview, undefined);
+	assert.equal(emptyUpdate.secret, undefined);
+});
+
+module.exports = {
+	setUp: function(callback) { callback(); },
+	tests,
+	tearDown: function(callback) { callback(); }
+};


### PR DESCRIPTION
## Problem

Persisted schedule data reached several HTML text, attribute, URL, and form contexts without context-appropriate encoding.  This affected workflow rows, Extra Ticks tooltips, history tooltips, event files, and secret previews.  Malformed legacy `ticks` or `files` values could also crash the scheduler worker or event editor.

## Change

- Encode URL components, text nodes, and quoted attributes at their actual output boundaries.
- Keep workflow `arg` and `wait`/`disabled` compatibility, including scalar arguments and numeric `0`/`1` flags.
- Validate new `ticks`, `files`, and workflow data as plain, correctly typed structures.
- Make existing renderers and the schedule worker fail safely on malformed legacy records.
- Derive secret previews on the server instead of trusting a stored preview supplied by the caller.

## Validation

- DOM/string regressions cover quote-breaking payloads, event files, workflow links and option values, tooltips, secret previews, and URL round trips.
- A VM test runs the real schedule worker `onmessage`; dialog tests execute the real file-editor Save callback with malformed legacy data.
- Full `npm test`: 104/104 tests, 375 assertions.
- Focused suite: 12/12; `node --check` and `git diff --check`: pass.

The issues and initial patches were proposed by a Codex Ultra security review. This consolidated version was manually re-analyzed, uses context-specific output handling, adds real regression coverage, and is submitted for maintainer review in line with our prior discussion.
