### PR TITLE
fix: encode job UI output safely

### DIFF
--- a/bin/workflow.js
+++ b/bin/workflow.js
@@ -3,9 +3,9 @@
 // const rl = require('readline').createInterface({ input: process.stdin });
 const PixlRequest = require('pixl-request');
 const request = new PixlRequest();
-const he = require('he');
 const {EOL} = require('os')
 const JSONStream = require('pixl-json-stream');
+const { buildWorkflowReportTable } = require('../lib/workflow_report');
 
 let bullet = '>' // '⬤'
 
@@ -409,40 +409,7 @@ stream.on('json', function (job) {
 			perf[perf_key] = jobStatus[key].elapsed || 0
 		})
 
-		function getNiceTitle(job, id) {
-			if(!job) return ''
-			let title = '<b> ' + job.seq + ' :: ' + (job.title || 'Unknown') + '</b>'
-			// if(id) title = `${id} :: ${title} `
-			// if(job.arg) title = title + ' :: ' + job.arg
-			if(job.arg) title = title + '@' + job.arg
-			return he.encode(title)
-		}
-
-		function getNiceStatus(job) {
-			return job.code ? (job.code == 255 ? '<span style="color:orange"><b>⚠️</b></span>' : '<span style="color:red"><b>✗</b></span>') : '<span style="color:green"><b>✔</b></span>'
-		}
-
-		var table = {
-			title: "Workflow Events",
-			header: [
-				"#", "title", "arg", "job", "started at", "elapsed", "status", "view log",  "description"
-			],
-			rows: Object.keys(jobStatus).map(key => [
-				jobStatus[key].seq,
-				
-				`<span style="${jobStatus[key].code % 255 ? 'color:red' : ''}"><b>${he.encode(jobStatus[key].title) || '[Unknown]'}</b></span>`,  //title
-				(jobStatus[key].arg ? he.encode(jobStatus[key].arg) : ''),  // arg			
-				key === jobStatus[key].event ? '' : `<a href="#JobDetails?id=${key}" target="_blank">${key}</a>`,  // joblink
-				jobStatus[key].start,
-				niceInterval(jobStatus[key].elapsed),
-				getNiceStatus(jobStatus[key]), // status
-				key === jobStatus[key].event ? '' : `<i id="view_${key}" onclick="this.className = this.className == 'fa fa-eye' ? 'fa fa-eye-slash' : 'fa fa-eye'; $P().get_log_to_grid(filterXSS(\`${getNiceTitle(jobStatus[key], key)}\`), '${key}')" style="cursor:pointer" class="fa fa-eye"></i>`,
-				//jobStatus[key].code ? `${he.encode(jobStatus[key].description)}`.substring(0,120) : ''
-				`${he.encode(jobStatus[key].description)}`.substring(0, 120)
-
-			]),
-			caption: ""
-		};
+		var table = buildWorkflowReportTable(jobStatus, niceInterval);
 
 		stream.write({ perf: perf, table: table })
 

