### PR TITLE
fix: scrub AWS session credentials

### DIFF
--- a/lib/api/admin.js
+++ b/lib/api/admin.js
@@ -379,7 +379,8 @@ module.exports = Class.create({
 		const sensitiveKeys = new Set([
 			'secret', 'token', 'secret_key', 'client_secret', 'password', 'passwd', 'private_key',
 			'access_token', 'refresh_token', 'id_token', 'id_token_hint',
-			'oidc_id_token_hint', 'oidc_id_token_hint_enc', 'logout_token', 'api_key', 'secretaccesskey'
+			'oidc_id_token_hint', 'oidc_id_token_hint_enc', 'logout_token', 'api_key',
+			'secretaccesskey', 'sessiontoken'
 		]);
 		const redact = function(value) {
 			if (!value || typeof value !== 'object') return;

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -91,7 +91,10 @@ module.exports = Class.create({
 		// clear env from sensitive data
 		delete process.env["CRONICLE_secret_key"];
 		delete process.env["CRONICLE_oauth__client_secret"];
+		delete process.env["CRONICLE_Storage__AWS__secretAccessKey"];
+		delete process.env["CRONICLE_Storage__AWS__sessionToken"];
 		delete process.env["CRONICLE_Storage__AWS__credentials__secretAccessKey"];
+		delete process.env["CRONICLE_Storage__AWS__credentials__sessionToken"];
 		delete process.env["CRONICLE_Storage__SQL__connection__password"];
 		delete process.env["CRONICLE_Storage__Sftp__connection__password"];
 		delete process.env["CRONICLE_Storage__Redis__password"];

--- a/lib/test.js
+++ b/lib/test.js
@@ -39,6 +39,16 @@ config.web_hook_config_keys = ["base_app_url", "something_custom"];
 config.something_custom = "nonstandard property";
 config.track_manual_jobs = true;
 config.queue_dir = 'data/unitqueue';
+config.Storage.AWS = {
+	secretAccessKey: 'UNIT_TEST_LEGACY_AWS_SECRET',
+	sessionToken: 'UNIT_TEST_LEGACY_AWS_SESSION',
+	region: 'eu-central-1',
+	credentials: {
+		accessKeyId: 'UNIT_TEST_VISIBLE_AWS_KEY',
+		secretAccessKey: 'UNIT_TEST_NESTED_AWS_SECRET',
+		sessionToken: 'UNIT_TEST_NESTED_AWS_SESSION'
+	}
+};
 
 // chdir to the proper server root dir
 process.chdir( require('path').dirname( __dirname ) );
@@ -81,6 +91,10 @@ module.exports = {
 		var self = this;
 		process.env.CRONICLE_password = 'UNIT_TEST_PASSWORD';
 		process.env.CRONICLE_sqlpassword = 'UNIT_TEST_SQL_PASSWORD';
+		process.env.CRONICLE_Storage__AWS__secretAccessKey = 'UNIT_TEST_LEGACY_AWS_SECRET';
+		process.env.CRONICLE_Storage__AWS__sessionToken = 'UNIT_TEST_LEGACY_AWS_SESSION';
+		process.env.CRONICLE_Storage__AWS__credentials__secretAccessKey = 'UNIT_TEST_NESTED_AWS_SECRET';
+		process.env.CRONICLE_Storage__AWS__credentials__sessionToken = 'UNIT_TEST_NESTED_AWS_SESSION';
 		
 		// make sure another unit test isn't running
 		var pid = false;
@@ -180,6 +194,10 @@ module.exports = {
 			test.ok( server.started > 0, 'Cronicle started up successfully');
 			test.ok( !process.env.CRONICLE_password, 'Generic password was removed from the process environment');
 			test.ok( !process.env.CRONICLE_sqlpassword, 'SQL password was removed from the process environment');
+			test.ok( !process.env.CRONICLE_Storage__AWS__secretAccessKey, 'Legacy AWS secret key was removed from the process environment');
+			test.ok( !process.env.CRONICLE_Storage__AWS__sessionToken, 'Legacy AWS session token was removed from the process environment');
+			test.ok( !process.env.CRONICLE_Storage__AWS__credentials__secretAccessKey, 'Nested AWS secret key was removed from the process environment');
+			test.ok( !process.env.CRONICLE_Storage__AWS__credentials__sessionToken, 'Nested AWS session token was removed from the process environment');
 			test.done();
 		},
 
@@ -465,6 +483,27 @@ module.exports = {
 				// save session_id for later
 				session_id = data.session_id;
 				
+				test.done();
+			} );
+		},
+
+		function testAPIConfigViewerRedactsAWSCredentials(test) {
+			var params = { session_id: session_id };
+			request.json( api_url + '/app/get_config', params, function(err, resp, data) {
+				var aws = data.config.Storage.AWS;
+				var sourceAWS = server.config.get().Storage.AWS;
+
+				test.ok( !err, "No error requesting Config Viewer API" );
+				test.ok( resp.statusCode == 200, "HTTP 200 from Config Viewer API" );
+				test.ok( data.code == 0, "Code is zero (no error)" );
+				test.ok( aws.secretAccessKey == '[REDACTED]', "Legacy AWS secret key was redacted" );
+				test.ok( aws.sessionToken == '[REDACTED]', "Legacy AWS session token was redacted" );
+				test.ok( aws.credentials.secretAccessKey == '[REDACTED]', "Nested AWS secret key was redacted" );
+				test.ok( aws.credentials.sessionToken == '[REDACTED]', "Nested AWS session token was redacted" );
+				test.ok( aws.credentials.accessKeyId == 'UNIT_TEST_VISIBLE_AWS_KEY', "AWS access key ID remained visible" );
+				test.ok( aws.region == 'eu-central-1', "AWS region remained visible" );
+				test.ok( sourceAWS.sessionToken == 'UNIT_TEST_LEGACY_AWS_SESSION', "Source AWS config was not mutated" );
+
 				test.done();
 			} );
 		},


### PR DESCRIPTION
## What changes

- hide camel-case AWS `sessionToken` values in Config Viewer
- remove legacy and nested AWS `secretAccessKey` / `sessionToken` environment variables during startup
- keep the regression coverage in the existing `lib/test.js` suite

## Concrete behavior

For example, when Cronicle starts with `CRONICLE_Storage__AWS__sessionToken`, the value is first loaded into server configuration. Before this change, a plugin process could still inherit that environment variable and Config Viewer could return the token unchanged.

After this change, the loaded server configuration keeps the credential for the storage engine, but the startup environment no longer contains it and Config Viewer returns `[REDACTED]`. Non-secret AWS fields such as `region` and `accessKeyId` remain visible.

Both the legacy direct AWS layout and the nested `credentials` layout are covered.

## Validation

- `npm ci`
- `npm test` — 97/97 tests, 448 assertions, 2 suites
- `node --check lib/engine.js`
- `node --check lib/api/admin.js`
- `node --check lib/test.js`
- `node --check test/oidc-logout.test.js`
- `git diff --check upstream/main...HEAD`
