### PR TITLE
ci: harden container publishing workflows

### DIFF
--- a/.github/scripts/resolve-docker-tag.sh
+++ b/.github/scripts/resolve-docker-tag.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+case "${PUBLISH_EVENT_NAME:-}" in
+	push)
+		image_tag="latest"
+		;;
+	release)
+		image_tag="${PUBLISH_RELEASE_TAG:-}"
+		;;
+	*)
+		echo "Unsupported Docker publish event" >&2
+		exit 1
+		;;
+esac
+
+# Docker distribution/reference.TagRegexp: [\w][\w.-]{0,127}
+if [[ ! "$image_tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+	echo "Invalid Docker image tag" >&2
+	exit 1
+fi
+
+if [[ -z "${GITHUB_ENV:-}" ]]; then
+	echo "GITHUB_ENV is required" >&2
+	exit 1
+fi
+
+printf 'TAG=%s\n' "$image_tag" >> "$GITHUB_ENV"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+
 jobs:
   # Run on PRs: build Docker image (no push) and run tests
   test:
@@ -21,24 +24,29 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
       - name: Install dependencies
         run: npm install
 
+      - name: Audit workflow security
+        run: npm run test:workflow-security
+
       - name: Run tests
         run: npm test
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build Docker image (no push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile
@@ -54,20 +62,27 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+        with:
+          persist-credentials: false
+
+      - name: Resolve Docker image tag
+        env:
+          PUBLISH_EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: bash .github/scripts/resolve-docker-tag.sh
 
       - name: downcase REPO
         run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -75,13 +90,13 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image (GHCR)
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile
@@ -98,14 +113,6 @@ jobs:
         run: |
           echo "building for $DOCKERHUB_USERNAME"
           echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-          if [ "${{ github.event_name }}" == "push" ]; then
-            TAG="latest"
-          elif [ "${{ github.event_name }}" == "release" ]; then
-            TAG="${{ github.event.release.tag_name }}"
-          else
-            echo "Unsupported event: ${{ github.event_name }}"
-            exit 1
-          fi
           echo "publishing tag $TAG"
-          docker build -t cronicle/edge:$TAG -f Dockerfile .
-          docker push cronicle/edge:$TAG
+          docker build -t "cronicle/edge:$TAG" -f Dockerfile .
+          docker push "cronicle/edge:$TAG"

--- a/.github/workflows/dockerhub-multi.yaml
+++ b/.github/workflows/dockerhub-multi.yaml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   # Run on PRs: build Docker image (no push) and run tests
   test:
@@ -17,27 +20,32 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
       - name: Install dependencies
         run: npm install
 
+      - name: Audit workflow security
+        run: npm run test:workflow-security
+
       - name: Run tests
         run: npm test
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build Docker image (no push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile
@@ -54,32 +62,31 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Resolve Docker image tag
+        env:
+          PUBLISH_EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: bash .github/scripts/resolve-docker-tag.sh
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.io
           username: ${{ secrets.DHUB_USER }}
           password: ${{ secrets.DHUB_TOKEN }}
 
-      - name: Set release tag as image tag
-        id: set-tag
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            echo "TAG=latest" >> $GITHUB_ENV
-          elif [ "${{ github.event_name }}" == "release" ]; then
-            echo "TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
-          fi
-
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"main": "lib/main.js",
 	"scripts": {
 		"test": "pixl-unit lib/test.js test/oidc-logout.test.js",
+		"test:workflow-security": "node test/workflow-security.test.js",
 		"boot": "pixl-boot install",
 		"unboot": "pixl-boot uninstall"
 	},

--- a/test/workflow-security.test.js
+++ b/test/workflow-security.test.js
@@ -1,0 +1,196 @@
+'use strict';
+
+const assert = require('assert');
+const childProcess = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const repoRoot = path.resolve(__dirname, '..');
+const workflowDir = path.join(repoRoot, '.github', 'workflows');
+const tagResolver = path.join(repoRoot, '.github', 'scripts', 'resolve-docker-tag.sh');
+
+// Resolved from the official repositories' exact refs/tags on 2026-08-20.
+const verifiedActionPins = new Map([
+	['actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26', 'v3.7.0'],
+	['actions/checkout@11d5960a326750d5838078e36cf38b85af677262', 'v4.4.0'],
+	['actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020', 'v4.4.0'],
+	['docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f', 'v3.12.0'],
+	['docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130', 'v3.7.0'],
+	['docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25', 'v5.4.0'],
+	['docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9', 'v3.7.0'],
+	['docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051', 'v5.10.0']
+]);
+
+function workflowFiles() {
+	return fs.readdirSync(workflowDir)
+		.filter((name) => /\.ya?ml$/i.test(name))
+		.sort()
+		.map((name) => path.join(workflowDir, name));
+}
+
+function isTrue(value) {
+	return value === true || value === 'true';
+}
+
+function stepPublishesImage(step) {
+	const uses = String(step.uses || '');
+	const run = String(step.run || '');
+	return (uses.startsWith('docker/build-push-action@') && isTrue((step.with || {}).push)) ||
+		/(^|\s)docker\s+push(?:\s|$)/m.test(run);
+}
+
+function stepUsesCredentials(step) {
+	const serialized = JSON.stringify(step);
+	const uses = String(step.uses || '');
+	const run = String(step.run || '');
+	return uses.startsWith('docker/login-action@') ||
+		/(^|\s)docker\s+login(?:\s|$)/m.test(run) ||
+		serialized.includes('${{ secrets.') ||
+		serialized.includes('${{ github.token');
+}
+
+function auditWorkflows() {
+	const files = workflowFiles();
+	assert(files.length > 0, 'No GitHub Actions workflows found');
+
+	let pinnedUses = 0;
+	let publishingJobs = 0;
+	const forbiddenRunExpression = /\$\{\{[^}]*\bgithub\.(?:event_name|event\.release\.tag_name|ref|ref_name)\b[^}]*\}\}/;
+
+	for (const file of files) {
+		const relative = path.relative(repoRoot, file);
+		const source = fs.readFileSync(file, 'utf8');
+		const workflow = yaml.load(source);
+		assert(workflow && typeof workflow === 'object', `${relative} did not parse as a workflow object`);
+		assert.strictEqual((workflow.permissions || {}).contents, 'read', `${relative} must default to contents: read`);
+		assert.notStrictEqual((workflow.permissions || {})['id-token'], 'write', `${relative} must not grant an unused OIDC token`);
+
+		const jobs = Object.entries(workflow.jobs || {});
+		if (jobs.some(([, job]) => (job.steps || []).some(stepPublishesImage))) {
+			const pullRequestJobs = jobs
+				.filter(([, job]) => String(job.if || '').includes("github.event_name == 'pull_request'"));
+			assert(pullRequestJobs.length > 0, `${relative} must have a pull-request test job`);
+			for (const [jobName, job] of pullRequestJobs) {
+				assert(/^ubuntu-/.test(String(job['runs-on'] || '')),
+					`${relative}:${jobName} must run the Bash workflow audit on Ubuntu`);
+				const steps = Array.isArray(job.steps) ? job.steps : [];
+				const auditIndex = steps.findIndex((step) => String(step.run || '').trim() === 'npm run test:workflow-security');
+				const projectTestIndex = steps.findIndex((step) => String(step.run || '').trim() === 'npm test');
+				assert(auditIndex >= 0, `${relative}:${jobName} must run the workflow security audit`);
+				assert(projectTestIndex >= 0, `${relative}:${jobName} must run the project tests`);
+				assert(auditIndex < projectTestIndex,
+					`${relative}:${jobName} must audit workflow security before the project tests`);
+			}
+		}
+
+		for (const [index, line] of source.split(/\r?\n/).entries()) {
+			if (!/^\s*uses:/.test(line)) continue;
+			const match = line.match(/^\s*uses:\s*([^\s#]+)(?:\s+#\s*(\S+))?\s*$/);
+			assert(match, `${relative}:${index + 1} has an unreadable uses entry`);
+			const actionRef = match[1];
+			if (actionRef.startsWith('./') || actionRef.startsWith('docker://')) continue;
+
+			const pin = actionRef.match(/^([^@]+)@([0-9a-f]{40})$/);
+			assert(pin, `${relative}:${index + 1} must pin ${actionRef} to a full commit SHA`);
+			const expectedTag = verifiedActionPins.get(actionRef);
+			assert(expectedTag, `${relative}:${index + 1} uses an unverified action pin: ${actionRef}`);
+			assert.strictEqual(match[2], expectedTag, `${relative}:${index + 1} must document ${expectedTag}`);
+			pinnedUses++;
+		}
+
+		for (const [jobName, job] of Object.entries(workflow.jobs || {})) {
+			assert.notStrictEqual((job.permissions || {})['id-token'], 'write', `${relative}:${jobName} must not grant an unused OIDC token`);
+			const steps = Array.isArray(job.steps) ? job.steps : [];
+			for (const step of steps) {
+				const run = String(step.run || '');
+				assert(!forbiddenRunExpression.test(run), `${relative}:${jobName} interpolates GitHub ref data directly into shell`);
+
+				if (String(step.uses || '').startsWith('actions/checkout@')) {
+					assert.strictEqual((step.with || {})['persist-credentials'], false,
+						`${relative}:${jobName} checkout must set persist-credentials: false`);
+				}
+			}
+
+			if (!steps.some(stepPublishesImage)) continue;
+			publishingJobs++;
+
+			const resolverIndexes = steps
+				.map((step, index) => String(step.run || '').trim() === 'bash .github/scripts/resolve-docker-tag.sh' ? index : -1)
+				.filter((index) => index >= 0);
+			assert.strictEqual(resolverIndexes.length, 1, `${relative}:${jobName} must run the tag resolver exactly once`);
+
+			const resolverIndex = resolverIndexes[0];
+			const resolver = steps[resolverIndex];
+			assert.strictEqual((resolver.env || {}).PUBLISH_EVENT_NAME, '${{ github.event_name }}',
+				`${relative}:${jobName} must pass event_name through env`);
+			assert.strictEqual((resolver.env || {}).PUBLISH_RELEASE_TAG, '${{ github.event.release.tag_name }}',
+				`${relative}:${jobName} must pass release.tag_name through env`);
+
+			const credentialIndex = steps.findIndex(stepUsesCredentials);
+			if (credentialIndex >= 0) {
+				assert(resolverIndex < credentialIndex, `${relative}:${jobName} must validate the tag before credentials are available`);
+			}
+		}
+	}
+
+	assert(pinnedUses > 0, 'No third-party action references were audited');
+	assert(publishingJobs > 0, 'No image-publishing jobs were audited');
+	return { files: files.length, pinnedUses, publishingJobs };
+}
+
+function runResolverCase(testCase) {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cronicle-workflow-security-'));
+	const envFile = path.join(tempDir, 'github-env');
+	const marker = path.join(tempDir, 'command-ran');
+	const releaseTag = typeof testCase.releaseTag === 'function' ? testCase.releaseTag(marker) : testCase.releaseTag;
+
+	try {
+		const result = childProcess.spawnSync('bash', [tagResolver], {
+			encoding: 'utf8',
+			env: {
+				...process.env,
+				GITHUB_ENV: envFile,
+				PUBLISH_EVENT_NAME: testCase.eventName,
+				PUBLISH_RELEASE_TAG: releaseTag || ''
+			}
+		});
+
+		assert.ifError(result.error);
+		const envOutput = fs.existsSync(envFile) ? fs.readFileSync(envFile, 'utf8') : '';
+		assert.strictEqual(fs.existsSync(marker), false, `${testCase.name} executed tag contents as shell code`);
+
+		if (testCase.expectedTag) {
+			assert.strictEqual(result.status, 0, `${testCase.name} should succeed: ${result.stderr}`);
+			assert.strictEqual(envOutput, `TAG=${testCase.expectedTag}\n`, `${testCase.name} wrote an unexpected environment value`);
+		}
+		else {
+			assert.notStrictEqual(result.status, 0, `${testCase.name} should be rejected`);
+			assert.strictEqual(envOutput, '', `${testCase.name} must not write to GITHUB_ENV`);
+		}
+	}
+	finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+const workflowAudit = auditWorkflows();
+
+[
+	{ name: 'push', eventName: 'push', releaseTag: '', expectedTag: 'latest' },
+	{ name: 'simple release', eventName: 'release', releaseTag: 'v1.2.3', expectedTag: 'v1.2.3' },
+	{ name: 'underscore prefix', eventName: 'release', releaseTag: '_candidate-1.2', expectedTag: '_candidate-1.2' },
+	{ name: 'maximum length', eventName: 'release', releaseTag: `a${'b'.repeat(127)}`, expectedTag: `a${'b'.repeat(127)}` },
+	{ name: 'command substitution', eventName: 'release', releaseTag: (marker) => `v1$(touch ${marker})` },
+	{ name: 'backtick substitution', eventName: 'release', releaseTag: (marker) => `v1\`touch ${marker}\`` },
+	{ name: 'newline injection', eventName: 'release', releaseTag: 'v1.2.3\nTAG=latest' },
+	{ name: 'slash', eventName: 'release', releaseTag: 'release/v1.2.3' },
+	{ name: 'too long', eventName: 'release', releaseTag: 'a'.repeat(129) },
+	{ name: 'invalid prefix', eventName: 'release', releaseTag: '.v1.2.3' },
+	{ name: 'empty release', eventName: 'release', releaseTag: '' },
+	{ name: 'unsupported event', eventName: 'workflow_dispatch', releaseTag: 'v1.2.3' },
+	{ name: 'ignored push payload', eventName: 'push', releaseTag: (marker) => `$(touch ${marker})`, expectedTag: 'latest' }
+].forEach(runResolverCase);
+
+console.log(`Workflow security checks passed: ${workflowAudit.files} workflows, ${workflowAudit.publishingJobs} publishing jobs, ${workflowAudit.pinnedUses} pinned action references.`);


### PR DESCRIPTION
## Problem

Both container-publishing workflows interpolated release metadata into a shell context, used mutable action tags, retained checkout credentials, and granted broader permissions than their jobs require.  A partial fix to only one workflow would leave the parallel DockerHub path exposed.

## Change

- Resolve and validate the Docker tag from an environment variable before registry login or build steps.
- Apply the same boundary to both publishing workflows.
- Pin all 19 action references to verified immutable upstream commit SHAs, retaining tag comments for updateability.
- Set explicit least-privilege permissions and disable persisted checkout credentials.
- Run the portable workflow audit as an explicit Ubuntu CI step without making the normal cross-platform `npm test` depend on Bash.

## Validation

- Durable security test covers both publishing jobs, tag injection cases, validation-before-login ordering, permissions, and all 19 pins.
- `actionlint` 1.7.12, Bash syntax, Node syntax, and YAML parsing: pass.
- Full `npm test`: 92/92 tests, 375 assertions.
- Focused workflow security test: pass for 2 workflows and 2 publishing jobs.

The issues and initial patches were proposed by a Codex Ultra security review. This consolidated version was manually re-analyzed across both publishing paths, adds durable regression coverage, and is submitted for maintainer review in line with our prior discussion.
