### PR TITLE
fix: isolate plugin transport credentials

### DIFF
--- a/bin/docker-plugin.js
+++ b/bin/docker-plugin.js
@@ -6,6 +6,7 @@ const { Writable } = require('stream');
 const { EOL } = require('os');
 const path = require('path')
 const fs = require('fs')
+const PluginEnv = require('../lib/plugin-env.js')
 
 // cronicle should send job json to stdin
 let job = {}
@@ -144,11 +145,8 @@ const stderr = new Writable({
 let truncVar = parseInt(process.env['TRUNC_VAR']) // optionally remove DOCKER_ prefix from passed vars
 
 // env variables
-let exclude = ['SSH_HOST', 'SSH_KEY', 'SSH_PASSWORD', 'DOCKER_PASSWORD']
-let include = ['BASE_URL', 'BASE_APP_URL', 'DOCKER_HOST', 'PULL_IMAGE', 'KEEP_CONTAINER', 'IMAGE', 'ENTRYPOINT_PATH']
-let vars = Object.entries(process.env)
-    .filter(([k, v]) => ((k.startsWith('JOB_') || k.startsWith('DOCKER_') || k.startsWith('ARG') || include.indexOf(k) > -1) && exclude.indexOf(k) === -1))
-    .map(([k, v]) => `${truncVar ? k.replace(/^DOCKER_/, '') : k}=${v}`)
+let vars = PluginEnv.buildDockerPluginEnv(process.env, truncVar)
+    .map(([k, v]) => `${k}=${v}`)
 
 // CONTAINER SETTING
 const createOptions = {

--- a/bin/kube-plugin.mjs
+++ b/bin/kube-plugin.mjs
@@ -6,6 +6,7 @@ import { readFileSync } from 'fs'
 import { PassThrough } from 'stream';
 import { EOL } from 'os'
 import { load } from 'js-yaml'
+import PluginEnv from '../lib/plugin-env.js'
 
 // cronicle should send job json to stdin
 let job = {}
@@ -82,7 +83,6 @@ if (KUBE_CONFIG && KUBE_CONFIG.trim() !== "") {
   try { kc.loadFromString(KUBE_CONFIG) }
   catch {
     printWarning("Invalid kube config setting. Falling back to default")
-    console.log(KUBE_CONFIG)
     kc.loadFromDefault()
   }
 }
@@ -116,12 +116,9 @@ process.on(sig, async (message) => {
 
 
 // --------- Resolve ENV Variables (to pass to pod) -------------------------//
-let exclude = ['KUBE_CONFIG']
-let include = ['BASE_URL', 'BASE_APP_URL', 'NAMESPACE', 'KEEP_POD', 'IMAGE']
 let truncVar = parseInt(process.env['TRUNC_VAR'])
-let envVars = Object.entries(process.env)
-  .filter(([k, v]) => ((k.startsWith('JOB_') || k.startsWith('KUBE_') || k.startsWith('ARG') || include.indexOf(k) > -1) && exclude.indexOf(k) === -1))
-  .map(([k, v]) => { return { name: (truncVar ? k.replace(/^KUBE_/, '') : k), value: v } })
+let envVars = PluginEnv.buildKubePluginEnv(process.env, truncVar)
+  .map(([name, value]) => { return { name, value } })
 
 
 // ------------------------ POD/JOB Manifest for Kube-Run --------------------------------

--- a/bin/ssh-plugin.js
+++ b/bin/ssh-plugin.js
@@ -6,6 +6,7 @@ const conn = new Client();
 const {EOL} = require('os')
 const JSONStream = require('pixl-json-stream');
 const { spawn } = require('child_process')
+const PluginEnv = require('../lib/plugin-env.js')
 
 const print = (text) => {
 	process.stdout.write(text + EOL);
@@ -44,7 +45,10 @@ function printJSONmessage(complete, code, desc) {
 
         let json = parseInt(process.env['JSON'] || '')
 
-        const child = process.platform == 'win32' ?  spawn('cmd', ['/c', command]) : spawn('sh', ['-c', command])
+		const childEnv = PluginEnv.sanitizeSSHLocalEnv(process.env);
+		const child = process.platform == 'win32' ?
+			spawn('cmd', ['/c', command], { env: childEnv }) :
+			spawn('sh', ['-c', command], { env: childEnv })
 
         child.on('error', (err) => printJSONmessage(1, 1, `Script failed: ${err.message}`))
 

--- a/bin/sshx-plugin.js
+++ b/bin/sshx-plugin.js
@@ -5,6 +5,7 @@ const { Client } = require('ssh2');
 const conn = new Client();
 const { EOL } = require('os')
 const fs = require('fs')
+const PluginEnv = require('../lib/plugin-env.js')
 
 // read job info from stdin (sent by Cronicle engine)
 const job = JSON.parse(fs.readFileSync(process.stdin.fd))
@@ -53,13 +54,10 @@ let SCRIPT_BASE64 = Buffer.from(process.env['SCRIPT'] ?? '#!/usr/bin/env sh\nech
 let prefix = process.env['PREFIX'] || ''
 
 // generate stdin script to pass variables and user script in base64 format
-let exclude = ['SSH_HOST', 'SSH_KEY', 'SSH_PASSWORD']
-let include = ['BASE_URL', 'BASE_APP_URL']
 process.env['JOB_CHAIN_DATA'] = JSON.stringify(job.chain_data) || 'has no data'
 
-let vars = Object.entries(process.env)
-    .filter(([k, v]) => ((k.startsWith('JOB_') || k.startsWith('SSH_') || k.startsWith('ARG') || include.indexOf(k) > -1) && exclude.indexOf(k) === -1))
-    .map(([key, value]) => `export ${truncVar ? key.replace(/^SSH_/, '') : key}=$(printf "${Buffer.from(value).toString('base64')}" | base64 -di)`)
+let vars = PluginEnv.buildSSHXPluginEnv(process.env, truncVar)
+    .map(([key, value]) => `export ${key}=$(printf "${Buffer.from(value).toString('base64')}" | base64 -di)`)
     .join('\n')
 
 let script = `
@@ -245,4 +243,3 @@ process.on(sig, (signal) => {
         if (process.connected) process.disconnect()
     }
 })
-

--- a/lib/job.js
+++ b/lib/job.js
@@ -14,6 +14,7 @@ const Tools = require("pixl-tools");
 const JSONStream = require("pixl-json-stream");
 const PixlMail = require('pixl-mail');
 const dotenv = require('dotenv');
+const PluginEnv = require('./plugin-env.js');
 
 //const si = require('systeminformation');
 const isUnix = os.platform() != 'win32';
@@ -298,7 +299,9 @@ module.exports = Class.create({
 						if (plugin.gid) job.gid = plugin.gid;
 					}
 
-					job.env = self.server.config.get('job_env') || {} 
+					// Each launch gets its own manager-computed environment.  BASE_URL and
+					// BASE_APP_URL must not mutate the shared job_env configuration.
+					job.env = Tools.copyHash(self.server.config.get('job_env') || {}, true)
 					let proto = 'http://'
 					let port = self.server.config.get('WebServer').http_port
 					if(self.server.config.get('WebServer').https) {
@@ -652,19 +655,9 @@ module.exports = Class.create({
 		child_opts.env['JOB_NOW'] = job.now;
 		child_opts.env['PWD'] = child_opts.cwd;
 
-		// copy all top-level job keys into child env, if number/string/boolean
-		for (var key in job) {
-			switch (typeof (job[key])) {
-				case 'string':
-				case 'number':
-					child_opts.env['JOB_' + key.toUpperCase()] = '' + job[key];
-					break;
-
-				case 'boolean':
-					child_opts.env['JOB_' + key.toUpperCase()] = job[key] ? 1 : 0;
-					break;
-			}
-		}
+		// Export public job metadata only.  Encrypted bundles and manager-only
+		// request metadata must not become JOB_* variables in plugin processes.
+		PluginEnv.copyPublicJobFieldsToEnv(job, child_opts.env);
 
 		// get uid / gid info for child env vars. Ignore for Win32
 		if (isUnix) {
@@ -731,7 +724,12 @@ module.exports = Class.create({
 			}
 		}
 
-		this.logDebug(9, "Child spawn options:", child_opts);
+		this.logDebug(9, "Child spawn options:", {
+			cwd: child_opts.cwd,
+			uid: child_opts.uid,
+			gid: child_opts.gid,
+			env_keys: Object.keys(child_opts.env).sort()
+		});
 
 		// create log file, write header to it
 		var dargs = Tools.getDateArgs(new Date());

--- a/lib/plugin-env.js
+++ b/lib/plugin-env.js
@@ -1,0 +1,228 @@
+// Helpers for keeping Cronicle's encrypted job metadata and connection
+// credentials out of plugin-created child environments.
+
+const PRIVATE_JOB_ENV_KEYS = new Set([
+	'JOB_ENV', 'JOB_SECRET', 'JOB_GLOBALENV', 'JOB_CAT_SECRET',
+	'JOB_PLUG_SECRET', 'JOB_LOCAL_SECRET', 'JOB_API_KEY',
+	'JOB_SESSION_ID', 'JOB_TOKEN'
+]);
+
+const CONNECTION_SECRET_ENV_KEYS = new Set([
+	'SSH_PASSWORD', 'SSH_KEY', 'SSH_PASSPHRASE',
+	'DOCKER_PASSWORD', 'KUBE_CONFIG'
+]);
+
+const SENSITIVE_QUERY_FIELDS = new Set([
+	'password', 'passwd', 'passphrase', 'privatekey', 'sshkey',
+	'token', 'accesstoken', 'refreshtoken', 'idtoken', 'sessiontoken',
+	'secret', 'secretkey', 'clientsecret', 'apikey', 'authorization'
+]);
+
+function normalizeCredentialKey(key) {
+	return String(key || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function normalizeEnvKey(key) {
+	return String(key || '').toUpperCase();
+}
+
+function findEnvKey(env, requestedKey) {
+	if (!env || !requestedKey) return null;
+	if (Object.prototype.hasOwnProperty.call(env, requestedKey)) return requestedKey;
+	const normalized = normalizeEnvKey(requestedKey);
+	return Object.keys(env).find(function(key) {
+		return normalizeEnvKey(key) === normalized;
+	}) || null;
+}
+
+function isSensitiveQueryField(key) {
+	const normalized = normalizeCredentialKey(key);
+	return SENSITIVE_QUERY_FIELDS.has(normalized) ||
+		normalized.endsWith('password') || normalized.endsWith('passwd') ||
+		normalized.endsWith('passphrase') || normalized.endsWith('privatekey') ||
+		normalized.endsWith('token') || normalized.endsWith('secret') ||
+		normalized.endsWith('apikey');
+}
+
+function parseConnectionUri(value) {
+	if (typeof value !== 'string' || !value.trim()) return null;
+	let candidate = value.trim();
+	try {
+		if (!candidate.match(/^[a-z][a-z0-9+.-]*:\/\//i)) {
+			if (!candidate.includes('@') && !candidate.includes('?')) return null;
+			candidate = 'ssh://' + candidate;
+		}
+		return new URL(candidate);
+	}
+	catch (err) {
+		return null;
+	}
+}
+
+function isCredentialedConnection(value) {
+	const uri = parseConnectionUri(value);
+	if (!uri) return false;
+	// Userinfo is connection-only even when the URI omits a password.  Some
+	// transports place an access token in the username slot.
+	if (uri.username || uri.password) return true;
+	for (const key of uri.searchParams.keys()) {
+		if (isSensitiveQueryField(key)) return true;
+	}
+	return false;
+}
+
+function resolveConnectionEnv(env, key) {
+	const keyName = findEnvKey(env, key);
+	const raw = keyName ? env[keyName] : undefined;
+	if (typeof raw !== 'string' || !raw) {
+		return { raw: raw, value: raw, keyName: keyName, refName: null };
+	}
+	const refName = findEnvKey(env, raw);
+	return {
+		raw: raw,
+		value: refName ? env[refName] : raw,
+		keyName: keyName,
+		refName: refName
+	};
+}
+
+function isPrivateJobEnvKey(key) {
+	return PRIVATE_JOB_ENV_KEYS.has(String(key || '').toUpperCase());
+}
+
+function copyPublicJobFieldsToEnv(job, env) {
+	Object.keys(job || {}).forEach(function(key) {
+		const envKey = 'JOB_' + key.toUpperCase();
+		if (isPrivateJobEnvKey(envKey)) return;
+		switch (typeof job[key]) {
+			case 'string':
+			case 'number':
+				env[envKey] = '' + job[key];
+				break;
+			case 'boolean':
+				env[envKey] = job[key] ? 1 : 0;
+				break;
+		}
+	});
+	return env;
+}
+
+function buildPluginEnvEntries(env, options) {
+	options = options || {};
+	// Preserve the plugins' existing case-sensitive positive allowlist on POSIX.
+	// Only security comparisons below are normalized for Windows semantics.
+	const prefixes = options.prefixes || [];
+	const include = new Set(options.include || []);
+	const blocked = new Set((options.exclude || []).map(normalizeEnvKey));
+	const truncatePrefix = options.truncatePrefix || '';
+
+	PRIVATE_JOB_ENV_KEYS.forEach(function(key) { blocked.add(normalizeEnvKey(key)); });
+	CONNECTION_SECRET_ENV_KEYS.forEach(function(key) { blocked.add(normalizeEnvKey(key)); });
+	(options.consumedKeys || []).forEach(function(key) {
+		if (key) blocked.add(normalizeEnvKey(key));
+	});
+	(options.connectionKeys || []).forEach(function(key) {
+		const resolved = resolveConnectionEnv(env, key);
+		if (options.consumeConnections || isCredentialedConnection(resolved.value)) {
+			blocked.add(normalizeEnvKey(key));
+			if (resolved.keyName) blocked.add(normalizeEnvKey(resolved.keyName));
+			if (resolved.refName) blocked.add(normalizeEnvKey(resolved.refName));
+		}
+	});
+
+	return Object.entries(env || {}).filter(function(entry) {
+		const key = entry[0];
+		const normalizedKey = normalizeEnvKey(key);
+		if (blocked.has(normalizedKey) || isPrivateJobEnvKey(normalizedKey)) return false;
+		return include.has(key) || prefixes.some(function(prefix) {
+			return key.startsWith(prefix);
+		});
+	}).map(function(entry) {
+		let key = entry[0];
+		if (truncatePrefix && key.startsWith(truncatePrefix)) {
+			key = key.substring(truncatePrefix.length);
+		}
+		return [key, entry[1]];
+	});
+}
+
+function buildDockerPluginEnv(env, truncatePrefix) {
+	return buildPluginEnvEntries(env, {
+		prefixes: ['JOB_', 'DOCKER_', 'ARG'],
+		include: [
+			'BASE_URL', 'BASE_APP_URL', 'DOCKER_HOST', 'PULL_IMAGE',
+			'KEEP_CONTAINER', 'IMAGE', 'ENTRYPOINT_PATH'
+		],
+		exclude: ['SSH_HOST'],
+		// Keep credential-free endpoints for compatibility with jobs that run a
+		// Docker client inside the child container.  Credentialed endpoints and
+		// their environment references remain private to this transport plugin.
+		connectionKeys: ['DOCKER_HOST'],
+		truncatePrefix: truncatePrefix ? 'DOCKER_' : ''
+	});
+}
+
+function buildKubePluginEnv(env, truncatePrefix) {
+	return buildPluginEnvEntries(env, {
+		prefixes: ['JOB_', 'KUBE_', 'ARG'],
+		include: ['BASE_URL', 'BASE_APP_URL', 'NAMESPACE', 'KEEP_POD', 'IMAGE'],
+		// JOB_ARG is user runtime input for this plugin, not a Kubernetes
+		// connection selector, so it remains available to the child pod.
+		connectionKeys: [],
+		truncatePrefix: truncatePrefix ? 'KUBE_' : ''
+	});
+}
+
+function buildSSHXPluginEnv(env, truncatePrefix) {
+	const sshHost = resolveConnectionEnv(env || {}, 'SSH_HOST');
+	const selectedKey = sshHost.raw ? 'SSH_HOST' : 'JOB_ARG';
+	const selected = selectedKey === 'SSH_HOST' ? sshHost :
+		resolveConnectionEnv(env || {}, selectedKey);
+	return buildPluginEnvEntries(env, {
+		prefixes: ['JOB_', 'SSH_', 'ARG'],
+		include: ['BASE_URL', 'BASE_APP_URL'],
+		connectionKeys: ['SSH_HOST', 'JOB_ARG'],
+		consumedKeys: [selected.keyName || selectedKey, selected.refName],
+		truncatePrefix: truncatePrefix ? 'SSH_' : ''
+	});
+}
+
+function sanitizeProcessEnv(env, options) {
+	options = options || {};
+	const blocked = new Set((options.exclude || []).map(normalizeEnvKey));
+	PRIVATE_JOB_ENV_KEYS.forEach(function(key) { blocked.add(normalizeEnvKey(key)); });
+	CONNECTION_SECRET_ENV_KEYS.forEach(function(key) { blocked.add(normalizeEnvKey(key)); });
+	(options.connectionKeys || []).forEach(function(key) {
+		const resolved = resolveConnectionEnv(env, key);
+		blocked.add(normalizeEnvKey(key));
+		if (resolved.keyName) blocked.add(normalizeEnvKey(resolved.keyName));
+		if (resolved.refName) blocked.add(normalizeEnvKey(resolved.refName));
+	});
+	const result = {};
+	Object.keys(env || {}).forEach(function(key) {
+		const normalizedKey = normalizeEnvKey(key);
+		if (!blocked.has(normalizedKey) && !isPrivateJobEnvKey(normalizedKey)) {
+			result[key] = env[key];
+		}
+	});
+	return result;
+}
+
+function sanitizeSSHLocalEnv(env) {
+	return sanitizeProcessEnv(env, { connectionKeys: ['SSH_HOST', 'JOB_ARG'] });
+}
+
+module.exports = {
+	CONNECTION_SECRET_ENV_KEYS,
+	PRIVATE_JOB_ENV_KEYS,
+	buildDockerPluginEnv,
+	buildKubePluginEnv,
+	buildPluginEnvEntries,
+	buildSSHXPluginEnv,
+	copyPublicJobFieldsToEnv,
+	isCredentialedConnection,
+	isPrivateJobEnvKey,
+	resolveConnectionEnv,
+	sanitizeProcessEnv,
+	sanitizeSSHLocalEnv
+};

--- a/lib/test.js
+++ b/lib/test.js
@@ -1461,6 +1461,61 @@ module.exports = {
 			} );
 		},
 
+		function testRemoteLaunchDoesNotMutateManagerJobEnv(test) {
+			var self = this;
+			var originalJobEnv = Tools.copyHash(server.config.get('job_env') || {}, true);
+			var configuredJobEnv = { REMOTE_PUBLIC_VALUE: 'manager-value' };
+			var capturedJob = null;
+			var remoteWorker = {
+				hostname: 'remote-env-worker',
+				manager: 0,
+				disabled: 0,
+				socket: {
+					emit: function(event, payload) {
+						if (event == 'launch_job') capturedJob = payload;
+					}
+				}
+			};
+			var cleanup = function() {
+				server.config.set('job_env', originalJobEnv);
+				delete cronicle.workers[remoteWorker.hostname];
+			};
+
+			server.config.set('job_env', configuredJobEnv);
+			cronicle.workers[remoteWorker.hostname] = remoteWorker;
+
+			storage.listFind('global/schedule', { id: this.event_id }, function(err, event) {
+				if (err || !event) {
+					cleanup();
+					test.ok(false, 'Failed to load event for remote launch: ' + err);
+					return test.done();
+				}
+
+				var remoteEvent = Tools.copyHash(event, true);
+				remoteEvent.target = remoteWorker.hostname;
+				remoteEvent.max_children = 0;
+				remoteEvent.web_hook = '';
+				remoteEvent.web_hook_start = '';
+				remoteEvent.web_hook_error = '';
+
+				cronicle.launchJob(remoteEvent, function(launchErr, jobs) {
+					test.ok(!launchErr, 'Remote job launch succeeded');
+					test.ok(jobs && jobs.length == 1, 'Remote launch returned one job');
+					test.ok(!!capturedJob, 'Remote launch crossed the worker socket');
+					if (capturedJob) {
+						test.ok(capturedJob.env.REMOTE_PUBLIC_VALUE == 'manager-value', 'Remote job retained manager job_env');
+						test.ok(capturedJob.env.BASE_URL.indexOf(server.hostname) > -1, 'Remote job BASE_URL points to manager');
+						test.ok(capturedJob.env.BASE_APP_URL == server.config.get('base_app_url'), 'Remote job retained manager BASE_APP_URL');
+						test.ok(capturedJob.env !== server.config.get('job_env'), 'Remote job owns an independent environment copy');
+					}
+					test.ok(!('BASE_URL' in server.config.get('job_env')), 'Launch did not add BASE_URL to shared job_env');
+					test.ok(!('BASE_APP_URL' in server.config.get('job_env')), 'Launch did not add BASE_APP_URL to shared job_env');
+					cleanup();
+					test.done();
+				});
+			});
+		},
+
 		function testLaunchJobStripsEventLaunchContext(test) {
 			// make sure event/API payloads cannot override admin-only Plugin launch options
 			var orig_launch_local_job = cronicle.launchLocalJob;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"license": "MIT",
 	"main": "lib/main.js",
 	"scripts": {
-		"test": "pixl-unit lib/test.js test/oidc-logout.test.js",
+		"test": "pixl-unit lib/test.js test/oidc-logout.test.js test/plugin-secret-environment-boundaries.test.js",
 		"boot": "pixl-boot install",
 		"unboot": "pixl-boot uninstall"
 	},

--- a/test/fixtures/kube-client-loader.mjs
+++ b/test/fixtures/kube-client-loader.mjs
@@ -1,0 +1,8 @@
+const mockUrl = new URL('./kube-client-probe.mjs', import.meta.url).href;
+
+export async function resolve(specifier, context, nextResolve) {
+	if (specifier === '@kubernetes/client-node') {
+		return { url: mockUrl, shortCircuit: true };
+	}
+	return nextResolve(specifier, context);
+}

--- a/test/fixtures/kube-client-probe.mjs
+++ b/test/fixtures/kube-client-probe.mjs
@@ -1,0 +1,27 @@
+export class CoreV1Api {
+	async createNamespacedPod({ body }) {
+		process.stdout.write(
+			'KUBE_ENV_PROBE=' + JSON.stringify(body.spec.containers[0].env) + '\n'
+		);
+		return {};
+	}
+	async readNamespacedPod() { return { spec: {} }; }
+}
+
+export class AppsV1Api {}
+export class BatchV1Api {}
+
+export class KubeConfig {
+	loadFromString() { throw new Error('probe invalid config'); }
+	loadFromDefault() {}
+	makeApiClient(ApiClass) { return new ApiClass(); }
+	getCurrentCluster() { return { name: 'probe-cluster' }; }
+}
+
+export class Watch {
+	async watch() { return { abort: function() {} }; }
+}
+
+export class Log {
+	async log() { return { abort: function() {} }; }
+}

--- a/test/fixtures/plugin-runtime-probe.cjs
+++ b/test/fixtures/plugin-runtime-probe.cjs
@@ -1,0 +1,66 @@
+const Module = require('node:module');
+const { EventEmitter } = require('node:events');
+const { PassThrough } = require('node:stream');
+
+const originalLoad = Module._load;
+
+class DockerProbe {
+	constructor() {
+		this.modem = {
+			host: null,
+			protocol: null,
+			demuxStream: function() {},
+			followProgress: function(stream, callback) { callback(); }
+		};
+	}
+
+	getImage() { return {}; }
+	getVolume() { return { remove: async function() {} }; }
+	async pull() { return new PassThrough(); }
+
+	async createContainer(options) {
+		process.stdout.write('DOCKER_ENV_PROBE=' + JSON.stringify(options.Env) + '\n');
+		return {
+			modem: this.modem,
+			putArchive: async function() {},
+			attach: async function() { return new PassThrough(); },
+			inspect: async function() { return { Mounts: [] }; },
+			start: async function() {},
+			wait: async function() { return { StatusCode: 0 }; }
+		};
+	}
+}
+
+class SSHProbeClient extends EventEmitter {
+	connect() {
+		process.nextTick(() => this.emit('ready'));
+		return this;
+	}
+
+	exec(command, options, callback) {
+		if (typeof options === 'function') {
+			callback = options;
+		}
+		const stream = new EventEmitter();
+		stream.stderr = new EventEmitter();
+		let input = '';
+		stream.stdin = {
+			write: function(chunk) { input += String(chunk); },
+			end: function() {
+				process.stdout.write(
+					'SSHX_SCRIPT_PROBE=' + Buffer.from(input).toString('base64') + '\n'
+				);
+				process.nextTick(() => stream.emit('close', 0, null));
+			}
+		};
+		callback(null, stream);
+	}
+
+	end() {}
+}
+
+Module._load = function(request, parent, isMain) {
+	if (request === 'dockerode') return DockerProbe;
+	if (request === 'ssh2') return { Client: SSHProbeClient };
+	return originalLoad.call(this, request, parent, isMain);
+};

--- a/test/fixtures/print-selected-env.cjs
+++ b/test/fixtures/print-selected-env.cjs
@@ -1,0 +1,10 @@
+process.stdout.write('SSH_LOCAL_ENV_PROBE=' + JSON.stringify({
+	BASE_URL: process.env.BASE_URL,
+	USER_RUNTIME_SECRET: process.env.USER_RUNTIME_SECRET,
+	JOB_SECRET: process.env.JOB_SECRET,
+	JOB_GLOBALENV: process.env.JOB_GLOBALENV,
+	SSH_HOST: process.env.SSH_HOST,
+	SSH_PASSWORD: process.env.SSH_PASSWORD,
+	SSH_KEY: process.env.SSH_KEY,
+	SSH_PASSPHRASE: process.env.SSH_PASSPHRASE
+}) + '\n');

--- a/test/plugin-secret-environment-boundaries.test.js
+++ b/test/plugin-secret-environment-boundaries.test.js
@@ -1,0 +1,326 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const PluginEnv = require('../lib/plugin-env');
+
+const repoRoot = path.resolve(__dirname, '..');
+const runtimeProbe = path.join(__dirname, 'fixtures', 'plugin-runtime-probe.cjs');
+const kubeLoader = path.join(__dirname, 'fixtures', 'kube-client-loader.mjs');
+const localEnvProbe = path.join(__dirname, 'fixtures', 'print-selected-env.cjs');
+
+const tests = [];
+function test(name, callback) {
+	const wrapped = function(testHandle) {
+		Promise.resolve().then(callback).then(function() {
+			testHandle.done();
+		}).catch(function(err) {
+			testHandle.ok(false, name + ': ' + (err && err.stack || err));
+			testHandle.done();
+		});
+	};
+	Object.defineProperty(wrapped, 'name', {
+		value: name.replace(/[^A-Za-z0-9]+/g, '_'), configurable: true
+	});
+	tests.push(wrapped);
+}
+
+function baseEnv(extra) {
+	return Object.assign({
+		PATH: process.env.PATH,
+		HOME: process.env.HOME,
+		LANG: process.env.LANG || 'C',
+		BASE_URL: 'https://manager.internal',
+		BASE_APP_URL: 'https://cronicle.example'
+	}, extra || {});
+}
+
+function runNode(args, options) {
+	const spawnOptions = Object.assign({
+		cwd: repoRoot,
+		encoding: 'utf8',
+		timeout: 15000
+	}, options || {});
+	let inputPath = null;
+	let inputFd = null;
+	if (Object.prototype.hasOwnProperty.call(spawnOptions, 'input')) {
+		inputPath = path.join(
+			os.tmpdir(), 'cronicle-plugin-env-' + process.pid + '-' + Date.now() + '.json'
+		);
+		fs.writeFileSync(inputPath, spawnOptions.input);
+		inputFd = fs.openSync(inputPath, 'r');
+		delete spawnOptions.input;
+		spawnOptions.stdio = [inputFd, 'pipe', 'pipe'];
+	}
+	let result;
+	try {
+		result = spawnSync(process.execPath, args, spawnOptions);
+	}
+	finally {
+		if (inputFd !== null) fs.closeSync(inputFd);
+		if (inputPath) fs.unlinkSync(inputPath);
+	}
+	if (result.error) throw result.error;
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	return result;
+}
+
+function readProbe(stdout, marker) {
+	const line = String(stdout).split(/\r?\n/).find((item) => item.startsWith(marker));
+	assert.ok(line, 'missing runtime probe ' + marker + ' in: ' + stdout);
+	return line.substring(marker.length);
+}
+
+test('manager job environment retains BASE_URL and user runtime secrets', () => {
+	const childEnv = {
+		BASE_URL: 'https://manager.internal',
+		BASE_APP_URL: 'https://cronicle.example',
+		USER_RUNTIME_SECRET: 'decrypted-for-user-code'
+	};
+	PluginEnv.copyPublicJobFieldsToEnv({
+		id: 'j1', debug: true, attempts: 2,
+		secret: 'encrypted-event', globalenv: 'encrypted-global',
+		cat_secret: 'encrypted-category', plug_secret: 'encrypted-plugin',
+		local_secret: 'encrypted-local', api_key: 'request-secret'
+	}, childEnv);
+
+	assert.equal(childEnv.BASE_URL, 'https://manager.internal');
+	assert.equal(childEnv.BASE_APP_URL, 'https://cronicle.example');
+	assert.equal(childEnv.USER_RUNTIME_SECRET, 'decrypted-for-user-code');
+	assert.equal(childEnv.JOB_ID, 'j1');
+	assert.equal(childEnv.JOB_DEBUG, 1);
+	assert.equal(childEnv.JOB_ATTEMPTS, '2');
+	['JOB_SECRET', 'JOB_GLOBALENV', 'JOB_CAT_SECRET', 'JOB_PLUG_SECRET',
+		'JOB_LOCAL_SECRET', 'JOB_API_KEY'].forEach((key) => {
+		assert.equal(Object.hasOwn(childEnv, key), false, key);
+	});
+});
+
+test('runtime job metadata remains available to existing plugin consumers', () => {
+	const childEnv = {};
+	PluginEnv.copyPublicJobFieldsToEnv({
+		command: 'bin/terminal-plugin.js',
+		cwd: '/opt/cronicle',
+		uid: 1000,
+		gid: 1000,
+		log_file: '/var/log/cronicle/jobs/j1.log',
+		web_hook: 'https://hooks.example/runtime',
+		web_hook_start: 'https://hooks.example/start',
+		web_hook_error: 'https://hooks.example/error',
+		post_data: 'runtime-post-data',
+		headers: 'X-Runtime: visible',
+		stdin_script: 'runtime bootstrap'
+	}, childEnv);
+
+	assert.deepEqual(childEnv, {
+		JOB_COMMAND: 'bin/terminal-plugin.js',
+		JOB_CWD: '/opt/cronicle',
+		JOB_UID: '1000',
+		JOB_GID: '1000',
+		JOB_LOG_FILE: '/var/log/cronicle/jobs/j1.log',
+		JOB_WEB_HOOK: 'https://hooks.example/runtime',
+		JOB_WEB_HOOK_START: 'https://hooks.example/start',
+		JOB_WEB_HOOK_ERROR: 'https://hooks.example/error',
+		JOB_POST_DATA: 'runtime-post-data',
+		JOB_HEADERS: 'X-Runtime: visible',
+		JOB_STDIN_SCRIPT: 'runtime bootstrap'
+	});
+});
+
+test('Docker plugin passes public runtime values without connection credentials', () => {
+	const result = runNode(['-r', runtimeProbe, path.join(repoRoot, 'bin', 'docker-plugin.js')], {
+		input: '{}\n',
+		env: baseEnv({
+			JOB_ID: 'j-docker',
+			JOB_ARG: 'ssh://user:arg-password@arg-host',
+			JOB_SECRET: 'encrypted-event',
+			JOB_GLOBALENV: 'encrypted-global',
+			DOCKER_HOST: 'DOCKER_REMOTE',
+			DOCKER_REMOTE: 'ssh://user:docker-password@docker-host',
+			DOCKER_VISIBLE: 'visible',
+			DOCKER_PASSWORD: 'registry-password',
+			SSH_PASSWORD: 'ssh-password',
+			SSH_KEY: 'ssh-key',
+			SSH_PASSPHRASE: 'ssh-passphrase',
+			ARG1: 'public-arg',
+			IMAGE: 'alpine',
+			PULL_IMAGE: '0'
+		})
+	});
+	const entries = JSON.parse(readProbe(result.stdout, 'DOCKER_ENV_PROBE='));
+	const passed = Object.fromEntries(entries.map((item) => item.split(/=(.*)/s).slice(0, 2)));
+
+	assert.equal(passed.JOB_ID, 'j-docker');
+	assert.equal(passed.DOCKER_VISIBLE, 'visible');
+	assert.equal(passed.ARG1, 'public-arg');
+	assert.equal(passed.BASE_URL, 'https://manager.internal');
+	assert.equal(passed.JOB_ARG, 'ssh://user:arg-password@arg-host');
+	['JOB_SECRET', 'JOB_GLOBALENV', 'DOCKER_HOST', 'DOCKER_REMOTE',
+		'DOCKER_PASSWORD', 'SSH_PASSWORD', 'SSH_KEY', 'SSH_PASSPHRASE']
+		.forEach((key) => assert.equal(Object.hasOwn(passed, key), false, key));
+});
+
+test('connection URI detection covers username tokens and normalized query keys', () => {
+	[
+		'ssh://TOKEN_ONLY@docker-host',
+		'https://docker-host?access_token=private',
+		'https://docker-host?client-secret=private',
+		'https://docker-host?sessionToken=private',
+		'https://docker-host?apiKey=private',
+		'https://docker-host?customRefresh_Token=private'
+	].forEach((uri) => {
+		const passed = Object.fromEntries(PluginEnv.buildDockerPluginEnv({
+			DOCKER_HOST: 'DOCKER_REMOTE',
+			DOCKER_REMOTE: uri,
+			DOCKER_VISIBLE: 'visible'
+		}, false));
+		assert.equal(Object.hasOwn(passed, 'DOCKER_HOST'), false, uri);
+		assert.equal(Object.hasOwn(passed, 'DOCKER_REMOTE'), false, uri);
+		assert.equal(passed.DOCKER_VISIBLE, 'visible', uri);
+	});
+
+	const compatible = Object.fromEntries(PluginEnv.buildDockerPluginEnv({
+		DOCKER_HOST: 'tcp://docker.example:2375',
+		DOCKER_VISIBLE: 'visible'
+	}, false));
+	assert.equal(compatible.DOCKER_HOST, 'tcp://docker.example:2375');
+	assert.equal(compatible.DOCKER_VISIBLE, 'visible');
+});
+
+test('environment filtering is case-insensitive at security boundaries', () => {
+	const docker = Object.fromEntries(PluginEnv.buildDockerPluginEnv({
+		JOB_Secret: 'encrypted-event',
+		DOCKER_password: 'registry-password',
+		SSH_Key: 'ssh-key',
+		DOCKER_Visible: 'visible'
+	}, false));
+	assert.deepEqual(docker, { DOCKER_Visible: 'visible' });
+
+	const kube = Object.fromEntries(PluginEnv.buildKubePluginEnv({
+		JOB_GlobalEnv: 'encrypted-global',
+		KUBE_Config: 'private-config',
+		KUBE_Visible: 'visible'
+	}, false));
+	assert.deepEqual(kube, { KUBE_Visible: 'visible' });
+
+	const sshx = Object.fromEntries(PluginEnv.buildSSHXPluginEnv({
+		SSH_Host: 'SSH_Remote',
+		SSH_Remote: 'ssh://token-only@host',
+		SSH_Password: 'connection-password',
+		SSH_Key: 'connection-key',
+		SSH_Passphrase: 'connection-passphrase',
+		SSH_TmpDir: '/safe/tmp'
+	}, false));
+	assert.deepEqual(sshx, { SSH_TmpDir: '/safe/tmp' });
+
+	const local = PluginEnv.sanitizeSSHLocalEnv({
+		Job_Secret: 'encrypted-event',
+		Ssh_Host: 'Ssh_Remote',
+		Ssh_Remote: 'ssh://token-only@host',
+		Ssh_Password: 'connection-password',
+		Ssh_Key: 'connection-key',
+		Ssh_Passphrase: 'connection-passphrase',
+		User_Runtime_Secret: 'decrypted-for-user-code'
+	});
+	assert.deepEqual(local, { User_Runtime_Secret: 'decrypted-for-user-code' });
+});
+
+test('Kubernetes plugin omits config and credentials from the real pod manifest', () => {
+	const result = runNode([
+		'--experimental-loader', kubeLoader,
+		path.join(repoRoot, 'bin', 'kube-plugin.mjs')
+	], {
+		input: JSON.stringify({ id: 'j-kube', params: {} }),
+		env: baseEnv({
+			JOB_ID: 'j-kube',
+			JOB_ARG: 'ssh://user:arg-password@arg-host',
+			JOB_SECRET: 'encrypted-event',
+			JOB_GLOBALENV: 'encrypted-global',
+			KUBE_CONFIG: 'KUBE_CONFIG_PRIVATE_SENTINEL',
+			KUBE_VISIBLE: 'visible',
+			ARG1: 'public-arg',
+			IMAGE: 'alpine',
+			VERBOSE: '1'
+		})
+	});
+	const entries = JSON.parse(readProbe(result.stdout, 'KUBE_ENV_PROBE='));
+	const passed = Object.fromEntries(entries.map((item) => [item.name, item.value]));
+
+	assert.equal(result.stdout.includes('KUBE_CONFIG_PRIVATE_SENTINEL'), false);
+	assert.equal(passed.JOB_ID, 'j-kube');
+	assert.equal(passed.KUBE_VISIBLE, 'visible');
+	assert.equal(passed.ARG1, 'public-arg');
+	assert.equal(passed.BASE_URL, 'https://manager.internal');
+	assert.equal(passed.JOB_ARG, 'ssh://user:arg-password@arg-host');
+	['JOB_SECRET', 'JOB_GLOBALENV', 'KUBE_CONFIG']
+		.forEach((key) => assert.equal(Object.hasOwn(passed, key), false, key));
+});
+
+test('SSH local mode keeps user runtime values out of connection-secret scope', () => {
+	const command = '"' + process.execPath + '" "' + localEnvProbe + '"';
+	const result = runNode([path.join(repoRoot, 'bin', 'ssh-plugin.js')], {
+		input: '',
+		env: baseEnv({
+			JSON: '1',
+			SSH_HOST: 'localhost',
+			SSH_CMD: command,
+			SCRIPT: '',
+			USER_RUNTIME_SECRET: 'decrypted-for-user-code',
+			JOB_SECRET: 'encrypted-event',
+			JOB_GLOBALENV: 'encrypted-global',
+			SSH_PASSWORD: 'connection-password',
+			SSH_KEY: 'connection-key',
+			SSH_PASSPHRASE: 'connection-passphrase'
+		})
+	});
+	const passed = JSON.parse(readProbe(result.stdout, 'SSH_LOCAL_ENV_PROBE='));
+
+	assert.equal(passed.BASE_URL, 'https://manager.internal');
+	assert.equal(passed.USER_RUNTIME_SECRET, 'decrypted-for-user-code');
+	['JOB_SECRET', 'JOB_GLOBALENV', 'SSH_HOST', 'SSH_PASSWORD', 'SSH_KEY', 'SSH_PASSPHRASE']
+		.forEach((key) => assert.equal(Object.hasOwn(passed, key), false, key));
+});
+
+test('SSHX plugin excludes the selected host reference and connection credentials', () => {
+	const result = runNode([
+		'-r', runtimeProbe, path.join(repoRoot, 'bin', 'sshx-plugin.js')
+	], {
+		input: JSON.stringify({ id: 'j-sshx', params: {}, chain_data: {} }),
+		env: baseEnv({
+			JOB_ID: 'j-sshx',
+			JOB_ARG: 'ssh://user:arg-password@arg-host',
+			JOB_SECRET: 'encrypted-event',
+			JOB_GLOBALENV: 'encrypted-global',
+			SSH_HOST: 'SSH_REMOTE',
+			SSH_REMOTE: 'ssh://user:ssh-password@ssh-host',
+			SSH_PASSWORD: 'connection-password',
+			SSH_KEY: 'connection-key',
+			SSH_PASSPHRASE: 'connection-passphrase',
+			SSH_TMPDIR: '/safe/tmp',
+			ARG1: 'public-arg'
+		})
+	});
+	const script = Buffer.from(
+		readProbe(result.stdout, 'SSHX_SCRIPT_PROBE='), 'base64'
+	).toString();
+
+	['JOB_ID', 'BASE_URL', 'SSH_TMPDIR', 'ARG1'].forEach((key) => {
+		assert.match(script, new RegExp('export ' + key + '='));
+	});
+	['JOB_ARG', 'JOB_SECRET', 'JOB_GLOBALENV', 'SSH_HOST', 'SSH_REMOTE',
+		'SSH_PASSWORD', 'SSH_KEY', 'SSH_PASSPHRASE'].forEach((key) => {
+		assert.doesNotMatch(script, new RegExp('export ' + key + '='));
+	});
+	['arg-password', 'encrypted-event', 'encrypted-global', 'ssh-password',
+		'connection-password', 'connection-key', 'connection-passphrase'].forEach((value) => {
+		assert.equal(script.includes(Buffer.from(value).toString('base64')), false, value);
+	});
+});
+
+module.exports = {
+	setUp: function(callback) { callback(); },
+	tests: tests,
+	tearDown: function(callback) { callback(); }
+};


### PR DESCRIPTION
## Summary

- keep encrypted job bundles and launch credentials out of automatically generated `JOB_*` variables
- preserve manager-computed `job_env`, `BASE_URL`, and `BASE_APP_URL` for remote jobs without mutating the shared configuration object
- prevent Docker, Kubernetes, SSH, and SSHX transport credentials from crossing into their child container, pod, local shell, or remote bootstrap environments
- stop logging the complete child environment and invalid Kubernetes config contents
- retain the existing public runtime contract, including user runtime secrets, `JOB_ARG` for Docker/Kubernetes, public `JOB_*` metadata, and credential-free `DOCKER_HOST`

## Boundary details

- Docker keeps connection-only credentials and credential-bearing `DOCKER_HOST` references in the wrapper, while preserving credential-free endpoints for compatible nested Docker clients.
- Kubernetes keeps `KUBE_CONFIG` in the wrapper and no longer prints invalid configuration content; `JOB_ARG` remains ordinary pod runtime input.
- SSH local execution removes the selected host/reference plus password, key, and passphrase from the spawned shell environment.
- SSHX removes the selected `SSH_HOST`/`JOB_ARG` transport value, its reference, and SSH credentials from the generated remote export script.
- URI detection covers password and username-only userinfo plus normalized token/secret/password query-key variants.

This PR intentionally does not change browser status payloads, completed-job storage, retry queues, email/webhook payloads, or manager-worker protocol state.

## Validation

- `npm test` — 101/101 tests, 384 assertions, 3 suites
- focused plugin boundary suite — 8/8
- real wrapper entrypoints exercised with captured Docker `Env`, Kubernetes pod manifest, SSH local process environment, and SSHX bootstrap script
- remote-manager launch regression verifies `job_env` copy semantics and manager `BASE_URL`
- `node --check` for all changed JavaScript/MJS sources
- `git diff --check`

## Review provenance

The issues and initial patches were proposed by a Codex Ultra security review (fork PRs [frankii91/cronicle-edge#15](https://github.com/frankii91/cronicle-edge/pull/15) and [frankii91/cronicle-edge#52](https://github.com/frankii91/cronicle-edge/pull/52)). This version was manually re-analyzed across all four transport plugins, expanded to the complete connection-credential boundary, tested against the real wrapper entrypoints, independently reviewed by three reviewers, and is submitted for maintainer review in line with our prior discussion.
