### PR TITLE
fix: fail closed on deprecated git bootstrap

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -183,8 +183,8 @@ You can generate a token to run specific event instead of creating global API ke
 ### Git integration
  - Github - HMAC signature check is supported. You can set `git_hub_key` config to verify signature. If not set cronicle will use `secret_key` (if x-signature-header is included in the request).
  - Gitlab - you can use cronicle API key as web hook secret key, but you can always bake API key or token in web hook url.
- - You can also automatically execute "git add / git commit / git push remote branch" on clicking backup button or even on each metadata update. First you need to set git repo (with auth) in your data folder. Then use related configs (there is an example in demo configs).
- - Before starting new Docker container you can also set `GIT_REPO` variable, so manager entrypoint will attempt to use this repo to setup data folder instead of running standard set up.
+ - Automatic metadata git add/commit/push sync is deprecated and unavailable.
+ - Startup restore through `GIT_REPO` was also deprecated and is not supported. Manager entrypoints refuse to start when this variable is set. Initialize storage explicitly, then restore reviewed metadata with `storage-cli.js import` before manager startup or with the authenticated Import API after normal startup.
 
 ### Hybrid schedule
 You can extend cron schedule by specifying extra minute ticks. This is helpful for uneven/one-time schedules. If you just specify hours/minutes without the date (e.g. 16:45 or 3PM), it will trigger job to run every day at that time. You can use full timestamp to run the job at specific time just once (e.g. 2021-01-01  16:45).

--- a/bin/control.sh
+++ b/bin/control.sh
@@ -12,7 +12,8 @@
 #	8 - configuration syntax error
 #
 # When multiple arguments are given, only the error from the _last_
-# one is reported.  Run "*ctl help" for usage info
+# one is reported, except a failed setup stops immediately so a later
+# start cannot run against incomplete storage.  Run "*ctl help" for usage info
 #
 #
 # |||||||||||||||||||| START CONFIGURATION SECTION  ||||||||||||||||||||
@@ -122,8 +123,8 @@ do
 		echo "$ARG: $STATUS"
 	;;
 	setup)
-		node $HOMEDIR/bin/storage-cli.js setup
-		#exit # do not exit to run setup and start in one shot
+		node "$HOMEDIR/bin/storage-cli.js" setup || exit $?
+		# continue on success to allow setup and start in one invocation
 	;;
 	maint)
 		node $HOMEDIR/bin/storage-cli.js maint $2

--- a/bin/manager
+++ b/bin/manager
@@ -31,6 +31,11 @@ while (( "$#" )); do
 shift
 done
 
+if [[ -n "${GIT_REPO:-}" ]]; then
+  echo "Error: GIT_REPO bootstrap is unsupported and was deprecated; restore data explicitly before starting the manager." >&2
+  exit 1
+fi
+
 if [[ $port ]]; then
   export CRONICLE_WebServer__http_port="$port"
   echo "Custom port set: $port"
@@ -64,11 +69,6 @@ if [[ $cluster ]]; then
   echo "Following nodes will be added on setup: $cluster"
 fi
 
-# pull data from git if needed
-# if [ ! -d data/global ] && [ -v GIT_REPO ]; then
-#         git clone $GIT_REPO $HOMEDIR/data
-# fi
-
 # check for custom nodejs binary
 if [ -f $HOMEDIR/nodejs/bin/node ]; then
       export PATH="$HOMEDIR/nodejs/bin:$PATH"
@@ -78,8 +78,9 @@ fi
 
 # setup storage OR make current host the primary manager if needed
 if [ "$reset" = 1 ]; then
-  node $HOMEDIR/bin/storage-cli.js reset || $HOMEDIR/bin/control.sh setup
-else $HOMEDIR/bin/control.sh setup
+  node "$HOMEDIR/bin/storage-cli.js" reset || "$HOMEDIR/bin/control.sh" setup || exit $?
+else
+  "$HOMEDIR/bin/control.sh" setup || exit $?
 fi
 
 
