### PR TITLE
build: pin active container base images

### DIFF
--- a/Docker/alpine-base.dockerfile
+++ b/Docker/alpine-base.dockerfile
@@ -6,6 +6,6 @@
 # multi-arch build
 # docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t cronicle/base-alpine:v3.22.2 --push -f Docker/alpine-base.dockerfile .
 
-FROM alpine:3.22.2
+FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 RUN apk add --no-cache bash nodejs tini util-linux bash openssl procps coreutils curl tar jq busybox-extras
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,13 @@
 # test run: docker run --rm -it  -p 3019:3012 -e CRONICLE_manager=1 cronicle:bundle bash
 # then type manager or worker
 
-# cronicle/base-alpine: 
-# FROM alpine:3.19.1
-# RUN apk add --no-cache bash nodejs tini util-linux bash openssl procps coreutils curl tar jq
-
-FROM cronicle/base-alpine AS build
+FROM cronicle/base-alpine:latest@sha256:75751298e3f56e7500f5be42cc4469ebc2b23b9f8eba801e1c3761fe9c9ee489 AS build
 RUN apk add --no-cache npm python3 alpine-sdk
 COPY . /build
 WORKDIR /build
 RUN ./bundle /dist --mysql --pgsql --s3 --sqlite --tools
 
-FROM cronicle/base-alpine 
+FROM cronicle/base-alpine:latest@sha256:75751298e3f56e7500f5be42cc4469ebc2b23b9f8eba801e1c3761fe9c9ee489
 
 # non root user for shell plugin
 ARG CRONICLE_UID=1000


### PR DESCRIPTION
## Problem

The active container build consumed mutable base-image references, so the same source revision could resolve to different build inputs over time.

## Change

- Pin both stages of the active root `Dockerfile` to the same immutable multi-architecture `cronicle/base-alpine` index digest.
- Pin the Alpine builder definition to an immutable `alpine:3.22.2` index digest.
- Keep the readable tags alongside the digests.

This is intentionally scoped to the active publication path.  The unused legacy `Docker/arm64.dockerfile` is not presented as covered by this PR.

## Validation

- Verified both index digests include the required amd64, arm64, and arm/v7 platforms.
- Both `docker buildx --check` runs pass without warnings.
- Real no-cache builds completed for the application image and helper base; runtime smoke confirmed Node, tini, manager/worker entrypoints, and expected data/config permissions.
- Full `npm test`: 92/92 tests, 375 assertions.
- CRLF-aware `git diff --check`: pass.

The issue and initial patch were proposed by a Codex Ultra security review. This version was manually re-analyzed against the active multi-architecture build path, validated with real builds and runtime smoke tests, and is submitted for maintainer review in line with our prior discussion.