--- a/htdocs/js/pages/Base.class.js
+++ b/htdocs/js/pages/Base.class.js
@@ -173,14 +173,39 @@ Class.subclass(Page, "Page.Base", {
 		return html;
 	},
 
+	toWellFormedString: function(value) {
+		// encodeURIComponent throws on lone UTF-16 surrogates, so normalize them first
+		var input = (value == null) ? '' : String(value);
+		if (input.toWellFormed) return input.toWellFormed();
+
+		var output = '';
+		for (var idx = 0; idx < input.length; idx++) {
+			var code = input.charCodeAt(idx);
+			if ((code >= 0xD800) && (code <= 0xDBFF)) {
+				var next = input.charCodeAt(idx + 1);
+				if ((next >= 0xDC00) && (next <= 0xDFFF)) {
+					output += input.charAt(idx) + input.charAt(++idx);
+				}
+				else output += '\uFFFD';
+			}
+			else if ((code >= 0xDC00) && (code <= 0xDFFF)) output += '\uFFFD';
+			else output += input.charAt(idx);
+		}
+		return output;
+	},
+
+	encodeQueryComponent: function(value) {
+		return encodeURIComponent(this.toWellFormedString(value));
+	},
+
 	getNiceArgument: function(arg, maxWidth, context) {
 		context = context || {}
 		let nice_arg = encode_entities(`${arg || ''}`)
 		if(nice_arg.length > maxWidth) nice_arg = nice_arg.substring(0,maxWidth-3) + "..."
 		let href = '#History?sub=error_history'
-		if(context.id) href += ('&id=' + context.id)
+		if(context.id) href += ('&id=' + this.encodeQueryComponent(context.id))
 		if(context.error) href += '&error=1'
-		return `<a href="${href}&max=25&arg=${encodeURIComponent(arg)}">${nice_arg}</a>`
+		return `<a href="${href}&max=25&arg=${this.encodeQueryComponent(arg)}">${nice_arg}</a>`
 	},
 
 	setGroupVisible: function (group, visible) {

--- a/htdocs/js/pages/Home.class.js
+++ b/htdocs/js/pages/Home.class.js
@@ -155,6 +155,34 @@ Class.subclass( Page.Base, "Page.Home", {
 		return true;
 	},
 	
+	get_failed_job_badge: function(stats, ui) {
+		stats = stats || {};
+		ui = ui || {};
+
+		var failedCount = Math.max(0, parseInt(stats.jobs_failed, 10) || 0);
+		var completedCount = Math.max(0, parseInt(stats.jobs_completed, 10) || 0);
+		var errorRate = parseFloat(ui.err_rate) || 0.03;
+		var badgeClass = completedCount && ((failedCount / completedCount) > errorRate) ? 'red2' : 'gray';
+		var errorEntries = Object.entries(stats.errorLog || {}).map(function(entry) {
+			return [String(entry[0]), Math.max(0, parseInt(entry[1], 10) || 0)];
+		});
+		var failedRuns = errorEntries.reduce(function(total, entry) { return total + entry[1]; }, 0);
+		var tooltip = errorEntries.sort(function(left, right) { return right[1] - left[1]; }).slice(0, 21)
+			.map(function(entry) {
+				// Event titles are text, while the count markup below is deliberately trusted.
+				return encode_entities(entry[0]) + ':\t<b>' + entry[1] + '</b>';
+			}).join('\n');
+
+		if (failedCount > failedRuns) {
+			tooltip = '<u>Failed to start: <b>' + (failedCount - failedRuns) + '</b></u> \n' + tooltip;
+		}
+
+		// Encode the complete, mixed-content tooltip for its surrounding HTML attribute.
+		var titleAttribute = escape_text_field_value(tooltip);
+		return '<a style="cursor:pointer;" href="#History?sub=error_history&error=1&max=' + failedCount +
+			'" title="' + titleAttribute + '" class="color_label ' + badgeClass + '">' + failedCount + '</a>&nbsp;';
+	},
+
 	refresh_header_stats: function () {
 		// refresh daemons stats in header fieldset
 		var html = '';
@@ -185,14 +213,7 @@ Class.subclass( Page.Base, "Page.Home", {
 		$(document).tooltip("disable")
 		$(document).tooltip("enable")
 
-		let errBg = stats.jobs_completed > 0 && (stats.jobs_failed || 0)/stats.jobs_completed > (parseFloat(ui.err_rate) || 0.03) ? 'red2' : 'gray'
-		let errorLog = Object.entries(stats.errorLog || {})
-		let runs_failed = Object.values(stats.errorLog || {}).reduce((a,b)=>a+b, 0)
-		let errTitle = errorLog.slice(0,21).sort((a,b)=> a[1] < b[1] ? 1 : -1).map(e=>`${e[0]}:\t<b>${e[1]}</b>`).join("\n")
-		if(stats.jobs_failed > runs_failed ) errTitle  = `<u>Failed to start: <b>${stats.jobs_failed - runs_failed }</b></u> \n` + errTitle 
-    // xhtml
-
-	let failed_badge = `<span style="cursor:pointer;" onclick='Nav.go("History?sub=error_history&error=1&max=${stats.jobs_failed || 0}")' title="${errTitle}" class="color_label ${errBg}">${stats.jobs_failed || 0}</span>&nbsp;`
+	let failed_badge = this.get_failed_job_badge(stats, ui)
 	
 	status_bar = [
 		{name: "EVENTS", value:  active_events.length},

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -16,6 +16,8 @@ Class.subclass(Page.Base, "Page.JobDetails", {
 		// var html = '';
 		// this.div.html( html );
 		this.charts = {};
+		this.workflow_log_generation = 0;
+		this.workflow_log_requests = new Map();
 	},
 
 	live_log_is_up: false,
@@ -472,6 +474,7 @@ Class.subclass(Page.Base, "Page.JobDetails", {
     }
 
 		this.div.html(html);
+		this.bind_workflow_log_controls();
 
 		// arch perf chart
 		var suffix = ' sec';
@@ -739,28 +742,203 @@ Class.subclass(Page.Base, "Page.JobDetails", {
 
 	},
 
-	unsetLogIcon(id) {
-		let el = document.getElementById('view_' + id)
-		if(el) el.className = 'fa fa-eye'
+	bind_workflow_log_controls: function(root) {
+		this.unbind_workflow_log_controls();
+		root = root || (this.div && this.div[0]);
+		if (!root || !root.addEventListener) return;
+
+		var self = this;
+		this.workflow_log_root = root;
+		this.workflow_log_click_handler = function(event) {
+			var target = event.target;
+			var control = target && target.closest ? target.closest('.workflow-log-toggle') : null;
+			if (!control || !root.contains(control)) return;
+
+			event.preventDefault();
+			var id = control.getAttribute('data-job-id') || '';
+			var title = control.getAttribute('data-log-title') || id;
+			if (id) self.get_log_to_grid(title, id);
+		};
+		root.addEventListener('click', this.workflow_log_click_handler);
+	},
+
+	invalidate_workflow_log_requests: function() {
+		var requests = this.workflow_log_requests;
+		this.workflow_log_requests = new Map();
+		this.workflow_log_generation = (this.workflow_log_generation || 0) + 1;
+
+		if (!requests || !requests.forEach) return;
+		requests.forEach(function(record) {
+			record.cancelled = true;
+			if (record.request && record.request.abort) {
+				try { record.request.abort(); }
+				catch (err) { /* request is already complete */ }
+			}
+		});
+	},
+
+	unbind_workflow_log_controls: function() {
+		if (this.workflow_log_root && this.workflow_log_click_handler) {
+			this.workflow_log_root.removeEventListener('click', this.workflow_log_click_handler);
+		}
+		this.invalidate_workflow_log_requests();
+		delete this.workflow_log_root;
+		delete this.workflow_log_click_handler;
+	},
+
+	is_current_workflow_log_request: function(record) {
+		return !!record && !record.cancelled &&
+			(record.generation === this.workflow_log_generation) &&
+			(record.root === this.workflow_log_root) &&
+			this.workflow_log_requests &&
+			(this.workflow_log_requests.get(record.id) === record);
+	},
+
+	set_workflow_log_icon: function(id, isOpen, root) {
+		var normalizedId = this.toWellFormedString(id);
+		root = root || this.workflow_log_root || document;
+		var controls = root.getElementsByClassName ? root.getElementsByClassName('workflow-log-toggle') : [];
+		for (var idx = 0; idx < controls.length; idx++) {
+			var control = controls[idx];
+			if (control.getAttribute('data-job-id') !== normalizedId) continue;
+			var icon = control.querySelector('.workflow-log-icon');
+			if (icon) icon.className = 'fa ' + (isOpen ? 'fa-eye-slash' : 'fa-eye') + ' workflow-log-icon';
+			control.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+		}
+	},
+
+	unsetLogIcon: function(id, root) {
+		this.set_workflow_log_icon(id, false, root);
+	},
+
+	get_workflow_log_grid: function(root) {
+		root = root || this.workflow_log_root || document;
+		if (root.id === 'log_grid') return root;
+		return root.querySelector ? root.querySelector('#log_grid') : null;
+	},
+
+	get_workflow_log_item: function(id, root) {
+		var grid = this.get_workflow_log_grid(root);
+		if (!grid) return null;
+		var normalizedId = this.toWellFormedString(id);
+		var items = grid.getElementsByClassName('workflow-log-preview');
+		for (var idx = 0; idx < items.length; idx++) {
+			if (items[idx].getAttribute('data-job-id') === normalizedId) return items[idx];
+		}
+		return null;
+	},
+
+	sanitize_ansi_log_html: function(logText) {
+		var ansiUp = new AnsiUp();
+		ansiUp.escape_html = true;
+		var ansiHtml = ansiUp.ansi_to_html(this.toWellFormedString(logText));
+
+		// Keep only markup emitted by ansi_up, while retaining terminal colors and safe links.
+		return filterXSS(ansiHtml, {
+			whiteList: { span: ['style'], a: ['href'] },
+			css: { whiteList: {
+				color: true,
+				'background-color': true,
+				'font-weight': true,
+				'font-style': true,
+				'text-decoration': true
+			} }
+		});
 	},
 
 	get_log_to_grid: function(title, id) {
 		if(!title) return
-		if(!id) id = title 
-		let curr = document.getElementById('log_' + id)
-		if(curr) { curr.remove(); return }
+		if(!id) id = title
+		title = this.toWellFormedString(title)
+		id = this.toWellFormedString(id)
+		var root = this.workflow_log_root || (this.div && this.div[0])
+		if (!root) return
 
-		$.get(`./api/app/get_job_log?id=${id}&session_id=${localStorage.session_id}`, (resp)=>{
-			let size = this.args.tail || 25
-			data = new AnsiUp().ansi_to_html(resp.split("\n").slice(-1*size - 4, -4).join("\n"))
-			const newItem = document.createElement('div');
-			newItem.setAttribute('id', 'log_' + id)
-            newItem.className = 'wflog grid-item'; // Apply any necessary classes
-            newItem.innerHTML = `<div class="wflog grid-title">${title}<i class="fa fa-window-close" style="float:right; cursor: pointer" onclick="$P().unsetLogIcon('${id}');this.parentNode.parentNode.remove()"></i></div> <pre>${data}</pre>`;
-            const gridContainer = document.getElementById('log_grid');
-            gridContainer.appendChild(newItem);
-			
-		})
+		let curr = this.get_workflow_log_item(id, root)
+		if(curr) {
+			curr.remove()
+			this.unsetLogIcon(id, root)
+			return
+		}
+
+		if (!this.workflow_log_requests) this.workflow_log_requests = new Map()
+		var pending = this.workflow_log_requests.get(id)
+		if (pending && this.is_current_workflow_log_request(pending)) return
+		if (pending) this.workflow_log_requests.delete(id)
+
+		this.set_workflow_log_icon(id, true, root)
+		var record = {
+			id: id,
+			root: root,
+			generation: this.workflow_log_generation || 0,
+			request: null,
+			cancelled: false
+		}
+		this.workflow_log_requests.set(id, record)
+
+		var handleSuccess = (resp)=>{
+			if (!this.is_current_workflow_log_request(record)) return
+			let size = (this.args && this.args.tail) || 25
+			let logTail = this.toWellFormedString(resp).split("\n").slice(-1*size - 4, -4).join("\n")
+			let ansiHtml = this.sanitize_ansi_log_html(logTail)
+			const gridContainer = this.get_workflow_log_grid(record.root)
+			if (!gridContainer) {
+				this.workflow_log_requests.delete(id)
+				this.unsetLogIcon(id, record.root)
+				return
+			}
+			if (this.get_workflow_log_item(id, record.root)) {
+				this.workflow_log_requests.delete(id)
+				return
+			}
+
+			const newItem = document.createElement('div')
+			newItem.className = 'wflog grid-item workflow-log-preview'
+			newItem.setAttribute('data-job-id', id)
+
+			const titleBar = document.createElement('div')
+			titleBar.className = 'wflog grid-title'
+			const titleLabel = document.createElement('b')
+			titleLabel.textContent = title
+			titleBar.appendChild(titleLabel)
+
+			const closeButton = document.createElement('button')
+			closeButton.type = 'button'
+			closeButton.className = 'fa fa-window-close workflow-log-close'
+			closeButton.setAttribute('aria-label', 'Close log preview')
+			closeButton.style.cssText = 'float:right;cursor:pointer;border:0;background:transparent;color:inherit'
+			closeButton.addEventListener('click', ()=>{
+				this.unsetLogIcon(id, record.root)
+				newItem.remove()
+			})
+			titleBar.appendChild(closeButton)
+
+			const output = document.createElement('pre')
+			// ansiHtml is the allowlisted output of sanitize_ansi_log_html above.
+			output.innerHTML = ansiHtml
+
+			newItem.appendChild(titleBar)
+			newItem.appendChild(output)
+			gridContainer.appendChild(newItem)
+			this.workflow_log_requests.delete(id)
+		}
+
+		var handleFailure = ()=>{
+			if (!this.is_current_workflow_log_request(record)) return
+			this.workflow_log_requests.delete(id)
+			this.unsetLogIcon(id, record.root)
+		}
+
+		try {
+			record.request = $.get('./api/app/get_job_log?id=' + this.encodeQueryComponent(id) +
+				'&session_id=' + this.encodeQueryComponent(localStorage.session_id || ''), handleSuccess)
+			if (record.request && record.request.fail) record.request.fail(handleFailure)
+			if (record.cancelled && record.request && record.request.abort) record.request.abort()
+		}
+		catch (err) {
+			handleFailure()
+			throw err
+		}
 	},
 
 	do_view_inline_log: function () {
@@ -1558,6 +1736,7 @@ Class.subclass(Page.Base, "Page.JobDetails", {
 
 	onDeactivate: function () {
 		// called when page is deactivated
+		this.unbind_workflow_log_controls();
 		for (var key in this.charts) {
 			this.charts[key].destroy();
 		}

--- a/htdocs/js/pages/JobDetails.class.js
+++ b/htdocs/js/pages/JobDetails.class.js
@@ -255,10 +255,7 @@ Class.subclass(Page.Base, "Page.JobDetails", {
 
 		let timing = summarize_event_timing(event.timing, event.timezone)
 
-		let source = job.source || 'Scheduler'
-		if(job.source_id) {
-			source = `<a href="#JobDetails?id=${job.source_id}">${source}</a>`
-		}
+		let source = this.getNiceJobSource(job)
 
 		html += `
 		  <div class="job-details grid-container" style="font-size:1.1em">
@@ -726,6 +723,15 @@ Class.subclass(Page.Base, "Page.JobDetails", {
 		// download job log file
 		const job = this.job;
 		window.location =  './api/app/get_job_log?id=' + job.id + '&download=1' + '&session_id=' + localStorage.session_id;
+	},
+
+	getNiceJobSource: function(job) {
+		job = job || {}
+		var source = encode_entities(this.toWellFormedString(job.source || 'Scheduler'))
+		if (job.source_id) {
+			source = '<a href="#JobDetails?id=' + this.encodeQueryComponent(job.source_id) + '">' + source + '</a>'
+		}
+		return source
 	},
 
 	do_download_html: function() {

--- a/lib/workflow_report.js
+++ b/lib/workflow_report.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const he = require('he');
+
+function toWellFormedString(value) {
+	const input = (value == null) ? '' : String(value);
+	if (input.toWellFormed) return input.toWellFormed();
+
+	let output = '';
+	for (let idx = 0; idx < input.length; idx++) {
+		const code = input.charCodeAt(idx);
+		if ((code >= 0xD800) && (code <= 0xDBFF)) {
+			const next = input.charCodeAt(idx + 1);
+			if ((next >= 0xDC00) && (next <= 0xDFFF)) {
+				output += input.charAt(idx) + input.charAt(++idx);
+			}
+			else output += '\uFFFD';
+		}
+		else if ((code >= 0xDC00) && (code <= 0xDFFF)) output += '\uFFFD';
+		else output += input.charAt(idx);
+	}
+	return output;
+}
+
+function encodeHtml(value) {
+	return he.encode(toWellFormedString(value));
+}
+
+function encodeQueryComponent(value) {
+	return encodeURIComponent(toWellFormedString(value));
+}
+
+function getLogTitle(job) {
+	job = job || {};
+	let title = toWellFormedString(job.seq) + ' :: ' + (toWellFormedString(job.title) || 'Unknown');
+	if (job.arg) title += '@' + toWellFormedString(job.arg);
+	return title;
+}
+
+function getNiceStatus(job) {
+	return job.code ?
+		(job.code == 255 ? '<span style="color:orange"><b>⚠️</b></span>' : '<span style="color:red"><b>✗</b></span>') :
+		'<span style="color:green"><b>✔</b></span>';
+}
+
+function buildLogControl(job, id) {
+	const normalizedId = toWellFormedString(id);
+	const logTitle = getLogTitle(job);
+	return '<button type="button" class="workflow-log-toggle" aria-expanded="false"' +
+		' aria-label="' + encodeHtml('View log: ' + logTitle) + '"' +
+		' data-job-id="' + encodeHtml(normalizedId) + '"' +
+		' data-log-title="' + encodeHtml(logTitle) + '"' +
+		' style="cursor:pointer;border:0;background:transparent;padding:0;color:inherit">' +
+		'<i class="fa fa-eye workflow-log-icon" aria-hidden="true"></i></button>';
+}
+
+function truncateText(value, maxLength) {
+	return Array.from(toWellFormedString(value)).slice(0, maxLength).join('');
+}
+
+function textCell(value) {
+	// The generic report renderer recognizes strings beginning with "filter:" as commands.
+	// Wrapping workflow-controlled text prevents arguments from entering that dispatch path.
+	return '<span>' + encodeHtml(value) + '</span>';
+}
+
+function buildWorkflowReportTable(jobStatus, niceInterval) {
+	jobStatus = jobStatus || {};
+	return {
+		title: 'Workflow Events',
+		header: [
+			'#', 'title', 'arg', 'job', 'started at', 'elapsed', 'status', 'view log', 'description'
+		],
+		rows: Object.keys(jobStatus).map(function(key) {
+			const job = jobStatus[key] || {};
+			const normalizedKey = toWellFormedString(key);
+			const isChildJob = key !== job.event;
+			const title = toWellFormedString(job.title) || '[Unknown]';
+			const titleStyle = (Number(job.code) % 255) ? 'color:red' : '';
+			const jobLink = isChildJob ? '<a href="#JobDetails?id=' + encodeQueryComponent(normalizedKey) +
+				'" target="_blank" rel="noopener noreferrer">' + encodeHtml(normalizedKey) + '</a>' : '';
+
+			return [
+				textCell(job.seq),
+				'<span style="' + titleStyle + '"><b>' + encodeHtml(title) + '</b></span>',
+				job.arg ? textCell(job.arg) : '',
+				jobLink,
+				textCell(job.start),
+				textCell(niceInterval(job.elapsed)),
+				getNiceStatus(job),
+				isChildJob ? buildLogControl(job, normalizedKey) : '',
+				textCell(truncateText(job.description, 120))
+			];
+		}),
+		caption: ''
+	};
+}
+
+module.exports = {
+	buildWorkflowReportTable,
+	encodeQueryComponent,
+	getLogTitle,
+	toWellFormedString
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,10 @@
 				"font-awesome": "4.7.0",
 				"graphlib": "^2.1.8",
 				"he": "^1.2.0",
+				"jose": "6.2.8",
 				"jquery": "^3.7.1",
 				"jquery-datetimepicker": "^2.5.21",
 				"jquery-ui-dist": "^1.13.2",
-				"jose": "6.2.8",
 				"js-yaml": "^4.1.0",
 				"jsonlint-mod": "^1.7.6",
 				"jstimezonedetect": "1.0.6",
@@ -68,7 +68,21 @@
 				"xss": "^1.0.8"
 			},
 			"devDependencies": {
+				"jsdom": "26.1.0",
 				"pixl-unit": "^2.0.1"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"dev": true,
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
 			}
 		},
 		"node_modules/@aws-crypto/crc32": {
@@ -1043,6 +1057,116 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
 			"integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/@egjs/hammerjs": {
 			"version": "2.0.17",
@@ -3023,6 +3147,19 @@
 			"resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
 			"integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
 		},
+		"node_modules/cssstyle": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+			"dev": true,
+			"dependencies": {
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/daemon": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/daemon/-/daemon-1.1.0.tgz",
@@ -3040,6 +3177,19 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.7",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -3055,6 +3205,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true
 		},
 		"node_modules/degenerator": {
 			"version": "5.0.1",
@@ -3247,6 +3403,18 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/errno": {
@@ -3669,6 +3837,18 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3693,6 +3873,18 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ieee754": {
@@ -3743,6 +3935,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true
 		},
 		"node_modules/isarray": {
 			"version": "1.0.0",
@@ -3815,6 +4013,45 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+			"dev": true,
+			"dependencies": {
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^5.1.1",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/jsep": {
@@ -3907,6 +4144,12 @@
 			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
 			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -4090,6 +4333,12 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/nwsapi": {
+			"version": "2.2.24",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+			"integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+			"dev": true
+		},
 		"node_modules/oauth4webapi": {
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.1.4.tgz",
@@ -4172,6 +4421,18 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"dev": true,
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/path-expression-matcher": {
@@ -4586,6 +4847,15 @@
 				"once": "^1.3.1"
 			}
 		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/railroad-diagrams": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -4654,6 +4924,12 @@
 			"integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
 			"license": "MIT"
 		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"dev": true
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4677,6 +4953,18 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
 		},
 		"node_modules/shell-quote": {
 			"version": "1.9.0",
@@ -4976,6 +5264,12 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true
+		},
 		"node_modules/tar-fs": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -5038,6 +5332,48 @@
 			},
 			"engines": {
 				"node": ">=0.8"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"dev": true,
+			"dependencies": {
+				"tldts-core": "^6.1.86"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"dev": true
+		},
+		"node_modules/tough-cookie": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"dev": true,
+			"dependencies": {
+				"tldts": "^6.1.32"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/tslib": {
@@ -5163,6 +5499,62 @@
 				"component-emitter": "^1.3.0 || ^2.0.0"
 			}
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+			"dev": true,
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"dev": true,
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/widest-line": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.0.0.tgz",
@@ -5207,6 +5599,21 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true
 		},
 		"node_modules/xmlhttprequest-ssl": {
 			"version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"license": "MIT",
 	"main": "lib/main.js",
 	"scripts": {
-		"test": "pixl-unit lib/test.js test/oidc-logout.test.js",
+		"test": "pixl-unit lib/test.js test/oidc-logout.test.js test/ui-output-encoding.test.js",
 		"boot": "pixl-boot install",
 		"unboot": "pixl-boot uninstall"
 	},
@@ -84,6 +84,7 @@
 		"xss": "^1.0.8"
 	},
 	"devDependencies": {
+		"jsdom": "26.1.0",
 		"pixl-unit": "^2.0.1"
 	}
 }

--- a/test/ui-output-encoding.test.js
+++ b/test/ui-output-encoding.test.js
@@ -1,0 +1,409 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { JSDOM } = require('jsdom');
+const filterXSS = require('xss');
+const AnsiUp = require('ansi_up').default;
+const { buildWorkflowReportTable, getLogTitle } = require('../lib/workflow_report');
+
+const projectRoot = path.dirname(__dirname);
+
+function loadBrowserClasses() {
+	const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+		url: 'https://cronicle.example/',
+		runScripts: 'outside-only'
+	});
+	const window = dom.window;
+
+	window.Page = function Page() {};
+	window.Class = {
+		subclass: function(parent, name, definition) {
+			function Subclass() {}
+			Subclass.prototype = Object.create((parent && parent.prototype) || {});
+			Object.assign(Subclass.prototype, definition);
+			Subclass.prototype.constructor = Subclass;
+
+			const parts = name.split('.');
+			let target = window;
+			for (let idx = 0; idx < parts.length - 1; idx++) target = target[parts[idx]];
+			target[parts[parts.length - 1]] = Subclass;
+		}
+	};
+	window.filterXSS = filterXSS;
+	window.AnsiUp = AnsiUp;
+
+	const context = dom.getInternalVMContext();
+	[
+		'node_modules/pixl-webapp/js/tools.js',
+		'node_modules/pixl-webapp/js/xml.js',
+		'htdocs/js/pages/Base.class.js',
+		'htdocs/js/pages/Home.class.js',
+		'htdocs/js/pages/JobDetails.class.js'
+	].forEach(function(relativePath) {
+		vm.runInContext(fs.readFileSync(path.join(projectRoot, relativePath), 'utf8'), context, {
+			filename: relativePath
+		});
+	});
+
+	return { dom, window };
+}
+
+function renderTableRow(window, row) {
+	const table = window.document.createElement('table');
+	table.innerHTML = '<tbody><tr>' + row.map(function(cell) { return '<td>' + cell + '</td>'; }).join('') + '</tr></tbody>';
+	return table;
+}
+
+function createWorkflowView(window, id, job) {
+	const jobs = Object.create(null);
+	jobs[id] = job;
+	const report = buildWorkflowReportTable(jobs, function() { return '00:00:03'; });
+	const root = window.document.createElement('div');
+	root.appendChild(renderTableRow(window, report.rows[0]));
+	const grid = window.document.createElement('div');
+	grid.id = 'log_grid';
+	root.appendChild(grid);
+	return {
+		root: root,
+		grid: grid,
+		control: root.querySelector('.workflow-log-toggle')
+	};
+}
+
+function makeLog(payload) {
+	return ['head1', 'head2', 'head3', 'head4', payload, 'foot1', 'foot2', 'foot3', 'foot4'].join('\n');
+}
+
+function installDeferredGet(window) {
+	const requests = [];
+	window.$ = {
+		get: function(url, success) {
+			const failureHandlers = [];
+			const request = {
+				url: url,
+				aborted: false,
+				fail: function(handler) {
+					failureHandlers.push(handler);
+					return request;
+				},
+				abort: function() {
+					request.aborted = true;
+					failureHandlers.forEach(function(handler) { handler(new Error('aborted')); });
+					return request;
+				},
+				resolve: function(data) { success(data); },
+				reject: function() {
+					failureHandlers.forEach(function(handler) { handler(new Error('late failure')); });
+				}
+			};
+			requests.push(request);
+			return request;
+		}
+	};
+	return requests;
+}
+
+function parseHashParams(href) {
+	return new URLSearchParams(href.slice(href.indexOf('?') + 1));
+}
+
+const tests = [];
+
+function addTest(name, callback) {
+	const wrapped = function(test) {
+		Promise.resolve().then(callback).then(function() {
+			test.done();
+		}).catch(function(err) {
+			test.ok(false, name + ': ' + (err && err.stack || err));
+			test.done();
+		});
+	};
+	Object.defineProperty(wrapped, 'name', {
+		value: name.replace(/[^A-Za-z0-9]+/g, '_'),
+		configurable: true
+	});
+	tests.push(wrapped);
+}
+
+addTest('workflow report emits passive controls and preserves encoded values', function() {
+	const { dom, window } = loadBrowserClasses();
+	const id = 'job\'\"><img src=x onerror="globalThis.pwned=1">/${template}`';
+	const title = 'Title ` ${globalThis.pwned=2} </button><script>globalThis.pwned=3</script>';
+	const arg = 'filter:eval(globalThis.pwned=4/* \" onerror=<script> */)';
+	const jobs = Object.create(null);
+	jobs[id] = {
+		seq: 7,
+		title: title,
+		arg: arg,
+		event: 'different-event',
+		start: '10:00:00',
+		elapsed: 2,
+		code: 1,
+		description: '<img src=x onerror="globalThis.pwned=5"> failed'
+	};
+
+	const report = buildWorkflowReportTable(jobs, function() { return '00:00:02'; });
+	const table = renderTableRow(window, report.rows[0]);
+	window.document.body.appendChild(table);
+	const cells = table.querySelectorAll('td');
+	const control = table.querySelector('.workflow-log-toggle');
+	const link = table.querySelector('a[href^="#JobDetails?"]');
+
+	assert.ok(control);
+	assert.equal(table.querySelectorAll('[onclick],[onerror],script,svg,img').length, 0);
+	assert.equal(control.getAttribute('data-job-id'), id);
+	assert.equal(control.getAttribute('data-log-title'), getLogTitle(jobs[id]));
+	assert.equal(cells[1].textContent, title);
+	assert.equal(cells[2].textContent, arg);
+	assert.doesNotMatch(report.rows[0][2], /^filter:(\w+)\((.+)\)$/);
+	assert.equal(parseHashParams(link.getAttribute('href')).get('id'), id);
+	assert.equal(window.globalThis.pwned, undefined);
+
+	assert.doesNotThrow(function() {
+		buildWorkflowReportTable({ child: {
+			seq: 1, title: 'bad\uD800title', event: 'parent', elapsed: 0
+		} }, function() { return ''; });
+	});
+	dom.window.close();
+});
+
+addTest('failed-job badge keeps trusted tooltip markup without attribute injection', function() {
+	const { dom, window } = loadBrowserClasses();
+	const eventTitle = 'Broken\" onmouseover="globalThis.pwned=1"><img src=x onerror="globalThis.pwned=2"><script>globalThis.pwned=3</script>';
+	const errorLog = Object.create(null);
+	errorLog[eventTitle] = 2;
+	const home = window.Page.Home.prototype;
+	const html = home.get_failed_job_badge({ jobs_completed: 10, jobs_failed: 3, errorLog: errorLog }, { err_rate: 0.1 });
+	const host = window.document.createElement('div');
+	host.innerHTML = html;
+	const badge = host.querySelector('a.color_label');
+
+	assert.ok(badge);
+	assert.equal(host.querySelectorAll('[onclick],[onmouseover],[onerror],script,img').length, 0);
+	assert.equal(badge.textContent, '3');
+	assert.equal(parseHashParams(badge.getAttribute('href')).get('max'), '3');
+	assert.match(badge.getAttribute('title'), /<u>Failed to start: <b>1<\/b><\/u>/);
+	assert.match(badge.getAttribute('title'), /&lt;img/);
+
+	const tooltip = window.document.createElement('div');
+	tooltip.innerHTML = filterXSS(badge.getAttribute('title'));
+	assert.equal(tooltip.querySelectorAll('[onerror],script,img').length, 0);
+	assert.ok(tooltip.querySelector('b'));
+	assert.match(tooltip.textContent, /<img src=x onerror=/);
+	assert.equal(window.globalThis.pwned, undefined);
+	dom.window.close();
+});
+
+addTest('history argument encodes context id and round-trips query values', function() {
+	const { dom, window } = loadBrowserClasses();
+	const id = 'event\" onmouseover="globalThis.pwned=1"><svg onload="globalThis.pwned=2">/😀';
+	const arg = '\"><img src=x onerror="globalThis.pwned=3"> argument & value';
+	const base = window.Page.Base.prototype;
+	const host = window.document.createElement('div');
+	host.innerHTML = base.getNiceArgument(arg, 500, { id: id, error: true });
+	const link = host.querySelector('a');
+	const params = parseHashParams(link.getAttribute('href'));
+
+	assert.equal(host.querySelectorAll('[onmouseover],[onerror],svg,img').length, 0);
+	assert.equal(params.get('id'), id);
+	assert.equal(params.get('arg'), arg);
+	assert.equal(link.textContent, arg);
+	assert.equal(params.get('error'), '1');
+	assert.equal(window.globalThis.pwned, undefined);
+
+	assert.doesNotThrow(function() {
+		const malformed = base.getNiceArgument('arg\uDFFF', 50, { id: 'id\uD800' });
+		const malformedHost = window.document.createElement('div');
+		malformedHost.innerHTML = malformed;
+		const malformedParams = parseHashParams(malformedHost.querySelector('a').getAttribute('href'));
+		assert.equal(malformedParams.get('id'), 'id\uFFFD');
+		assert.equal(malformedParams.get('arg'), 'arg\uFFFD');
+	});
+	dom.window.close();
+});
+
+addTest('workflow view-log click and close use DOM-safe title id and ANSI output', function() {
+	const { dom, window } = loadBrowserClasses();
+	const id = 'child\'\"><img src=x onerror="globalThis.pwned=1">/😀';
+	const job = {
+		seq: 8,
+		title: 'Job </b><script>globalThis.pwned=2</script>',
+		arg: '\" onerror="globalThis.pwned=3',
+		event: 'parent',
+		start: '10:00:00',
+		elapsed: 3,
+		code: 0,
+		description: 'ok'
+	};
+	const jobs = Object.create(null);
+	jobs[id] = job;
+	const report = buildWorkflowReportTable(jobs, function() { return '00:00:03'; });
+	const root = window.document.createElement('div');
+	const table = renderTableRow(window, report.rows[0]);
+	root.appendChild(table);
+	const grid = window.document.createElement('div');
+	grid.id = 'log_grid';
+	root.appendChild(grid);
+	window.document.body.appendChild(root);
+
+	window.localStorage.session_id = 'session\"&/😀';
+	const logPayload = '\u001b[31mred\u001b[0m <img src=x onerror="globalThis.pwned=4"><script>globalThis.pwned=5</script>';
+	const log = ['head1', 'head2', 'head3', 'head4', logPayload, 'foot1', 'foot2', 'foot3', 'foot4'].join('\n');
+	const requests = [];
+	window.$ = {
+		get: function(url, callback) {
+			requests.push(url);
+			callback(log);
+			return { fail: function() { return this; } };
+		}
+	};
+
+	const page = Object.create(window.Page.JobDetails.prototype);
+	page.args = { tail: 25 };
+	page.bind_workflow_log_controls(root);
+	const control = root.querySelector('.workflow-log-toggle');
+	const icon = control.querySelector('.workflow-log-icon');
+	icon.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+	let preview = grid.querySelector('.workflow-log-preview');
+	assert.ok(preview);
+	assert.equal(preview.getAttribute('data-job-id'), id);
+	assert.equal(preview.querySelector('.grid-title b').textContent, getLogTitle(job));
+	assert.equal(preview.querySelectorAll('script,img,[onerror],[onclick]').length, 0);
+	assert.ok(preview.querySelector('pre span[style]'));
+	assert.match(preview.querySelector('pre').textContent, /<img src=x onerror=/);
+	assert.equal(control.getAttribute('aria-expanded'), 'true');
+	assert.ok(icon.classList.contains('fa-eye-slash'));
+	assert.equal(window.globalThis.pwned, undefined);
+
+	const requestUrl = new URL(requests[0], window.location.href);
+	assert.equal(requestUrl.searchParams.get('id'), id);
+	assert.equal(requestUrl.searchParams.get('session_id'), window.localStorage.session_id);
+
+	control.click();
+	assert.equal(grid.querySelector('.workflow-log-preview'), null);
+	assert.equal(requests.length, 1);
+	assert.ok(icon.classList.contains('fa-eye'));
+
+	control.click();
+	preview = grid.querySelector('.workflow-log-preview');
+	assert.ok(preview);
+	preview.querySelector('.workflow-log-close').click();
+	assert.equal(grid.querySelector('.workflow-log-preview'), null);
+	assert.equal(control.getAttribute('aria-expanded'), 'false');
+	assert.ok(icon.classList.contains('fa-eye'));
+
+	page.unbind_workflow_log_controls();
+	dom.window.close();
+});
+
+addTest('workflow view-log deduplicates rapid clicks while a request is pending', async function() {
+	const { dom, window } = loadBrowserClasses();
+	const id = 'pending-job\"/><script>globalThis.pwned=1</script>';
+	const job = {
+		seq: 9, title: 'Pending <img src=x onerror="globalThis.pwned=2">', arg: 'arg',
+		event: 'parent', start: '10:00:00', elapsed: 3, code: 0, description: 'ok'
+	};
+	const view = createWorkflowView(window, id, job);
+	window.document.body.appendChild(view.root);
+	const requests = installDeferredGet(window);
+	const page = Object.create(window.Page.JobDetails.prototype);
+	page.args = { tail: 25 };
+	page.bind_workflow_log_controls(view.root);
+
+	view.control.click();
+	view.control.click();
+	assert.equal(requests.length, 1);
+	assert.equal(view.grid.querySelectorAll('.workflow-log-preview').length, 0);
+	assert.equal(view.control.getAttribute('aria-expanded'), 'true');
+
+	requests[0].resolve(makeLog('\u001b[32mready\u001b[0m'));
+	await Promise.resolve();
+	assert.equal(view.grid.querySelectorAll('.workflow-log-preview').length, 1);
+	assert.equal(requests.length, 1);
+
+	page.unbind_workflow_log_controls();
+	dom.window.close();
+});
+
+addTest('workflow view-log ignores a stale response after unbind and reactivation', async function() {
+	const { dom, window } = loadBrowserClasses();
+	const id = 'same-job\" onerror="globalThis.pwned=1';
+	const oldJob = {
+		seq: 10, title: 'Old <script>globalThis.pwned=2</script>', event: 'parent',
+		start: '10:00:00', elapsed: 3, code: 0, description: 'old'
+	};
+	const newJob = Object.assign({}, oldJob, { title: 'New safe generation' });
+	const oldView = createWorkflowView(window, id, oldJob);
+	window.document.body.appendChild(oldView.root);
+	const requests = installDeferredGet(window);
+	const page = Object.create(window.Page.JobDetails.prototype);
+	page.args = { tail: 25 };
+	page.bind_workflow_log_controls(oldView.root);
+	oldView.control.click();
+	assert.equal(requests.length, 1);
+
+	page.unbind_workflow_log_controls();
+	assert.equal(requests[0].aborted, true);
+	const newView = createWorkflowView(window, id, newJob);
+	window.document.body.appendChild(newView.root);
+	page.bind_workflow_log_controls(newView.root);
+	newView.control.click();
+	assert.equal(requests.length, 2);
+
+	requests[0].resolve(makeLog('stale response <img src=x onerror="globalThis.pwned=3">'));
+	requests[0].reject();
+	await Promise.resolve();
+	assert.equal(oldView.grid.querySelectorAll('.workflow-log-preview').length, 0);
+	assert.equal(newView.grid.querySelectorAll('.workflow-log-preview').length, 0);
+	assert.equal(newView.control.getAttribute('aria-expanded'), 'true');
+
+	requests[1].resolve(makeLog('\u001b[34mcurrent response\u001b[0m'));
+	await Promise.resolve();
+	const currentPreview = newView.grid.querySelector('.workflow-log-preview');
+	assert.ok(currentPreview);
+	assert.equal(currentPreview.querySelector('.grid-title b').textContent, getLogTitle(newJob));
+	assert.equal(window.globalThis.pwned, undefined);
+
+	page.unbind_workflow_log_controls();
+	dom.window.close();
+});
+
+addTest('workflow view-log ignores a failure delivered after a successful preview', async function() {
+	const { dom, window } = loadBrowserClasses();
+	const id = 'late-failure-job';
+	const job = {
+		seq: 11, title: 'Late failure', event: 'parent', start: '10:00:00',
+		elapsed: 3, code: 0, description: 'ok'
+	};
+	const view = createWorkflowView(window, id, job);
+	window.document.body.appendChild(view.root);
+	const requests = installDeferredGet(window);
+	const page = Object.create(window.Page.JobDetails.prototype);
+	page.args = { tail: 25 };
+	page.bind_workflow_log_controls(view.root);
+	view.control.click();
+
+	requests[0].resolve(makeLog('\u001b[35mcomplete\u001b[0m'));
+	await Promise.resolve();
+	assert.equal(view.grid.querySelectorAll('.workflow-log-preview').length, 1);
+	assert.equal(view.control.getAttribute('aria-expanded'), 'true');
+
+	requests[0].reject();
+	await Promise.resolve();
+	assert.equal(view.grid.querySelectorAll('.workflow-log-preview').length, 1);
+	assert.equal(view.control.getAttribute('aria-expanded'), 'true');
+	assert.ok(view.control.querySelector('.workflow-log-icon').classList.contains('fa-eye-slash'));
+
+	page.unbind_workflow_log_controls();
+	dom.window.close();
+});
+
+module.exports = {
+	setUp: function(callback) { callback(); },
+	tests: tests,
+	tearDown: function(callback) { callback(); }
+};

--- a/test/ui-output-encoding.test.js
+++ b/test/ui-output-encoding.test.js
@@ -225,6 +225,31 @@ addTest('history argument encodes context id and round-trips query values', func
 	dom.window.close();
 });
 
+addTest('job source link encodes URL and text contexts independently', function() {
+	const { dom, window } = loadBrowserClasses();
+	const id = 'parent\" onmouseover="globalThis.pwned=1"><svg onload="globalThis.pwned=2">/😀';
+	const source = 'API Key </a><img src=x onerror="globalThis.pwned=3"><script>globalThis.pwned=4</script>';
+	const details = window.Page.JobDetails.prototype;
+	const host = window.document.createElement('div');
+	host.innerHTML = details.getNiceJobSource({ source: source, source_id: id });
+	const link = host.querySelector('a');
+
+	assert.ok(link);
+	assert.equal(host.querySelectorAll('[onmouseover],[onload],[onerror],svg,img,script').length, 0);
+	assert.equal(parseHashParams(link.getAttribute('href')).get('id'), id);
+	assert.equal(link.textContent, source);
+	assert.equal(window.globalThis.pwned, undefined);
+
+	assert.doesNotThrow(function() {
+		const malformed = window.document.createElement('div');
+		malformed.innerHTML = details.getNiceJobSource({ source: 'source\uDFFF', source_id: 'id\uD800' });
+		const malformedLink = malformed.querySelector('a');
+		assert.equal(parseHashParams(malformedLink.getAttribute('href')).get('id'), 'id\uFFFD');
+		assert.equal(malformedLink.textContent, 'source\uFFFD');
+	});
+	dom.window.close();
+});
+
 addTest('workflow view-log click and close use DOM-safe title id and ANSI output', function() {
 	const { dom, window } = loadBrowserClasses();
 	const id = 'child\'\"><img src=x onerror="globalThis.pwned=1">/😀';


### PR DESCRIPTION
## Problem

Stored job metadata reached multiple UI/report contexts without safe construction: failed-job tooltips, workflow report log controls, asynchronous log previews, history argument links, and Job Details source links. The preview flow also allowed duplicate/stale requests to mutate a newly rendered page.

## Change

- Encode text, attributes, query components, and report data at their output boundaries.
- Encode Job Details source labels as text and `source_id` as a URL component, including malformed UTF-16 handling.
- Replace inline report JavaScript with passive `data-*` controls and delegated handlers.
- Build preview controls through DOM APIs and sanitize the intentional ANSI-to-HTML output with a narrow allowlist.
- Track preview requests by normalized job ID and page generation, deduplicate rapid clicks, abort on deactivation, and ignore stale success/failure callbacks.

Trusted formatting in the existing tooltips and ANSI colors/links remains supported. Caller-controlled provenance is independently removed server-side by [#257](https://github.com/cronicle-edge/cronicle-edge/pull/257); this PR keeps the rendering boundary safe for legacy stored records as well.

## Validation

- jsdom regressions cover quote/tag payloads, `filter:eval(...)`, source link text/URL contexts, malformed UTF-16, report toggles, close behavior, ANSI spans/links, URL round trips, and absence of active injected nodes.
- Deferred callback tests cover double-click deduplication, abort/reactivation, stale responses, and late failures.
- Full `npm test`: 100/100 tests, 375 assertions.
- Focused suite: 8/8; `node --check` and `git diff --check`: pass.

The issues and initial patches were proposed by a Codex Ultra security review, including fork PR [frankii91/cronicle-edge#13](https://github.com/frankii91/cronicle-edge/pull/13). This consolidated version was manually re-analyzed, uses context-appropriate URL/text encoding rather than the generated attribute-unsafe patch, includes the asynchronous UI lifecycle, adds real regression coverage, and is submitted for maintainer review in line with our prior discussion.