@@ -104,5 +105,4 @@ fi
 
 #$HOMEDIR/bin/control.sh start
 exec $BINARY --echo --foreground --manager --color $color --debug $debug
-
 

--- a/bin/manager.bat
+++ b/bin/manager.bat
@@ -83,6 +83,11 @@ goto parseArgs
 
 :endArgs
 
+if defined GIT_REPO (
+  echo Error: GIT_REPO bootstrap is unsupported and was deprecated; restore data explicitly before starting the manager. 1>&2
+  exit /b 1
+)
+
 cd /D %SCRIPT_LOC%
 
 REM check for custom node version
@@ -93,9 +98,15 @@ IF EXIST "%~dp0..\nodejs\node.exe" (
 REM setup or reset manager
 if "%CRONICLE_RESET%"=="1" (
   node .\storage-cli.js reset || node .\storage-cli.js setup
+  if errorlevel 1 goto setup_failed
   echo Croncile manager was reset to current host
 ) else (
   node .\storage-cli.js setup
+  if errorlevel 1 goto setup_failed
 )
 
 node .\cronicle.js --manager --echo --foreground --color --debug %DEBUG%
+exit /b
+
+:setup_failed
+exit /b 1

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"license": "MIT",
 	"main": "lib/main.js",
 	"scripts": {
-		"test": "pixl-unit lib/test.js test/oidc-logout.test.js",
+		"test": "pixl-unit lib/test.js test/oidc-logout.test.js test/bootstrap-entrypoints.test.js",
 		"boot": "pixl-boot install",
 		"unboot": "pixl-boot uninstall"
 	},

--- a/test/bootstrap-entrypoints.test.js
+++ b/test/bootstrap-entrypoints.test.js
@@ -1,0 +1,186 @@
+const assert = require('node:assert/strict');
+const cp = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const root = path.dirname(__dirname);
+const tempRoots = [];
+const tests = [];
+
+function test(name, callback) {
+	const wrapped = function(testHandle) {
+		try {
+			callback();
+			testHandle.done();
+		}
+		catch (err) {
+			testHandle.ok(false, name + ': ' + (err && err.stack || err));
+			testHandle.done();
+		}
+	};
+	Object.defineProperty(wrapped, 'name', {
+		value: name.replace(/[^A-Za-z0-9]+/g, '_'),
+		configurable: true
+	});
+	tests.push(wrapped);
+}
+
+function makeInstall() {
+	const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cronicle-bootstrap-test-'));
+	tempRoots.push(home);
+	fs.mkdirSync(path.join(home, 'bin'), { recursive: true });
+	fs.mkdirSync(path.join(home, 'nodejs', 'bin'), { recursive: true });
+	fs.mkdirSync(path.join(home, 'lib'), { recursive: true });
+	fs.mkdirSync(path.join(home, 'logs'), { recursive: true });
+	fs.copyFileSync(path.join(root, 'bin', 'manager'), path.join(home, 'bin', 'manager'));
+	fs.copyFileSync(path.join(root, 'bin', 'control.sh'), path.join(home, 'bin', 'control.sh'));
+	fs.chmodSync(path.join(home, 'bin', 'manager'), 0o755);
+	fs.chmodSync(path.join(home, 'bin', 'control.sh'), 0o755);
+
+	const fakeNode = `#!/bin/sh
+printf '%s\\n' "$*" >> "$BOOTSTRAP_TRACE"
+case "$1" in
+  -v)
+    printf '%s\\n' 'v-test'
+    exit 0
+    ;;
+  -e)
+    printf '%s\\n' 'logs/cronicled.pid'
+    exit 0
+    ;;
+  */storage-cli.js)
+    case "$2" in
+      setup) exit "\${BOOTSTRAP_SETUP_EXIT:-0}" ;;
+      reset) exit "\${BOOTSTRAP_RESET_EXIT:-0}" ;;
+    esac
+    ;;
+  */lib/main.js|*/bin/cronicle.js)
+    exit "\${BOOTSTRAP_RUNTIME_EXIT:-0}"
+    ;;
+esac
+exit 0
+`;
+	fs.writeFileSync(path.join(home, 'nodejs', 'bin', 'node'), fakeNode, { mode: 0o755 });
+	return home;
+}
+
+function run(script, args, values) {
+	const home = path.dirname(path.dirname(script));
+	const trace = path.join(home, 'trace.log');
+	const env = Object.assign({}, process.env, {
+		BOOTSTRAP_TRACE: trace,
+		BOOTSTRAP_SETUP_EXIT: '0',
+		BOOTSTRAP_RESET_EXIT: '0',
+		BOOTSTRAP_RUNTIME_EXIT: '0'
+	}, values || {});
+	delete env.GIT_REPO;
+	if (values && Object.prototype.hasOwnProperty.call(values, 'GIT_REPO')) {
+		env.GIT_REPO = values.GIT_REPO;
+	}
+	const result = cp.spawnSync(script, args || [], { env, encoding: 'utf8' });
+	result.trace = fs.existsSync(trace) ? fs.readFileSync(trace, 'utf8') : '';
+	return result;
+}
+
+test('manager rejects deprecated GIT_REPO without exposing it or starting setup/runtime', function() {
+	const home = makeInstall();
+	const secretUrl = 'https://user:credential@example.invalid/private.git';
+	const result = run(path.join(home, 'bin', 'manager'), [], { GIT_REPO: secretUrl });
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /GIT_REPO.*unsupported|unsupported.*GIT_REPO/i);
+	assert.equal((result.stdout + result.stderr).includes(secretUrl), false);
+	assert.equal((result.stdout + result.stderr).includes('credential'), false);
+	assert.equal(result.trace, '');
+});
+
+test('control setup preserves storage-cli failure and does not continue to start', function() {
+	const home = makeInstall();
+	const result = run(path.join(home, 'bin', 'control.sh'), ['setup', 'start'], {
+		BOOTSTRAP_SETUP_EXIT: '37'
+	});
+	assert.equal(result.status, 37);
+	assert.match(result.trace, /storage-cli\.js setup/);
+	assert.doesNotMatch(result.trace, /lib\/main\.js|bin\/cronicle\.js/);
+});
+
+test('control setup success can still continue to start', function() {
+	const home = makeInstall();
+	const result = run(path.join(home, 'bin', 'control.sh'), ['setup', 'start']);
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.trace, /storage-cli\.js setup/);
+	assert.match(result.trace, /lib\/main\.js/);
+});
+
+test('manager preserves setup failure and never starts the runtime', function() {
+	const home = makeInstall();
+	const result = run(path.join(home, 'bin', 'manager'), [], { BOOTSTRAP_SETUP_EXIT: '37' });
+	assert.equal(result.status, 37);
+	assert.match(result.trace, /storage-cli\.js setup/);
+	assert.doesNotMatch(result.trace, /lib\/main\.js|bin\/cronicle\.js/);
+});
+
+test('manager reset fallback preserves setup failure and never starts the runtime', function() {
+	const home = makeInstall();
+	const result = run(path.join(home, 'bin', 'manager'), ['--reset'], {
+		BOOTSTRAP_RESET_EXIT: '23',
+		BOOTSTRAP_SETUP_EXIT: '37'
+	});
+	assert.equal(result.status, 37);
+	assert.match(result.trace, /storage-cli\.js reset/);
+	assert.match(result.trace, /storage-cli\.js setup/);
+	assert.doesNotMatch(result.trace, /lib\/main\.js|bin\/cronicle\.js/);
+});
+
+test('manager reset success skips setup and starts the runtime', function() {
+	const home = makeInstall();
+	const result = run(path.join(home, 'bin', 'manager'), ['--reset']);
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.trace, /storage-cli\.js reset/);
+	assert.doesNotMatch(result.trace, /storage-cli\.js setup/);
+	assert.match(result.trace, /lib\/main\.js/);
+});
+
+test('manager reset failure can recover through successful setup', function() {
+	const home = makeInstall();
+	const result = run(path.join(home, 'bin', 'manager'), ['--reset'], {
+		BOOTSTRAP_RESET_EXIT: '23'
+	});
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.trace, /storage-cli\.js reset/);
+	assert.match(result.trace, /storage-cli\.js setup/);
+	assert.match(result.trace, /lib\/main\.js/);
+});
+
+test('manager without GIT_REPO completes setup and starts the runtime', function() {
+	const home = makeInstall();
+	const result = run(path.join(home, 'bin', 'manager'));
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.trace, /storage-cli\.js setup/);
+	assert.match(result.trace, /lib\/main\.js/);
+});
+
+test('Windows manager source contract rejects GIT_REPO and guards both setup paths', function() {
+	const managerBat = fs.readFileSync(path.join(root, 'bin', 'manager.bat'), 'utf8');
+	const setupGuards = managerBat.match(/node \.\\storage-cli\.js setup\s*\n\s*if errorlevel 1 goto setup_failed/gi) || [];
+	const gitRepoGuardIndex = managerBat.search(/if defined GIT_REPO/i);
+	const firstSetupIndex = managerBat.search(/storage-cli\.js setup/i);
+	assert.match(managerBat, /if defined GIT_REPO \([\s\S]*?GIT_REPO bootstrap is unsupported[\s\S]*?exit \/b 1[\s\S]*?\)/i);
+	assert.doesNotMatch(managerBat, /%GIT_REPO%/i);
+	assert.ok(gitRepoGuardIndex >= 0 && gitRepoGuardIndex < firstSetupIndex);
+	assert.equal(setupGuards.length, 2);
+	assert.match(managerBat, /node \.\\cronicle\.js[^\n]*\nexit \/b\s*\n\s*:setup_failed/i);
+	assert.match(managerBat, /:setup_failed\s*\nexit \/b 1/i);
+	assert.ok(managerBat.indexOf(':setup_failed') > managerBat.indexOf('node .\\cronicle.js'));
+});
+
+module.exports = {
+	setUp: function(callback) { callback(); },
+	tests: tests,
+	tearDown: function(callback) {
+		for (const tempRoot of tempRoots.splice(0)) {
+			fs.rmSync(tempRoot, { recursive: true, force: true });
+		}
+		callback();
+	}
+};


### PR DESCRIPTION
## Summary

- fail closed in both Unix and Windows manager entrypoints when deprecated `GIT_REPO` bootstrap is configured
- never print the configured repository value, which may contain credentials
- propagate setup failures so a later `start`/manager runtime cannot run against incomplete storage
- update the Git integration documentation to match the currently disabled/deprecated implementation and point to explicit import workflows

## Why

The repository-clone block in the current Unix manager is commented out and has been deprecated for years, but the README still advertises `GIT_REPO` as a supported Docker restore path. Re-enabling that old block does not provide a safe restore: a partial checkout can still fall through to setup and seed default state.

This change deliberately does **not** reactivate automatic restore or add persistent recovery state. It makes the unsupported configuration explicit and ensures a failed `storage-cli.js setup` stops before the runtime on both manager entrypoints.

## Validation

- focused entrypoint suite — 9/9
- full `npm test` — 101/101 tests, 375 assertions, 3 suites
- local no-network container/entrypoint smoke — 9/9
- `bash -n bin/manager bin/control.sh`
- `dash -n bin/control.sh`
- static Windows `cmd.exe` source-contract regression for the guard and both setup paths
- `node --check test/bootstrap-entrypoints.test.js`
- `git diff --check`

The Windows batch file was not executed under a real Windows `cmd.exe` in this environment; its control-flow contract is covered statically.

## Review provenance

The issue and an initial patch were proposed by a Codex Ultra security review (fork PR [frankii91/cronicle-edge#19](https://github.com/frankii91/cronicle-edge/pull/19)). That generated patch was not ported because it reactivated the deprecated clone path and treated incomplete storage as restored. This fail-closed version was manually re-analyzed across Unix/Windows bootstrap and setup lifecycles, independently reviewed, and is submitted for maintainer review in line with our prior discussion.
