### PR TITLE
fix: secure job log authorization and transfer

### DIFF
--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -3,48 +3,212 @@
 // Released under the MIT License
 
 const fs = require('fs');
+const path = require('path');
 const async = require('async');
 const Class = require("pixl-class");
 const Tools = require("pixl-tools");
 const readLastLines = require('read-last-lines');
+const PassThrough = require('stream').PassThrough;
 
 module.exports = Class.create({
 
+	getRawJobLogHeaders: function () {
+		return {
+			'Content-Type': 'text/plain; charset=utf-8',
+			'X-Content-Type-Options': 'nosniff',
+			'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+			'Pragma': 'no-cache',
+			'Expires': '0'
+		};
+	},
+
+	abortJobLogHTTPResponse: function (response, destination, message) {
+		// Returning false from pixl-request preflight switches it to buffer mode.
+		// Destroy the network response first so an incompatible/unbounded body can
+		// never be accumulated in manager memory.
+		if (response && response.destroy && !response.destroyed) {
+			response.destroy(new Error(message || "Incompatible job-log response"));
+		}
+		if (destination && destination.destroy && !destination.destroyed) destination.destroy();
+	},
+
+	requireJobLogAccess: function (args, user, job, callback) {
+		// Authorize against the immutable job snapshot, rather than the current
+		// event (which may have been edited or deleted after the job ran).
+		if (!job || !job.category || !job.target) {
+			this.doError('job', "Job authorization metadata is unavailable.", callback);
+			return false;
+		}
+		if (!this.requireCategoryPrivilege(user, job.category, callback)) return false;
+		if (!this.requireGroupPrivilege(args, user, job.target, callback)) return false;
+		return true;
+	},
+
+	sameFileIdentity: function (left, right) {
+		return !!left && !!right &&
+			(String(left.dev) == String(right.dev)) &&
+			(String(left.ino) == String(right.ino));
+	},
+
+	openJobLogFile: function (file_path, callback) {
+		// Validate the directory entry, open it once without following links where
+		// supported, and verify that the descriptor still refers to that entry.
+		// All reads below use this descriptor, never a second path lookup.
+		var self = this;
+		fs.lstat(file_path, function (err, before) {
+			if (err) return callback(err);
+			if (!before.isFile() || (before.nlink != 1)) {
+				return callback(new Error("Job log is not a single-link regular file"));
+			}
+
+			var flags = fs.constants.O_RDONLY;
+			if (typeof fs.constants.O_NOFOLLOW == 'number') flags |= fs.constants.O_NOFOLLOW;
+			if (typeof fs.constants.O_NONBLOCK == 'number') flags |= fs.constants.O_NONBLOCK;
+
+			fs.open(file_path, flags, function (err, fd) {
+				if (err) return callback(err);
+				fs.fstat(fd, function (err, opened) {
+					if (err || !opened.isFile() || (opened.nlink != 1) || !self.sameFileIdentity(before, opened)) {
+						return fs.close(fd, function () {
+							callback(err || new Error("Job log changed while it was being opened"));
+						});
+					}
+					callback(null, fd, opened);
+				});
+			});
+		});
+	},
+
+	deleteJobLogIfUnchanged: function (file_path, opened) {
+		// Node does not expose a portable unlink-by-descriptor operation.  Recheck
+		// identity and file type immediately before deleting the fixed job slot.
+		// Eliminating the final lstat/unlink window altogether would require a
+		// private quarantine plus retry lifecycle (or a two-phase transfer).
+		var self = this;
+		fs.lstat(file_path, function (err, current) {
+			if (err) return;
+			if (!current.isFile() || (current.nlink != 1) || !self.sameFileIdentity(opened, current)) {
+				return self.logError('file', "Refusing to delete a replaced job log: " + file_path);
+			}
+			fs.unlink(file_path, function (err) {
+				if (err) self.logError('file', "Failed to delete fetched job log: " + file_path + ": " + err);
+			});
+		});
+	},
+
+	deleteJobLogAfterCompleteTransfer: function (response, source, file_path, opened, expected_size) {
+		// HTTP `finish` only means the response was ended.  pixl-server also ends a
+		// response after a source-stream error, so require a clean source `end` too.
+		var self = this;
+		var source_ended = false;
+		var response_finished = false;
+		var source_failed = false;
+		var deleted = false;
+		var maybe_delete = function () {
+			if (deleted || source_failed || !source_ended || !response_finished) return;
+			deleted = true;
+			self.deleteJobLogIfUnchanged(file_path, opened);
+		};
+		source.once('error', function () { source_failed = true; });
+		source.once('end', function () {
+			source_ended = true;
+			if ((typeof expected_size == 'number') &&
+				(!source.jobLogComplete || (source.jobLogBytesRead != expected_size))) {
+				source_failed = true;
+			}
+			maybe_delete();
+		});
+		response.once('finish', function () { response_finished = true; maybe_delete(); });
+		response.once('close', function () {
+			// A client disconnect can leave a backpressured source paused after
+			// unpipe, so destroy it explicitly and let its descriptor owner close
+			// after any pending positional read completes.  Never delete the log.
+			if (!response_finished) {
+				source_failed = true;
+				if (source && source.destroy) source.destroy();
+			}
+		});
+	},
+
+	getMutableJobUpdates: function (updates, callback) {
+		var allowed = [
+			'title', 'timeout', 'repeat', 'interval', 'enabled', 'retries',
+			'retry_delay', 'chain', 'chain_error', 'notify_success', 'notify_fail',
+			'web_hook', 'cpu_limit', 'cpu_sustain', 'memory_limit',
+			'memory_sustain', 'log_max_size', 'suspended'
+		];
+		if (!updates || (typeof updates != 'object') || Array.isArray(updates)) {
+			this.doError('api', "Job updates must be an object.", callback);
+			return false;
+		}
+
+		var clean = Object.create(null);
+		var keys = Object.keys(updates);
+		for (var idx = 0; idx < keys.length; idx++) {
+			var key = keys[idx];
+			if (allowed.indexOf(key) < 0) {
+				this.doError('api', "Cannot update protected job property: " + key, callback);
+				return false;
+			}
+			clean[key] = updates[key];
+		}
+		if (!this.requireValidEventData(clean, callback)) return false;
+		if (!this.validateOptionalParams(clean, {
+			repeat: [ /^(boolean|number)$/, /^(\d+|false)$/ ],
+			interval: [ /^(boolean|number)$/, /^(\d+|false)$/ ],
+			suspended: [ /^(boolean|number)$/, /^(\d+|true|false)$/ ]
+		}, callback)) return false;
+		return clean;
+	},
+
+	buildMutableJobStub: function (id, updates) {
+		// updateLocalJob historically iterates with `for...in`, so hand it a
+		// null-prototype object even if another API polluted Object.prototype.
+		var stub = Object.create(null);
+		stub.id = id;
+		Object.keys(updates).forEach(function (key) { stub[key] = updates[key]; });
+		return stub;
+	},
+
 	api_get_job_log: function (args, callback) {
 		// view job log (plain text or download)
-		// client API, no auth
 		var self = this;
+		if (!this.requiremanager(args, callback)) return;
 
 		if (!this.requireParams(args.query, {
 			id: /^\w+$/
 		}, callback)) return;
 
 		this.loadSession(args, function (err, session, user) {
-
-			if(self.server.config.get('protect_job_log')) {
-				if (err) return self.doError('session', err.message, callback);
-				if (!self.requireValidUser(session, user, callback)) return;
-			}
+			if (err) return self.doError('session', err.message, callback);
+			if (!self.requireValidUser(session, user, callback)) return;
+			args.user = user;
+			args.session = session;
 
 			let key = 'jobs/' + args.query.id + '/log.txt.gz';
 
-			self.storage.getStream(key, function (err, stream) {
+			self.storage.get('jobs/' + args.query.id, function (err, job) {
 				if (err) {
 					return callback("404 Not Found", {}, "(No log file found.)\n");
 				}
-	
-				let headers = {
-					'Content-Type': "text/plain; charset=utf-8",
-					'Content-Encoding': "gzip"
-				};
-	
-				// optional download instead of view
-				if (args.query.download) {
-					headers['Content-disposition'] = "attachment; filename=Cronicle-Job-Log-" + args.query.id + '.txt';
-				}
-	
-				// pass stream to web server
-				callback("200 OK", headers, stream);
+				if (!self.requireJobLogAccess(args, user, job, callback)) return;
+
+				self.storage.getStream(key, function (err, stream) {
+					if (err) {
+						return callback("404 Not Found", {}, "(No log file found.)\n");
+					}
+
+					let headers = self.getRawJobLogHeaders();
+					headers['Content-Encoding'] = 'gzip';
+
+					// optional download instead of view
+					if (args.query.download) {
+						headers['Content-Disposition'] = "attachment; filename=Cronicle-Job-Log-" + args.query.id + '.txt';
+					}
+
+					// pass stream to web server
+					callback("200 OK", headers, stream);
+				});
 			});
 		
 		});
@@ -52,6 +216,11 @@ module.exports = Class.create({
 	},
 
 	get_active_job_by_id(id) {
+		// On a manager, prefer the immutable launch snapshot.  worker.active_jobs
+		// is status telemetry and must not define log authorization metadata.
+		let managerJob = this.getManagerJobLogSnapshot(id)
+		if (managerJob) return managerJob
+		if (this.multi.manager) return undefined
 
 		let activeJobs = this.getAllActiveJobs(true)
 		if (activeJobs[id]) return activeJobs[id]
@@ -85,7 +254,7 @@ module.exports = Class.create({
 
 		if(!filePath) return self.doError('log', 'Missing log_file parameter', callback)
 
-		fs.stat(filePath, (err, stats) => {
+		self.openJobLogFile(filePath, (err, fd, stats) => {
 			if (err) {
 			   return  callback({ error: err.message || true, dur: new Date - start, next: offset })
 			}
@@ -103,7 +272,9 @@ module.exports = Class.create({
 	
 			// if offset exceeds file size, return right away
 			if (availableBytes < 1) {
-				return callback({ skipBytes: skipBytes, fileSize: fileSize, next: offset, dur: new Date - start })
+				return fs.close(fd, function () {
+					callback({ skipBytes: skipBytes, fileSize: fileSize, next: offset, dur: new Date - start })
+				});
 			}
 	
 			let bytesToRead = availableBytes
@@ -112,25 +283,15 @@ module.exports = Class.create({
 				bytesToRead = maxBytes
 			}
 	
-			fs.open(filePath, 'r', (err, fd) => {
-	
-				if (err) {
-					return callback({ error: err.message || true, skipBytes: skipBytes, fileSize: fileSize, next: offset, dur: new Date - start, })
-				}
-	
-				let buffer = Buffer.alloc(bytesToRead);
-				fs.read(fd, buffer, 0, bytesToRead, offset, (err, bytesRead, buffer) => {
-	
-					fs.close(fd, () => {
-						let dur = new Date - start
-						if (err) {
-							return callback({ error: err.message || true, skipBytes: skipBytes, fileSize: fileSize, next: offset, dur: dur})
-						}
-	
-						return callback({ data: String(buffer), fileSize: fileSize, skipBytes: skipBytes, next: offset + bytesRead, dur: dur})    
-					
-					}); 
-					 
+			let buffer = Buffer.alloc(bytesToRead);
+			fs.read(fd, buffer, 0, bytesToRead, offset, (err, bytesRead) => {
+				fs.close(fd, () => {
+					let dur = new Date - start
+					if (err) {
+						return callback({ error: err.message || true, skipBytes: skipBytes, fileSize: fileSize, next: offset, dur: dur})
+					}
+
+					return callback({ data: String(buffer.subarray(0, bytesRead)), fileSize: fileSize, skipBytes: skipBytes, next: offset + bytesRead, dur: dur})
 				});
 			});
 	
@@ -138,14 +299,16 @@ module.exports = Class.create({
 	},
     
 	// this is proxy between and user and logs on different nodes
-	api_get_live_console: async function (args, callback) {
+	api_get_live_console: function (args, callback) {
 		// runs on manager 
 		const self = this;
 
+		if (!self.requiremanager(args, callback)) return;
 		self.loadSession(args, function (err, session, user) {
 			if (err) return self.doError('session', err.message, callback);
-			if (!self.requiremanager(args, callback)) return;
-			if (!self.requireValidUser(session, user, callback)) return;			
+			if (!self.requireValidUser(session, user, callback)) return;
+			args.user = user;
+			args.session = session;
 
 			//let query = args.query;
 			let params = Tools.mergeHashes(args.params, args.query);
@@ -157,12 +320,13 @@ module.exports = Class.create({
 			let job = self.get_active_job_by_id(params.id)
 
 			if (!job) return self.doError('job', "Invalid or Completed job", callback);
+			if (!self.requireJobLogAccess(args, user, job, callback)) return;
 
 			let pageSize = self.server.config.get('live_log_page_size') || 8192
 
 			if(self.server.hostname === job.hostname) { 
 				// if job is running on this server (manager), read file right away
-                params.log_file = job.log_file
+				params.log_file = self.getJobLogFilePath(job.id, job.detached)
 				params.event_title = job.event_title 
 				params.hostname = job.hostname				
 				params.max_bytes = params.download ? pageSize*16 : pageSize
@@ -212,7 +376,7 @@ module.exports = Class.create({
 			return callback("404 Not Found", {}, "Completed or Invalid job")
 		}
 
-		params.log_file= job.log_file
+		params.log_file = self.getJobLogFilePath(job.id, job.detached)
 		params.event_title = job.event_title 
 		params.hostname = job.hostname
 
@@ -220,40 +384,102 @@ module.exports = Class.create({
 		self.get_job_log_chunk(params, callback)
 	},
 
+	api_get_live_job_log_file: function (args, callback) {
+		// Internal manager-to-worker raw stream.  User authorization happens on
+		// the manager before it calls this endpoint.
+		var self = this;
+		var params = Tools.mergeHashes(args.params, args.query);
+		if (!this.requireParams(params, {
+			id: /^\w+$/,
+			auth: /^[a-f0-9]{64}$/i
+		}, callback)) return;
+
+		var expected = Tools.digestHex(params.id + this.server.config.get('secret_key'));
+		if (!this.secureCompareStrings(params.auth, expected)) {
+			return callback("403 Forbidden", {}, "Authentication failure.\n");
+		}
+
+		var job = this.get_active_job_by_id(params.id);
+		if (!job) return callback("404 Not Found", {}, "Completed or invalid job.\n");
+
+		var log_file = this.getJobLogFilePath(job.id, job.detached);
+		this.openJobLogFile(log_file, function (err, fd) {
+			if (err) return callback("404 Not Found", {}, "Live job log is unavailable.\n");
+			var headers = self.getRawJobLogHeaders();
+			headers['X-Cronicle-Live-Job-Log-Protocol'] = '2';
+			callback("200 OK", headers, fs.createReadStream(null, { fd: fd, autoClose: true }));
+		});
+	},
+
 
 	api_get_live_job_log: function (args, callback) {
 		// get live job job, as it is being written
-		// client API, no auth
 		var self = this;
 		var query = args.query;
+		if (!this.requiremanager(args, callback)) return;
 
 		if (!this.requireParams(query, {
 			id: /^\w+$/
 		}, callback)) return;
 
-		job = this.activeJobs[query.id] || {};
+		this.loadSession(args, function (err, session, user) {
+			if (err) return self.doError('session', err.message, callback);
+			if (!self.requireValidUser(session, user, callback)) return;
+			args.user = user;
+			args.session = session;
 
-		// see if log file exists on this server
-		// var log_file = this.server.config.get('log_dir') + '/jobs/' + query.id + '.log';
-		var log_file = this.server.config.get('log_dir') + '/jobs/' + query.id + (job.detached ? '-detached' : '') + '.log';
-
-		fs.stat(log_file, function (err, stats) {
-			if (err) {
-				return self.doError('job', "Failed to fetch job log: " + err, callback);
-			}
-
-			var headers = { 'Content-Type': "text/html; charset=utf-8" };
-
-			// optional download instead of view
+			var job = self.get_active_job_by_id(query.id);
+			if (!job) return self.doError('job', "Failed to locate job: " + query.id, callback);
+			if (!self.requireJobLogAccess(args, user, job, callback)) return;
+			var headers = self.getRawJobLogHeaders();
 			if (query.download) {
-				headers['Content-disposition'] = "attachment; filename=Cronicle-Partial-Job-Log-" + query.id + '.txt';
+				headers['Content-Disposition'] = "attachment; filename=Cronicle-Partial-Job-Log-" + query.id + '.txt';
 			}
 
-			// get readable stream to file
-			var stream = fs.createReadStream(log_file);
+			if (job.hostname == self.server.hostname) {
+				var log_file = self.getJobLogFilePath(job.id, job.detached);
+				return self.openJobLogFile(log_file, function (err, fd) {
+					if (err) return self.doError('job', "Failed to fetch job log: " + err, callback);
+					callback("200 OK", headers, fs.createReadStream(null, { fd: fd, autoClose: true }));
+				});
+			}
 
-			// stream to client as plain text
-			callback("200 OK", headers, stream);
+			var worker = self.workers[job.hostname];
+			if (!worker) return self.doError('job', "Failed to locate job server: " + job.hostname, callback);
+			var api_url = self.getWorkerServerBaseAPIURL(worker.hostname, worker.ip) + '/app/get_live_job_log_file';
+			api_url += Tools.composeQueryString({
+				id: job.id,
+				auth: Tools.digestHex(job.id + self.server.config.get('secret_key'))
+			});
+
+			var proxy = new PassThrough();
+			var response_started = false;
+			self.request.get(api_url, {
+				download: proxy,
+				headers: { 'Accept-Encoding': 'identity' },
+				preflight: function (err, resp, stream) {
+					var valid = !err && resp && (resp.statusCode == 200) &&
+						(resp.headers['x-cronicle-live-job-log-protocol'] == '2') &&
+						/^text\/plain\b/i.test(resp.headers['content-type'] || '');
+					if (!valid) {
+						self.abortJobLogHTTPResponse(resp, stream, "Incompatible live job-log response");
+						return false;
+					}
+					response_started = true;
+					callback("200 OK", headers, proxy);
+					resp.pipe(stream);
+				}
+			}, function (err) {
+				if (err && response_started) return proxy.destroy(err);
+				if (err) {
+					proxy.destroy();
+					return self.doError('job', "Failed to fetch live job log: " + err.message, callback);
+				}
+				if (!response_started) {
+					proxy.destroy();
+					return self.doError('job', "Job server returned an incompatible live-log response.", callback);
+				}
+			});
 		});
 	},
 
@@ -263,41 +489,70 @@ module.exports = Class.create({
 		var self = this;
 		var query = args.query;
 
-		if (!this.requireParams(query, {
-			path: /^[\w\-\.\/\\\:]+\.log$/,
-			auth: /^\w+$/
-		}, callback)) return;
+		var id = '';
+		var detached = false;
 
-		if (query.auth != Tools.digestHex(query.path + this.server.config.get('secret_key'))) {
-			return callback("403 Forbidden", {}, "Authentication failure.\n");
+		if (('id' in query) || ('detached' in query)) {
+			// Protocol v2: the manager supplies only immutable job identity.
+			if (!this.requireParams(query, {
+				id: /^\w+$/,
+				detached: /^[01]$/,
+				auth: /^[a-f0-9]{64}$/i
+			}, callback)) return;
+			id = query.id;
+			detached = (query.detached == '1');
+			if (!this.verifyJobLogFetchAuth(id, detached, query.auth)) {
+				return callback("403 Forbidden", {}, "Authentication failure.\n");
+			}
+		}
+		else {
+			// Worker-first rolling upgrade compatibility.  Old managers send the
+			// worker path back to it.  Accept it only when it is exactly the locally
+			// derived canonical job slot; a correctly signed outside path still fails.
+			if (!this.requireParams(query, { auth: /^[a-f0-9]{64}$/i }, callback)) return;
+			if ((typeof query.path != 'string') || !query.path.match(/\.log$/i) ||
+				(Buffer.byteLength(query.path, 'utf8') > 32768)) {
+				return callback("403 Forbidden", {}, "Invalid job log path.\n");
+			}
+			var resolved = path.resolve(query.path);
+			var filename_match = path.basename(resolved).match(/^(\w+)(-detached)?\.log$/);
+			if (!filename_match) return callback("403 Forbidden", {}, "Invalid job log path.\n");
+			id = filename_match[1];
+			detached = !!filename_match[2];
+			if (resolved != this.getJobLogFilePath(id, detached)) {
+				return callback("403 Forbidden", {}, "Invalid job log path.\n");
+			}
+			var legacy_auth = Tools.digestHex(query.path + this.server.config.get('secret_key'));
+			if (!this.secureCompareStrings(query.auth, legacy_auth)) {
+				return callback("403 Forbidden", {}, "Authentication failure.\n");
+			}
 		}
 
-		var log_file = query.path;
+		var log_file = this.getJobLogFilePath(id, detached);
 
-		fs.stat(log_file, function (err, stats) {
+		this.openJobLogFile(log_file, function (err, fd, opened) {
 			if (err) {
-				return callback("404 Not Found", {}, "Log file not found: " + log_file + ".\n");
+				return callback("404 Not Found", {}, "Job log file is unavailable.\n");
 			}
 
-			var headers = { 'Content-Type': "text/plain" };
+			var headers = self.getRawJobLogHeaders();
+			headers['X-Cronicle-Job-Log-Protocol'] = '2';
+			headers['Content-Length'] = String(opened.size);
+			var descriptor = self.createJobLogDescriptorOwner(fd);
+			var stream = self.createJobLogDescriptorStream(descriptor, opened.size);
+			var close_descriptor = function () { descriptor.close(function () {}); };
+			stream.once('end', close_descriptor);
+			stream.once('error', close_descriptor);
+			stream.once('close', close_descriptor);
 
-			// get readable stream to file
-			var stream = fs.createReadStream(log_file);
+			// Delete only after the committed number of bytes reached a clean source
+			// EOF and the HTTP response completed.
+			self.deleteJobLogAfterCompleteTransfer(args.response, stream, log_file, opened, opened.size);
 
-			// stream to client as plain text
+			// stream to manager as plain text
 			callback("200 OK", headers, stream);
 
-			args.response.on('finish', function () {
-				// only delete local log file once log is COMPLETELY sent
-				self.logDebug(4, "Deleting log file: " + log_file);
-
-				fs.unlink(log_file, function (err) {
-					// ignore error
-				});
-
-			}); // response finish
-
-		}); // fs.stat
+		}); // openJobLogFile
 	},
 
 	api_get_log_watch_auth: function (args, callback) {
@@ -323,13 +578,12 @@ module.exports = Class.create({
 			// due to a race condition, the job may not be registered yet
 			async.retry( { times: 20, interval: 250 },
 				async.ensureAsync( function(callback) {
-					job = self.findJob(params);
+					job = self.get_active_job_by_id(params.id);
 					return job ? callback() : callback("NOPE");
 				} ),
 				function(err) {
 					if (err) return self.doError('job', "Failed to locate job for log watch auth: " + params.id, callback);
-					if (!self.requireCategoryPrivilege(user, job.category, callback)) return;
-					if (!self.requireGroupPrivilege(args, user, job.target, callback)) return;
+					if (!self.requireJobLogAccess(args, user, job, callback)) return;
 
 					// generate token
 					var token = Tools.digestHex(params.id + self.server.config.get('secret_key'));
@@ -363,10 +617,20 @@ module.exports = Class.create({
 			if (!self.requireCategoryPrivilege(user, job.category, callback)) return;
 			if (!self.requireGroupPrivilege(args, user, job.target, callback)) return;
 
-			var result = self.updateJob(params);
+			// `hostname` was historically sent by the UI as a lookup hint.  Keep
+			// accepting it, but never let it (or any other invariant) reach the job.
+			var requested_updates = {};
+			Object.keys(params).forEach(function (key) {
+				if ((key != 'id') && (key != 'hostname')) requested_updates[key] = params[key];
+			});
+			var updates = self.getMutableJobUpdates(requested_updates, callback);
+			if (updates === false) return;
+			var stub = self.buildMutableJobStub(params.id, updates);
+
+			var result = self.updateJob(stub);
 			if (!result) return self.doError('job', "Failed to update job.", callback);
 
-			self.logTransaction('job_update', params.id, self.getClientInfo(args, params));
+			self.logTransaction('job_update', params.id, self.getClientInfo(args, stub));
 
 			callback({ code: 0 });
 		});
@@ -387,7 +651,8 @@ module.exports = Class.create({
 			args.user = user;
 			args.session = session;
 
-			var updates = params.updates;
+			var updates = self.getMutableJobUpdates(params.updates, callback);
+			if (updates === false) return;
 			delete params.updates;
 
 			var all_jobs = self.getAllActiveJobs(true);
@@ -406,7 +671,8 @@ module.exports = Class.create({
 
 			for (var idx = 0, len = jobs.length; idx < len; idx++) {
 				var job = jobs[idx];
-				var result = self.updateJob(Tools.mergeHashes(updates, { id: job.id }));
+				var stub = self.buildMutableJobStub(job.id, updates);
+				var result = self.updateJob(stub);
 				if (result) {
 					count++;
 					self.logTransaction('job_update', job.id, self.getClientInfo(args, updates));

--- a/lib/comm.js
+++ b/lib/comm.js
@@ -14,7 +14,35 @@ module.exports = Class.create({
 
 	workers: null,
 	sockets: null,
-	
+
+	updateLocalJobFromManager: function(stub) {
+		// Enforce the public runtime-field contract again at the worker trust
+		// boundary.  This protects worker-first rolling upgrades from a legacy
+		// manager forwarding client-controlled invariant fields.
+		if (!stub || (typeof stub != 'object') || Array.isArray(stub) ||
+			!Object.prototype.hasOwnProperty.call(stub, 'id') ||
+			(typeof stub.id != 'string') || !stub.id.match(/^\w+$/) ||
+			([ '__proto__', 'prototype', 'constructor' ].indexOf(stub.id) >= 0)) {
+			this.logError('job', "Refusing malformed job update from manager");
+			return false;
+		}
+
+		var requested_updates = Object.create(null);
+		Object.keys(stub).forEach(function (key) {
+			if ((key != 'id') && (key != 'hostname')) requested_updates[key] = stub[key];
+		});
+		var validation_error = '';
+		var updates = this.getMutableJobUpdates(requested_updates, function (data) {
+			validation_error = (data && data.description) ? data.description : String(data || '');
+		});
+		if (updates === false) {
+			this.logError('job', "Refusing protected job update from manager for " + stub.id +
+				(validation_error ? ": " + validation_error : ''));
+			return false;
+		}
+		return this.updateLocalJob(this.buildMutableJobStub(stub.id, updates));
+	},
+
 	setupCluster: function() {
 		// establish communication channel with all workers
 		var self = this;
@@ -66,14 +94,26 @@ module.exports = Class.create({
 	connectToworker: function(worker) {
 		// establish communication with worker via socket.io
 		var self = this;
+		// Status payloads are merged into `worker` below.  Retain the originally
+		// registered identity in a hidden, immutable property so both this socket and
+		// later reconnects remain bound to it even if telemetry mutates `worker`.
+		if (!Object.prototype.hasOwnProperty.call(worker, '_registeredSource')) {
+			Object.defineProperty(worker, '_registeredSource', {
+				value: Object.freeze({ hostname: worker.hostname, ip: worker.ip || '' }),
+				enumerable: false,
+				writable: false,
+				configurable: false
+			});
+		}
+		var source_worker = worker._registeredSource;
 		var port = this.server.config.get('remote_server_port') || this.web.config.get('http_port');
 		
 		var url = '';
 		if (this.server.config.get('server_comm_use_hostnames')) {
-			url = 'http://' + worker.hostname + ':' + port;
+			url = 'http://' + source_worker.hostname + ':' + port;
 		}
 		else {
-			url = 'http://' + (worker.ip || worker.hostname) + ':' + port;
+			url = 'http://' + (source_worker.ip || source_worker.hostname) + ':' + port;
 		}
 		
 		this.logDebug(8, "Connecting to worker via socket.io: " + url);
@@ -186,11 +226,11 @@ module.exports = Class.create({
 		} );
 		
 		socket.on('finish_job', function(job) {
-			self.finishJob( job );
+			self.finishJob( job, source_worker );
 		} );
 		
 		socket.on('fetch_job_log', function(job) {
-			self.fetchStoreJobLog( job );
+			self.fetchStoreJobLog( job, source_worker );
 		} );
 		
 		socket.on('auth_failure', function(data) {
@@ -404,8 +444,11 @@ module.exports = Class.create({
 		} );
 		
 		socket.on('update_job', function(stub) {
-			// update job (server-to-server comm)
-			if (socket._pixl_manager) self.updateLocalJob( stub );
+			// Update job (server-to-server comm).  Enforce the same runtime-field
+			// allowlist on the worker so a worker-first rolling upgrade remains safe
+			// while its manager is still running the legacy API implementation.
+			if (!socket._pixl_manager) return;
+			self.updateLocalJobFromManager(stub);
 		} );
 		
 		socket.on('restart_server', function(args) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -42,6 +42,7 @@ module.exports = Class.create({
 	],
 
 	activeJobs: null,
+	remoteLogFetchJobs: null,
 	deadJobs: null,
 	eventQueue: null,
 	kids: null,
@@ -76,6 +77,9 @@ module.exports = Class.create({
 
 		// keep track of jobs
 		this.activeJobs = {};
+		// Manager-owned immutable launch snapshots used for remote log
+		// authorization.  Never merge worker status payloads into this map.
+		this.remoteLogFetchJobs = Object.create(null);
 		this.deadJobs = {};
 		this.eventQueue = {};
 		this.kids = {};

--- a/lib/job.js
+++ b/lib/job.js
@@ -4,9 +4,12 @@
 
 const async = require('async');
 const cp = require('child_process');
+const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const Readable = require('stream').Readable;
+const Writable = require('stream').Writable;
 const sqparse = require('shell-quote').parse;
 const zlib = require('zlib');
 const Class = require("pixl-class");
@@ -19,6 +22,163 @@ const dotenv = require('dotenv');
 const isUnix = os.platform() != 'win32';
 
 module.exports = Class.create({
+
+	getJobLogFilePath: function (id, detached) {
+		// Derive job log paths locally.  Never accept a filesystem path from a
+		// client or another server as authorization to read a file.
+		if (!String(id || '').match(/^\w+$/)) return false;
+		return path.resolve(path.join(
+			this.server.config.get('log_dir'), 'jobs',
+			id + (detached ? '-detached' : '') + '.log'
+		));
+	},
+
+	getManagerJobLogSnapshot: function (id) {
+		if (this.multi.manager && this.remoteLogFetchJobs && this.remoteLogFetchJobs[id]) {
+			return this.remoteLogFetchJobs[id];
+		}
+		if (this.activeJobs && this.activeJobs[id]) return this.activeJobs[id];
+		if (this.multi.manager && this.internalQueue) {
+			for (var key in this.internalQueue) {
+				var task = this.internalQueue[key];
+				if (task && (task.action === 'launchLocalJob') && (task.id === id)) return task;
+			}
+		}
+		return undefined;
+	},
+
+	bindRemoteFinishedJob: function (job, source_worker) {
+		if (!job || !String(job.id || '').match(/^\w+$/) || !source_worker || !source_worker.hostname) {
+			return false;
+		}
+		var snapshot = this.remoteLogFetchJobs && this.remoteLogFetchJobs[job.id];
+		if (!snapshot || (snapshot.hostname != source_worker.hostname)) return false;
+		if (job.hostname && (job.hostname != source_worker.hostname)) return false;
+
+		var bound = Tools.copyHash(job);
+		[ 'id', 'hostname', 'detached', 'category', 'target', 'event', 'event_title', 'plugin' ].forEach(function (key) {
+			if (key in snapshot) bound[key] = snapshot[key];
+		});
+		return bound;
+	},
+
+	getJobLogFetchAuth: function (id, detached) {
+		// Domain-separate this capability from the other cluster tokens.
+		return crypto.createHmac('sha256', String(this.server.config.get('secret_key')))
+			.update('fetch-job-log\0' + id + '\0' + (detached ? '1' : '0'))
+			.digest('hex');
+	},
+
+	secureCompareStrings: function (supplied, expected) {
+		var supplied_buffer = Buffer.from(String(supplied || ''));
+		var expected_buffer = Buffer.from(String(expected || ''));
+		if (supplied_buffer.length != expected_buffer.length) return false;
+		return crypto.timingSafeEqual(supplied_buffer, expected_buffer);
+	},
+
+	verifyJobLogFetchAuth: function (id, detached, auth) {
+		var expected = this.getJobLogFetchAuth(id, detached);
+		return this.secureCompareStrings(auth, expected);
+	},
+
+	createJobLogDescriptorOwner: function (fd, io) {
+		// Serialize descriptor shutdown behind all outstanding positional I/O.
+		// Streams may be destroyed on protocol/storage errors, but close(2) is not
+		// called until every fs.read/fs.write callback has returned.
+		io = io || fs;
+		var pending = 0;
+		var closing = false;
+		var close_started = false;
+		var closed = false;
+		var close_callbacks = [];
+
+		var maybe_close = function () {
+			if (!closing || pending || close_started) return;
+			close_started = true;
+			io.close(fd, function (err) {
+				closed = true;
+				var callbacks = close_callbacks.splice(0);
+				callbacks.forEach(function (callback) { callback(err); });
+			});
+		};
+		var start = function (callback) {
+			if (!closing && !closed) {
+				pending++;
+				return true;
+			}
+			process.nextTick(function () { callback(new Error("Job log descriptor is closing")); });
+			return false;
+		};
+		var finish = function (callback, args) {
+			pending--;
+			try { callback.apply(null, args); }
+			finally { maybe_close(); }
+		};
+
+		return {
+			fd: fd,
+			read: function (buffer, offset, length, position, callback) {
+				if (!start(callback)) return;
+				io.read(fd, buffer, offset, length, position, function () {
+					finish(callback, Array.prototype.slice.call(arguments));
+				});
+			},
+			write: function (buffer, offset, length, position, callback) {
+				if (!start(callback)) return;
+				io.write(fd, buffer, offset, length, position, function () {
+					finish(callback, Array.prototype.slice.call(arguments));
+				});
+			},
+			close: function (callback) {
+				if (!callback) callback = function () {};
+				if (closed) return process.nextTick(function () { callback(); });
+				close_callbacks.push(callback);
+				closing = true;
+				maybe_close();
+			},
+			isClosing: function () { return closing; }
+		};
+	},
+
+	createJobLogDescriptorStream: function (descriptor, byte_limit) {
+		// A positional descriptor reader which never owns or closes the fd.
+		// This lets the caller keep one capability across storage and archive copies.
+		var limited = Number.isSafeInteger(byte_limit) && (byte_limit >= 0);
+		var position = 0;
+		var reading = false;
+		var ended = false;
+		var stream = new Readable({
+			read: function (requested) {
+				if (reading || ended || stream.destroyed) return;
+				if (limited && (position >= byte_limit)) {
+					ended = true;
+					stream.jobLogComplete = true;
+					return stream.push(null);
+				}
+				reading = true;
+				var length = Math.max(1, Math.min(requested || 65536, 1024 * 1024));
+				if (limited) length = Math.min(length, byte_limit - position);
+				var buffer = Buffer.alloc(length);
+				descriptor.read(buffer, 0, length, position, function (err, bytes_read) {
+					reading = false;
+					if (stream.destroyed) return;
+					if (err) return stream.destroy(err);
+					if (!bytes_read) {
+						ended = true;
+						stream.jobLogComplete = !limited || (position == byte_limit);
+						return stream.push(null);
+					}
+					position += bytes_read;
+					stream.jobLogBytesRead = position;
+					stream.push(buffer.subarray(0, bytes_read));
+				});
+			}
+		});
+		stream.jobLogExpectedSize = limited ? byte_limit : null;
+		stream.jobLogBytesRead = 0;
+		stream.jobLogComplete = false;
+		return stream;
+	},
 
 	launchOrQueueJob: function (event, callback) {
 		// launch job, or queue upon failure (if event desires)
@@ -373,14 +533,28 @@ module.exports = Class.create({
 						self.launchLocalJob(job);						
 					}
 					else if (worker.socket) {
-						// send the job to remote worker server
-						self.logDebug(6, "Sending remote job to: " + worker.hostname, job);
-						worker.socket.emit('launch_job', job);
+						// Record an immutable manager-owned assignment before the worker can
+						// acknowledge or complete it.  Worker status is never authoritative for
+						// log identity or category/group authorization.
+						self.remoteLogFetchJobs[job.id] = {
+							id: job.id,
+							hostname: worker.hostname,
+							detached: job.detached ? 1 : 0,
+							category: job.category,
+							target: job.target,
+							event: job.event,
+							event_title: job.event_title,
+							plugin: job.plugin
+						};
 
 						// Pre-insert job into worker's active_jobs, so something will show in getAllActiveJobs() right away.
 						// Important for when the scheduler is catching up, and may try to launch a bunch of jobs in a row.
 						if (!worker.active_jobs) worker.active_jobs = {};
 						worker.active_jobs[job.id] = job;
+
+						// send the job to remote worker server
+						self.logDebug(6, "Sending remote job to: " + worker.hostname, job);
+						worker.socket.emit('launch_job', job);
 					}
 
 					// fire web hook
@@ -578,10 +752,7 @@ module.exports = Class.create({
 		else {
 
 			// construct fully qualified path to job log file
-			job.log_file = path.resolve(path.join(
-				this.server.config.get('log_dir'), 'jobs',
-				job.id + (job.detached ? '-detached' : '') + '.log'
-			));
+			job.log_file = this.getJobLogFilePath(job.id, job.detached);
 		}
 
 		this.logDebug(6, "Launching local job", this.safeJobLog(job));
@@ -1062,13 +1233,16 @@ module.exports = Class.create({
 
 	updateLocalJob: function (stub) {
 		// update local job properties
-		var job = this.activeJobs[stub.id];
+		if (!stub || (typeof stub != 'object') || (typeof stub.id != 'string')) return false;
+		var job = (this.activeJobs && Object.prototype.hasOwnProperty.call(this.activeJobs, stub.id)) ?
+			this.activeJobs[stub.id] : null;
 		if (!job) {
 			// must be a pending job
 			if (this.internalQueue) {
 				for (var key in this.internalQueue) {
+					if (!Object.prototype.hasOwnProperty.call(this.internalQueue, key)) continue;
 					var task = this.internalQueue[key];
-					if ((task.action == 'launchLocalJob') && (task.id == stub.id)) {
+					if (task && (task.action == 'launchLocalJob') && (task.id === stub.id)) {
 						job = task;
 						break;
 					}
@@ -1084,9 +1258,9 @@ module.exports = Class.create({
 		this.logDebug(4, "Updating local job: " + stub.id, stub);
 
 		// update properties
-		for (var key in stub) {
+		Object.keys(stub).forEach(function (key) {
 			if (key != 'id') job[key] = stub[key];
-		}
+		});
 
 		return true;
 	},
@@ -1590,53 +1764,251 @@ module.exports = Class.create({
 		} // worker
 	},
 
-	fetchStoreJobLog: function (job) {
+	storeJobLogFromDescriptor: function (job, descriptor, callback) {
+		// Store a fetched worker log from the descriptor that was already verified.
+		// Do not reopen its temporary pathname: a job running under the same local
+		// account could otherwise replace the pathname between download and upload.
+		var self = this;
+		var storage_path = 'jobs/' + job.id + '/log.txt.gz';
+		var settled = false;
+		var finish = function (err) {
+			if (settled) return;
+			settled = true;
+			callback(err);
+		};
+		var source = this.createJobLogDescriptorStream(descriptor);
+		var gzip = zlib.createGzip(this.server.config.get('gzip_opts') || {});
+		source.on('error', finish);
+		gzip.on('error', finish);
+		source.pipe(gzip);
+
+		this.storage.putStream(storage_path, gzip, function (err) {
+			if (err) {
+				self.logError('storage', "Failed to store job log: " + storage_path + ": " + err);
+				return finish(err);
+			}
+
+			self.logDebug(9, "Job log stored successfully: " + storage_path);
+			if (!self.server.config.get('copy_job_logs_to')) return finish();
+
+			var dargs = Tools.getDateArgs(Tools.timeNow());
+			var dest_path = self.server.config.get('copy_job_logs_to').replace(/\/$/, '') + '/';
+			if (job.event_title) dest_path += job.event_title.replace(/\W+/g, '') + '.';
+			dest_path += job.id + '.' + (dargs.yyyy_mm_dd + '-' + dargs.hh_mi_ss).replace(/\W+/g, '-') + '.log';
+
+			// Copy from the held descriptor as well.  Exclusive creation prevents a
+			// pre-planted destination symlink from becoming an overwrite primitive.
+			var copy_source = self.createJobLogDescriptorStream(descriptor);
+			var copy_dest = fs.createWriteStream(dest_path, { flags: 'wx', mode: 0o600 });
+			var copy_failed = false;
+			var copy_error = function (err) {
+				if (copy_failed) return;
+				copy_failed = true;
+				copy_source.destroy();
+				copy_dest.destroy();
+				self.logError('file', "Failed to copy fetched job log to: " + dest_path + ": " + err);
+				// Match the historical behavior: archival-copy failure does not turn a
+				// successful primary storage upload into a failed job-log transfer.
+				finish();
+			};
+			copy_source.on('error', copy_error);
+			copy_dest.on('error', copy_error);
+			copy_dest.on('finish', function () {
+				if (!copy_failed) finish();
+			});
+			copy_source.pipe(copy_dest);
+		});
+	},
+
+	fetchStoreJobLog: function (job, source_worker) {
 		// fetch remote job log from worker, and then store in storage
 		var self = this;
 		if (!this.multi.manager) return;
 
-		var worker = this.workers[job.hostname];
-		if (!worker) {
-			this.logError('job', "Failed to locate worker: " + job.hostname + " for job: " + job.id);
-			worker = { hostname: job.hostname }; // hail mary
+		// The worker connection is the authority for the source host.  Do not let
+		// the socket payload redirect the manager to a different server.
+		if (!source_worker || !source_worker.hostname) {
+			return this.logError('job', "Refusing job log fetch without a source worker");
 		}
+		if (!job || !String(job.id || '').match(/^\w+$/)) {
+			return this.logError('job', "Refusing job log fetch with an invalid job ID");
+		}
+		if (job.hostname && (job.hostname != source_worker.hostname)) {
+			return this.logError('job', "Refusing job log fetch with a mismatched source worker: " + job.id);
+		}
+
+		var worker = source_worker;
+		var known_job = this.remoteLogFetchJobs && this.remoteLogFetchJobs[job.id];
+		if (!known_job || (known_job.hostname != worker.hostname)) {
+			return this.logError('job', "Refusing job log fetch for a job not assigned to the source worker: " + job.id);
+		}
+		if (known_job.log_fetch_in_flight) {
+			return this.logError('job', "Refusing duplicate in-flight job log fetch: " + job.id);
+		}
+		known_job.log_fetch_in_flight = 1;
+		var release_fetch = function () {
+			if (self.remoteLogFetchJobs && (self.remoteLogFetchJobs[job.id] === known_job)) {
+				delete known_job.log_fetch_in_flight;
+			}
+		};
+
+		// Use the manager-owned launch snapshot for all identity fields.  The
+		// completion payload may contain results, but cannot choose a storage slot.
+		job = Tools.copyHash(job);
+		job.id = known_job.id;
+		job.hostname = worker.hostname;
+		job.detached = known_job.detached ? 1 : 0;
+		var detached = job.detached;
 
 		// construct url to API on remote server w/auth key
 		var api_url = this.getWorkerServerBaseAPIURL(worker.hostname, worker.ip) + '/app/fetch_delete_job_log';
 
 		api_url += Tools.composeQueryString({
-			path: job.log_file,
-			auth: Tools.digestHex(job.log_file + this.server.config.get('secret_key'))
+			id: job.id,
+			detached: detached,
+			auth: this.getJobLogFetchAuth(job.id, detached)
 		});
 
-		this.logDebug(6, "Fetching remote job log via HTTP GET: " + api_url);
+		this.logDebug(6, "Fetching remote job log via HTTP GET", {
+			id: job.id,
+			hostname: worker.hostname,
+			detached: detached
+		});
 
-		// just in case remote server has different base dir than manager
-		job.log_file = this.server.config.get('log_dir') + '/jobs/' + path.basename(job.log_file);
-
-		this.request.get(api_url, { download: job.log_file }, function (err, resp) {
-			// check for error
+		// Never download into the world-writable jobs directory.  Use a private,
+		// unpredictable directory and an exclusive file, then retain its descriptor;
+		// directory permissions alone do not isolate a job running under the same UID.
+		fs.mkdtemp(path.join(os.tmpdir(), 'cronicle-job-log-'), function (err, temp_dir) {
 			if (err) {
-				var err_msg = "Failed to fetch job log file: " + api_url + ": " + err;
-				self.logError('job', err_msg);
+				release_fetch();
+				return self.logError('file', "Failed to create private job-log download directory: " + err);
 			}
-			else if (resp.statusCode != 200) {
-				var err_msg = "Failed to fetch job log file: " + api_url + ": HTTP " + resp.statusCode + " " + resp.statusMessage;
-				self.logError('job', err_msg);
-			}
-			else {
-				// success
-				self.logDebug(5, "Job log was fetched successfully", api_url);
 
-				// then call uploadJobLog again to store it (this also deletes the file)
-				self.uploadJobLog(job);
-			} // http success
-		}); // request.get
+			job.log_file = path.join(temp_dir, job.id + (detached ? '-detached' : '') + '.log');
+			var flags = fs.constants.O_RDWR | fs.constants.O_CREAT | fs.constants.O_EXCL;
+			if (typeof fs.constants.O_NOFOLLOW == 'number') flags |= fs.constants.O_NOFOLLOW;
+
+			fs.open(job.log_file, flags, 0o600, function (err, fd) {
+				if (err) {
+					release_fetch();
+					fs.rmdir(temp_dir, function () {;});
+					return self.logError('file', "Failed to create private job-log download file: " + err);
+				}
+
+				fs.fstat(fd, function (err, opened) {
+					if (err || !opened.isFile() || (opened.nlink != 1)) {
+						release_fetch();
+						return fs.close(fd, function () {
+							fs.unlink(job.log_file, function () { fs.rmdir(temp_dir, function () {;}); });
+						});
+					}
+
+					// Keep this exact O_EXCL descriptor from the first response byte through
+					// gzip/storage.  A small descriptor-backed Writable deliberately has no
+					// path-open or fd-close behavior of its own.
+					var descriptor = self.createJobLogDescriptorOwner(fd);
+					var download_offset = 0;
+					var download = new Writable({
+						write: function (chunk, encoding, done) {
+							var buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+							var buffer_offset = 0;
+							var write_next = function () {
+								descriptor.write(buffer, buffer_offset, buffer.length - buffer_offset, download_offset, function (err, bytes_written) {
+									if (err) return done(err);
+									if (!bytes_written) return done(new Error("Failed to write fetched job log"));
+									buffer_offset += bytes_written;
+									download_offset += bytes_written;
+									if (buffer_offset < buffer.length) return write_next();
+									done();
+								});
+							};
+							write_next();
+						}
+					});
+					download.path = job.log_file;
+					var protocol_ok = false;
+					var expected_size = null;
+					var close_fd = function (callback) {
+						descriptor.close(function () { callback(); });
+					};
+					var cleanup_temp = function () {
+						release_fetch();
+						if (!download.destroyed) download.destroy();
+						close_fd(function () {
+							fs.unlink(job.log_file, function () {
+								fs.rmdir(temp_dir, function () {;});
+							});
+						});
+					};
+
+					self.request.get(api_url, {
+						download: download,
+						headers: { 'Accept-Encoding': 'identity' },
+						preflight: function (err, resp, stream) {
+							var length_header = resp && resp.headers && resp.headers['content-length'];
+							var valid_length = (typeof length_header == 'string') && /^\d+$/.test(length_header);
+							expected_size = valid_length ? Number(length_header) : null;
+							valid_length = valid_length && Number.isSafeInteger(expected_size) && (expected_size >= 0);
+							protocol_ok = !err && resp && (resp.statusCode == 200) && resp.headers &&
+								(resp.headers['x-cronicle-job-log-protocol'] == '2') && valid_length &&
+								/^text\/plain\b/i.test(resp.headers['content-type'] || '');
+							if (!protocol_ok) {
+								self.abortJobLogHTTPResponse(resp, stream, "Incompatible job-log transfer response");
+								return false;
+							}
+							resp.pipe(stream);
+						}
+					}, function (err) {
+						if (err) {
+							self.logError('job', "Failed to fetch job log file from " + worker.hostname + " for job " + job.id + ": " + err);
+							return cleanup_temp();
+						}
+						if (!protocol_ok) {
+							self.logError('job', "Worker returned an incompatible job-log transfer response for job " + job.id);
+							return cleanup_temp();
+						}
+						if (download_offset != expected_size) {
+							self.logError('job', "Worker returned an incomplete job log for " + job.id +
+								": expected " + expected_size + " bytes, received " + download_offset);
+							return cleanup_temp();
+						}
+
+						self.logDebug(5, "Job log was fetched successfully", { id: job.id, hostname: worker.hostname });
+						self.storeJobLogFromDescriptor(job, descriptor, function (upload_err) {
+							if (upload_err) {
+								release_fetch();
+								return close_fd(function () {
+									self.logError('storage', "Retaining fetched job log after upload failure: " + job.log_file);
+								});
+							}
+
+							close_fd(function () {
+								fs.lstat(job.log_file, function (err, current) {
+									if (err || !current.isFile() || (current.nlink != 1) || !self.sameFileIdentity(opened, current)) {
+										return self.logError('file', "Retaining replaced fetched job log: " + job.log_file);
+									}
+									fs.unlink(job.log_file, function () {
+										fs.rmdir(temp_dir, function () {;});
+									});
+								});
+							});
+						});
+					}); // request.get
+				}); // fstat
+			}); // open
+		}); // mkdtemp
 	},
 
-	finishJob: function (job) {
+	finishJob: function (job, source_worker) {
 		// finish cleaning up job
 		var self = this;
+		if (source_worker) {
+			job = this.bindRemoteFinishedJob(job, source_worker);
+			if (!job) {
+				this.logError('job', "Refusing finished job not assigned to source worker");
+				return false;
+			}
+		}
 
 		if (!job.time_end) job.time_end = Tools.timeNow();
 		job.elapsed = Math.max(0, job.time_end - job.time_start);
@@ -1873,6 +2245,7 @@ module.exports = Class.create({
 		if (worker && worker.active_jobs && worker.active_jobs[job.id]) {
 			delete worker.active_jobs[job.id];
 		}
+		if (this.remoteLogFetchJobs) delete this.remoteLogFetchJobs[job.id];
 
 		// just in case job was in limbo, we can remove it now
 		delete this.deadJobs[job.id];
@@ -2303,7 +2676,7 @@ module.exports = Class.create({
 		}
 
 		// prepare to log watch
-		var log_file = job.log_file;
+		var log_file = this.getJobLogFilePath(job.id, job.detached);
 		var log_fd = null;
 		var log_stats = null;
 		var log_chunk_size = 32678;
@@ -2336,14 +2709,11 @@ module.exports = Class.create({
 				callback();
 			},
 			function (callback) {
-				fs.open(log_file, 'r', function (err, fd) {
-					if (!err) log_fd = fd;
-					callback(err);
-				});
-			},
-			function (callback) {
-				fs.fstat(log_fd, function (err, stats) {
-					log_stats = stats;
+				self.openJobLogFile(log_file, function (err, fd, stats) {
+					if (!err) {
+						log_fd = fd;
+						log_stats = stats;
+					}
 					callback(err);
 				});
 			},

--- a/lib/test.js
+++ b/lib/test.js
@@ -4,6 +4,11 @@
 
 var cp = require('child_process');
 var fs = require('fs');
+var os = require('os');
+var path = require('path');
+var EventEmitter = require('events').EventEmitter;
+var Readable = require('stream').Readable;
+var zlib = require('zlib');
 var async = require('async');
 var moment = require('moment-timezone');
 
@@ -65,6 +70,11 @@ var cronicle = null;
 var request = null;
 var api_url = '';
 var session_id = '';
+var log_auth_sessions = {
+	category_denied: 'unit_log_category_denied',
+	group_denied: 'unit_log_group_denied',
+	allowed: 'unit_log_allowed'
+};
 
 module.exports = {
 	logDebug: function(level, msg, data) {
@@ -249,18 +259,650 @@ module.exports = {
 			test.ok( !cronicle.internalQueue.launch, "Launch abort task was removed from queue" );
 			test.ok( launch_task.abort_reason == 'unit test', "Launch abort task received abort reason" );
 			
-			other_task = { action: 'someOtherAction', id: 'unit-watch-job' };
-			launch_task = { action: 'launchLocalJob', id: 'unit-watch-job', hostname: server.hostname };
+			other_task = { action: 'someOtherAction', id: 'unitwatchjob' };
+			launch_task = { action: 'launchLocalJob', id: 'unitwatchjob', hostname: server.hostname };
 			cronicle.internalQueue = { other: other_task, launch: launch_task };
 			
 			cronicle.watchJobLog(
-				{ id: 'unit-watch-job' },
+				{ id: 'unitwatchjob' },
 				{ id: 'unitSocket', request: { connection: { remoteAddress: '127.0.0.1' } } }
 			);
 			test.ok( other_task.action == 'someOtherAction', "Non-launch watch task action was not mutated" );
+			test.ok(cronicle.getManagerJobLogSnapshot('unitwatchjob') === launch_task, "Manager log authorization found the canonical pending launch task");
+
+			// Existing prototype pollution must not extend the API update allowlist
+			// when updateLocalJob later iterates its stub with `for...in`.
+			launch_task.log_file = 'ORIGINAL-PENDING-LOG';
+			Object.defineProperty(Object.prototype, 'log_file', {
+				value: 'POLLUTED-PROTOTYPE-LOG', enumerable: true, configurable: true, writable: true
+			});
+			try {
+				var clean_updates = cronicle.getMutableJobUpdates({ notify_fail: 'safe@example.invalid' }, function () {});
+				var safe_stub = cronicle.buildMutableJobStub('unitwatchjob', clean_updates);
+				cronicle.updateLocalJob(safe_stub);
+				test.ok(Object.getPrototypeOf(clean_updates) === null, "Sanitized updates have no polluted prototype");
+				test.ok(Object.getPrototypeOf(safe_stub) === null, "Job update stub has no polluted prototype");
+				test.ok(launch_task.log_file == 'ORIGINAL-PENDING-LOG', "Inherited protected field did not mutate pending job");
+				test.ok(launch_task.notify_fail == 'safe@example.invalid', "Own allowlisted field still updated pending job");
+			}
+			finally {
+				delete Object.prototype.log_file;
+			}
+
+			var protected_manager_update = cronicle.updateLocalJobFromManager({
+				id: 'unitwatchjob',
+				log_file: 'FORGED-MANAGER-LOG'
+			});
+			test.ok(!protected_manager_update, "Worker rejected a protected field from a legacy manager update");
+			test.ok(launch_task.log_file == 'ORIGINAL-PENDING-LOG', "Legacy manager could not mutate the worker log path");
+			var allowed_manager_update = cronicle.updateLocalJobFromManager({
+				id: 'unitwatchjob',
+				suspended: true
+			});
+			test.ok(!!allowed_manager_update, "Worker accepted an allowlisted field from its manager");
+			test.ok(launch_task.suspended === true, "Allowlisted manager update reached the pending job");
+
+			// A locally polluted prototype must not supply the job identity for a
+			// manager update that omitted its own id field.
+			Object.defineProperty(Object.prototype, 'id', {
+				value: 'unitwatchjob', enumerable: true, configurable: true, writable: true
+			});
+			try {
+				var inherited_id_update = cronicle.updateLocalJobFromManager({
+					notify_fail: 'polluted-id@example.invalid'
+				});
+				test.ok(!inherited_id_update, "Worker rejected an update with only an inherited job ID");
+				test.ok(launch_task.notify_fail == 'safe@example.invalid', "Inherited job ID could not select and mutate a pending job");
+			}
+			finally {
+				delete Object.prototype.id;
+			}
+
+			var array_id_update = cronicle.updateLocalJobFromManager({
+				id: [ 'unitwatchjob' ],
+				notify_success: 'array-id@example.invalid'
+			});
+			test.ok(!array_id_update, "Worker rejected a coerced array job ID");
+			test.ok(!launch_task.notify_success, "Array job ID could not select and mutate a pending job");
+
+			var proto_had_suspended = Object.prototype.hasOwnProperty.call(Object.prototype, 'suspended');
+			var proto_suspended = Object.prototype.suspended;
+			try {
+				var magic_id_update = cronicle.updateLocalJobFromManager({
+					id: '__proto__',
+					suspended: false
+				});
+				test.ok(!magic_id_update, "Worker rejected the __proto__ job ID");
+				test.ok(
+					(Object.prototype.hasOwnProperty.call(Object.prototype, 'suspended') === proto_had_suspended) &&
+					(Object.prototype.suspended === proto_suspended),
+					"Magic job ID did not mutate Object.prototype"
+				);
+				test.ok(!cronicle.updateLocalJob({ id: '__proto__', suspended: false }), "Local job lookup rejected an inherited prototype target");
+				test.ok(
+					(Object.prototype.hasOwnProperty.call(Object.prototype, 'suspended') === proto_had_suspended) &&
+					(Object.prototype.suspended === proto_suspended),
+					"Direct local lookup did not mutate Object.prototype"
+				);
+			}
+			finally {
+				if (proto_had_suspended) Object.prototype.suspended = proto_suspended;
+				else delete Object.prototype.suspended;
+			}
 			
 			cronicle.internalQueue = old_queue;
 			test.done();
+		},
+
+		function testJobLogTransferBoundary(test) {
+			var outside_log = path.join(os.tmpdir(), 'cronicle-edge-unit-outside-' + process.pid + '.log');
+			var traversal_id = '../cronicle-edge-unit-outside-' + process.pid;
+			var symlink_id = 'unitfetchsymlink';
+			var hardlink_id = 'unitfetchhardlink';
+			var legacy_id = 'unitfetchlegacy';
+			var valid_id = 'unitfetchvalid';
+			var empty_id = 'unitfetchempty';
+			var symlink_log = cronicle.getJobLogFilePath(symlink_id, false);
+			var hardlink_log = cronicle.getJobLogFilePath(hardlink_id, false);
+			var hardlink_copy = hardlink_log + '.copy';
+			var legacy_log = cronicle.getJobLogFilePath(legacy_id, false);
+			var valid_log = cronicle.getJobLogFilePath(valid_id, false);
+			var empty_log = cronicle.getJobLogFilePath(empty_id, false);
+
+			[ outside_log, symlink_log, hardlink_log, hardlink_copy, legacy_log, valid_log, empty_log ].forEach(function (file) {
+				try { fs.unlinkSync(file); }
+				catch (err) { if (err.code != 'ENOENT') throw err; }
+			});
+			fs.writeFileSync(outside_log, 'OUTSIDE SECRET');
+
+			var original_request_get = cronicle.request.get;
+			var fetch_calls = [];
+			var source_worker = {
+				hostname: 'real-worker.example',
+				ip: '127.0.0.1',
+				active_jobs: {
+					unitsourcebinding: { id: 'unitsourcebinding', hostname: 'real-worker.example', detached: 0 },
+					unitunknownsource: { id: 'unitunknownsource', hostname: 'real-worker.example', detached: 0 }
+				}
+			};
+			cronicle.remoteLogFetchJobs.unitsourcebinding = {
+				id: 'unitsourcebinding',
+				hostname: 'real-worker.example',
+				detached: 0,
+				category: 'general',
+				target: 'maingrp'
+			};
+			cronicle.request.get = function () { fetch_calls.push(true); };
+			cronicle.fetchStoreJobLog({
+				id: 'unitsourcebinding',
+				hostname: 'forged-worker.example',
+				log_file: outside_log
+			}, source_worker);
+			test.ok(fetch_calls.length == 0, "Worker payload cannot redirect a fetch to another host");
+			cronicle.fetchStoreJobLog({
+				id: 'unitunknownsource',
+				hostname: 'real-worker.example'
+			}, source_worker);
+			test.ok(fetch_calls.length == 0, "Worker cannot choose an ID absent from the manager snapshot");
+			cronicle.request.get = original_request_get;
+
+			cronicle.remoteLogFetchJobs.unitfinishbinding = {
+				id: 'unitfinishbinding',
+				hostname: 'real-worker.example',
+				detached: 1,
+				category: 'manager-category',
+				target: 'manager-group',
+				event: 'manager-event',
+				event_title: 'Manager Event',
+				plugin: 'manager-plugin'
+			};
+			var bound_finished_job = cronicle.bindRemoteFinishedJob({
+				id: 'unitfinishbinding',
+				hostname: 'real-worker.example',
+				detached: 0,
+				category: 'forged-category',
+				target: 'forged-group',
+				event: 'forged-event',
+				event_title: 'Forged Event',
+				plugin: 'forged-plugin',
+				code: 7,
+				description: 'worker result'
+			}, source_worker);
+			test.ok(!!bound_finished_job, "Assigned worker completion was accepted");
+			test.ok(bound_finished_job.hostname == 'real-worker.example', "Completion hostname came from the manager snapshot");
+			test.ok(bound_finished_job.detached == 1, "Completion detached mode came from the manager snapshot");
+			test.ok(bound_finished_job.category == 'manager-category', "Completion category came from the manager snapshot");
+			test.ok(bound_finished_job.target == 'manager-group', "Completion group came from the manager snapshot");
+			test.ok(bound_finished_job.event == 'manager-event', "Completion event came from the manager snapshot");
+			test.ok(bound_finished_job.event_title == 'Manager Event', "Completion title came from the manager snapshot");
+			test.ok(bound_finished_job.plugin == 'manager-plugin', "Completion plugin came from the manager snapshot");
+			test.ok((bound_finished_job.code == 7) && (bound_finished_job.description == 'worker result'), "Worker result fields were retained");
+			test.ok(!cronicle.bindRemoteFinishedJob({ id: 'unitfinishbinding' }, {
+				hostname: 'different-worker.example'
+			}), "A different worker could not finish the assigned job");
+			delete cronicle.remoteLogFetchJobs.unitfinishbinding;
+
+			async.series([
+				function (callback) {
+					// Descriptor close must wait for delayed read and write callbacks on
+					// protocol/storage error paths.
+					var events = [];
+					var fake_io = {
+						read: function (fd, buffer, offset, length, position, done) {
+							setTimeout(function () {
+								buffer.write('R', offset);
+								events.push('read');
+								done(null, 1, buffer);
+							}, 30);
+						},
+						write: function (fd, buffer, offset, length, position, done) {
+							setTimeout(function () {
+								events.push('write');
+								done(null, length, buffer);
+							}, 20);
+						},
+						close: function (fd, done) {
+							events.push('close');
+							done();
+						}
+					};
+					var owner = cronicle.createJobLogDescriptorOwner(123, fake_io);
+					owner.read(Buffer.alloc(1), 0, 1, 0, function (err) { test.ok(!err, "Delayed descriptor read completed"); });
+					owner.write(Buffer.from('W'), 0, 1, 0, function (err) { test.ok(!err, "Delayed descriptor write completed"); });
+					owner.close(function (err) {
+						test.ok(!err, "Descriptor owner closed without error");
+						test.ok(events.indexOf('close') > events.indexOf('read'), "Descriptor close waited for pending read");
+						test.ok(events.indexOf('close') > events.indexOf('write'), "Descriptor close waited for pending write");
+						callback();
+					});
+					test.ok(events.indexOf('close') < 0, "Descriptor did not close synchronously over pending I/O");
+				},
+				function (callback) {
+					var original_delete = cronicle.deleteJobLogIfUnchanged;
+					var delete_calls = 0;
+					cronicle.deleteJobLogIfUnchanged = function () { delete_calls++; };
+					var failed_response = new EventEmitter();
+					var failed_source = new EventEmitter();
+					cronicle.deleteJobLogAfterCompleteTransfer(failed_response, failed_source, 'failed.log', {});
+					failed_response.emit('finish');
+					failed_source.emit('error', new Error('deliberate read failure'));
+					test.ok(delete_calls == 0, "Response finish after source error did not delete worker log");
+
+					var good_response = new EventEmitter();
+					var good_source = new EventEmitter();
+					cronicle.deleteJobLogAfterCompleteTransfer(good_response, good_source, 'good.log', {});
+					good_source.emit('end');
+					test.ok(delete_calls == 0, "Clean source EOF alone did not delete before response finish");
+					good_response.emit('finish');
+					test.ok(delete_calls == 1, "Clean source EOF plus response finish deleted exactly once");
+
+					var short_response = new EventEmitter();
+					var short_source = new EventEmitter();
+					short_source.jobLogComplete = false;
+					short_source.jobLogBytesRead = 4;
+					cronicle.deleteJobLogAfterCompleteTransfer(short_response, short_source, 'short.log', {}, 10);
+					short_source.emit('end');
+					short_response.emit('finish');
+					test.ok(delete_calls == 1, "Clean EOF shorter than the committed size preserved the worker log");
+					cronicle.deleteJobLogIfUnchanged = original_delete;
+					callback();
+				},
+				function (callback) {
+					// A disconnected HTTP client must destroy a paused source and close
+					// its held descriptor after any pending positional read, without
+					// deleting the worker log.
+					var original_delete = cronicle.deleteJobLogIfUnchanged;
+					var delete_calls = 0;
+					var events = [];
+					cronicle.deleteJobLogIfUnchanged = function () { delete_calls++; };
+					var fake_io = {
+						read: function (fd, buffer, offset, length, position, done) {
+							setTimeout(function () {
+								buffer.write('R', offset);
+								events.push('read');
+								done(null, 1, buffer);
+							}, 20);
+						},
+						close: function (fd, done) {
+							events.push('close');
+							test.ok(events.indexOf('close') > events.indexOf('read'), "Aborted transfer waited for pending descriptor read");
+							test.ok(delete_calls == 0, "Aborted transfer preserved the worker log");
+							cronicle.deleteJobLogIfUnchanged = original_delete;
+							done();
+							callback();
+						}
+					};
+					var owner = cronicle.createJobLogDescriptorOwner(456, fake_io);
+					var source = cronicle.createJobLogDescriptorStream(owner, 1024);
+					var close_descriptor = function () { owner.close(function () {}); };
+					source.once('end', close_descriptor);
+					source.once('error', close_descriptor);
+					source.once('close', close_descriptor);
+					var response = new EventEmitter();
+					cronicle.deleteJobLogAfterCompleteTransfer(response, source, 'aborted.log', {}, 1024);
+					source.read(1);
+					response.emit('close');
+					test.ok(source.destroyed, "Response close destroyed the paused source stream");
+					test.ok(events.indexOf('close') < 0, "Descriptor remained open while its read was pending");
+				},
+				function (callback) {
+					var original_upload = cronicle.uploadJobLog;
+					var upload_calls = 0;
+					cronicle.uploadJobLog = function () { upload_calls++; };
+					cronicle.request.get = function (url, options, request_callback) {
+						fetch_calls.push({ url: url, options: options });
+						cronicle.request.get = original_request_get;
+						var private_dir = path.dirname(options.download.path);
+						test.ok(url.indexOf('path=') < 0, "Manager protocol has no path parameter");
+						test.ok((url.indexOf(outside_log) < 0) && (url.indexOf(encodeURIComponent(outside_log)) < 0), "Manager did not forward worker-supplied log_file");
+						test.ok(path.basename(options.download.path) == 'unitsourcebinding.log', "Manager tied the temporary filename to the known job ID");
+						test.ok((fs.statSync(private_dir).mode & 0o777) == 0o700, "Manager download directory is private");
+						var response_aborted = false;
+						var response = {
+							statusCode: 200,
+							headers: { 'content-type': 'application/json' },
+							destroy: function () { response_aborted = true; this.destroyed = true; }
+						};
+						var accepted = options.preflight(null, response, options.download);
+						test.ok(accepted === false, "Manager rejected HTTP 200 without the transfer protocol header");
+						test.ok(response_aborted, "Manager aborted incompatible response instead of buffering its body");
+						request_callback(null, response, Buffer.from('{"code":"api"}'));
+						setTimeout(function () {
+							test.ok(upload_calls == 0, "Incompatible HTTP 200 body was not uploaded as a job log");
+							test.ok(!fs.existsSync(private_dir), "Rejected manager download was cleaned from the private directory");
+							cronicle.uploadJobLog = original_upload;
+							callback();
+						}, 50);
+					};
+					cronicle.fetchStoreJobLog({
+						id: 'unitsourcebinding',
+						hostname: 'real-worker.example',
+						log_file: outside_log
+					}, source_worker);
+				},
+				function (callback) {
+					// A protocol-valid 200 response is not sufficient: storage must only
+					// begin after the downloaded bytes exactly match Content-Length.
+					cronicle.remoteLogFetchJobs.unitsourcebinding = {
+						id: 'unitsourcebinding',
+						hostname: 'real-worker.example',
+						detached: 0,
+						category: 'general',
+						target: 'maingrp'
+					};
+					var original_descriptor_store = cronicle.storeJobLogFromDescriptor;
+					var store_calls = 0;
+					var private_dir = '';
+					cronicle.storeJobLogFromDescriptor = function () { store_calls++; };
+					cronicle.request.get = function (url, options, request_callback) {
+						cronicle.request.get = original_request_get;
+						private_dir = path.dirname(options.download.path);
+						var response = Readable.from([ 'SHORT' ]);
+						response.statusCode = 200;
+						response.headers = {
+							'content-type': 'text/plain; charset=utf-8',
+							'x-cronicle-job-log-protocol': '2',
+							'content-length': '6'
+						};
+						options.download.once('finish', function () {
+							request_callback(null, response);
+							setTimeout(function () {
+								test.ok(store_calls == 0, "Short manager download was not stored");
+								test.ok(!fs.existsSync(private_dir), "Short manager download was cleaned up");
+								cronicle.storeJobLogFromDescriptor = original_descriptor_store;
+								callback();
+							}, 50);
+						});
+						options.preflight(null, response, options.download);
+					};
+					cronicle.fetchStoreJobLog({
+						id: 'unitsourcebinding',
+						hostname: 'real-worker.example'
+					}, source_worker);
+				},
+				function (callback) {
+					// A same-UID job can discover and replace a manager temp pathname.
+					// Prove the storage upload remains bound to the O_EXCL descriptor.
+					cronicle.remoteLogFetchJobs.unitsourcebinding = {
+						id: 'unitsourcebinding',
+						hostname: 'real-worker.example',
+						detached: 0,
+						category: 'general',
+						target: 'maingrp'
+					};
+					var original_put_stream = cronicle.storage.putStream;
+					var original_descriptor_store = cronicle.storeJobLogFromDescriptor;
+					var original_copy_dir = server.config.get('copy_job_logs_to');
+					var archive_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cronicle-job-archive-'));
+					server.config.set('copy_job_logs_to', archive_dir);
+					var manager_temp_path = '';
+					var held_path = '';
+					var stored_bytes = '';
+					var descriptor_store_done = false;
+					var replacement_skipped = false;
+					cronicle.storeJobLogFromDescriptor = function (job, fd, store_callback) {
+						original_descriptor_store.call(cronicle, job, fd, function (err) {
+							descriptor_store_done = true;
+							store_callback(err);
+						});
+					};
+					cronicle.storage.putStream = function (key, gzip_stream, put_callback) {
+						var chunks = [];
+						test.ok(key == 'jobs/unitsourcebinding/log.txt.gz', "Manager stored the known job ID slot");
+						gzip_stream.on('data', function (chunk) { chunks.push(chunk); });
+						gzip_stream.on('end', function () {
+							zlib.gunzip(Buffer.concat(chunks), function (err, data) {
+								test.ok(!err, "Descriptor-backed manager upload produced valid gzip");
+								stored_bytes = String(data || '');
+								put_callback(err);
+							});
+						});
+					};
+					cronicle.request.get = function (url, options, request_callback) {
+						cronicle.request.get = original_request_get;
+						manager_temp_path = options.download.path;
+						held_path = manager_temp_path + '.held';
+						var response = Readable.from([ 'ORIGINAL MANAGER DOWNLOAD' ]);
+						response.statusCode = 200;
+						response.headers = {
+							'content-type': 'text/plain; charset=utf-8',
+							'x-cronicle-job-log-protocol': '2',
+							'content-length': String(Buffer.byteLength('ORIGINAL MANAGER DOWNLOAD'))
+						};
+						options.download.once('finish', function () {
+							fs.renameSync(manager_temp_path, held_path);
+							try { fs.symlinkSync(outside_log, manager_temp_path); }
+							catch (err) {
+								if ((err.code != 'EPERM') && (err.code != 'EACCES') && (err.code != 'ENOTSUP')) throw err;
+								replacement_skipped = true;
+								test.ok(true, "Manager replacement regression skipped because this platform forbids symlink creation");
+							}
+							request_callback(null, response);
+						});
+						options.preflight(null, response, options.download);
+					};
+					cronicle.fetchStoreJobLog({
+						id: 'unitsourcebinding',
+						hostname: 'real-worker.example',
+						event_title: 'Descriptor Archive',
+						log_file: outside_log
+					}, source_worker);
+
+					var check_upload = function () {
+						var archive_files = fs.readdirSync(archive_dir);
+						if (!stored_bytes || !descriptor_store_done || !archive_files.length) return setTimeout(check_upload, 10);
+						test.ok(stored_bytes == 'ORIGINAL MANAGER DOWNLOAD', "Path replacement could not change manager upload bytes");
+						if (!replacement_skipped) test.ok(stored_bytes.indexOf('OUTSIDE SECRET') < 0, "Manager did not upload replacement symlink contents");
+						test.ok(archive_files.length == 1, "Descriptor-backed manager upload created one optional archive");
+						test.ok(fs.readFileSync(path.join(archive_dir, archive_files[0]), 'utf8') == 'ORIGINAL MANAGER DOWNLOAD', "Optional archive used the same held descriptor bytes");
+						cronicle.storage.putStream = original_put_stream;
+						cronicle.storeJobLogFromDescriptor = original_descriptor_store;
+						server.config.set('copy_job_logs_to', original_copy_dir);
+						fs.unlinkSync(path.join(archive_dir, archive_files[0]));
+						fs.rmdirSync(archive_dir);
+						try { fs.unlinkSync(manager_temp_path); } catch (err) { if (err.code != 'ENOENT') return callback(err); }
+						try { fs.unlinkSync(held_path); } catch (err) { if (err.code != 'ENOENT') return callback(err); }
+						try { fs.rmdirSync(path.dirname(manager_temp_path)); } catch (err) { if (err.code != 'ENOENT') return callback(err); }
+						callback();
+					};
+					check_upload();
+				},
+				function (callback) {
+					// The old protocol allowed an authenticated caller to select any path.
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						path: outside_log,
+						auth: Tools.digestHex(outside_log + config.secret_key)
+					});
+					request.get(url, function (err, resp, data) {
+						test.ok(!err, "Signed outside-path request completed");
+						test.ok(resp.statusCode == 403, "Signed outside path was rejected");
+						test.ok(String(data).indexOf('OUTSIDE SECRET') < 0, "Outside file contents were not disclosed");
+						test.ok(fs.existsSync(outside_log), "Outside file was not deleted");
+						callback();
+					});
+				},
+				function (callback) {
+					// A new worker safely accepts the exact canonical request from an old
+					// manager, allowing worker-first rolling upgrades.
+					fs.writeFileSync(legacy_log, 'LEGACY CANONICAL LOG');
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						path: legacy_log,
+						auth: Tools.digestHex(legacy_log + config.secret_key)
+					});
+					request.get(url, function (err, resp, data) {
+						test.ok(!err, "Canonical legacy request completed");
+						test.ok(resp.statusCode == 200, "Canonical legacy request remained compatible");
+						test.ok(String(data) == 'LEGACY CANONICAL LOG', "Canonical legacy request returned exact bytes");
+						test.ok(resp.headers['x-cronicle-job-log-protocol'] == '2', "Compatible worker advertises protocol v2");
+						setTimeout(function () {
+							test.ok(!fs.existsSync(legacy_log), "Canonical legacy job log was deleted after transfer");
+							callback();
+						}, 50);
+					});
+				},
+				function (callback) {
+					// Canonical equality, not a restrictive character allowlist, is the
+					// security boundary for worker-first compatibility.
+					var old_log_dir = server.config.get('log_dir');
+					var spaced_log_dir = path.join(os.tmpdir(), 'cronicle edge logs ' + process.pid);
+					fs.mkdirSync(path.join(spaced_log_dir, 'jobs'), { recursive: true });
+					server.config.set('log_dir', spaced_log_dir);
+					var spaced_id = 'unitfetchlegacyspace';
+					var spaced_log = cronicle.getJobLogFilePath(spaced_id, false);
+					fs.writeFileSync(spaced_log, 'LEGACY PATH WITH SPACE');
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						path: spaced_log,
+						auth: Tools.digestHex(spaced_log + config.secret_key)
+					});
+					request.get(url, function (err, resp, data) {
+						test.ok(!err, "Canonical legacy path with spaces completed");
+						test.ok(resp.statusCode == 200, "Canonical legacy path with spaces remained compatible");
+						test.ok(String(data) == 'LEGACY PATH WITH SPACE', "Legacy path with spaces returned exact bytes");
+						setTimeout(function () {
+							test.ok(!fs.existsSync(spaced_log), "Legacy path with spaces was deleted after complete transfer");
+							server.config.set('log_dir', old_log_dir);
+							fs.rmdirSync(path.join(spaced_log_dir, 'jobs'));
+							fs.rmdirSync(spaced_log_dir);
+							callback();
+						}, 50);
+					});
+				},
+				function (callback) {
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						id: traversal_id,
+						detached: 0,
+						auth: cronicle.getJobLogFetchAuth(traversal_id, false)
+					});
+					request.get(url, function (err, resp, data) {
+						test.ok(!err, "Traversal request completed");
+						test.ok(resp.statusCode == 200, "Traversal ID returned an API error");
+						test.ok(String(data).indexOf('OUTSIDE SECRET') < 0, "Traversal did not disclose outside contents");
+						test.ok(fs.existsSync(outside_log), "Traversal did not delete the outside file");
+						callback();
+					});
+				},
+				function (callback) {
+					try { fs.symlinkSync(outside_log, symlink_log); }
+					catch (err) {
+						if ((err.code == 'EPERM') || (err.code == 'EACCES') || (err.code == 'ENOTSUP')) {
+							test.ok(true, "Symlink regression skipped because this platform forbids symlink creation");
+							return callback();
+						}
+						return callback(err);
+					}
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						id: symlink_id,
+						detached: 0,
+						auth: cronicle.getJobLogFetchAuth(symlink_id, false)
+					});
+					request.get(url, function (err, resp, data) {
+						test.ok(!err, "Symlink request completed");
+						test.ok(resp.statusCode == 404, "Symlink job log was rejected");
+						test.ok(String(data).indexOf('OUTSIDE SECRET') < 0, "Symlink target contents were not disclosed");
+						test.ok(fs.lstatSync(symlink_log).isSymbolicLink(), "Rejected symlink was preserved");
+						test.ok(fs.existsSync(outside_log), "Symlink target was preserved");
+						fs.unlinkSync(symlink_log);
+						callback();
+					});
+				},
+				function (callback) {
+					fs.writeFileSync(hardlink_log, 'HARD LINK LOG');
+					try { fs.linkSync(hardlink_log, hardlink_copy); }
+					catch (err) {
+						fs.unlinkSync(hardlink_log);
+						if ((err.code == 'EPERM') || (err.code == 'EACCES') || (err.code == 'ENOTSUP')) {
+							test.ok(true, "Hardlink regression skipped because this platform forbids hardlink creation");
+							return callback();
+						}
+						return callback(err);
+					}
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						id: hardlink_id,
+						detached: 0,
+						auth: cronicle.getJobLogFetchAuth(hardlink_id, false)
+					});
+					request.get(url, function (err, resp) {
+						test.ok(!err, "Hardlink request completed");
+						test.ok(resp.statusCode == 404, "Multiply linked job log was rejected");
+						test.ok(fs.existsSync(hardlink_log) && fs.existsSync(hardlink_copy), "Rejected hardlinks were preserved");
+						fs.unlinkSync(hardlink_log);
+						fs.unlinkSync(hardlink_copy);
+						callback();
+					});
+				},
+				function (callback) {
+					fs.writeFileSync(valid_log, 'VALID JOB LOG');
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						id: valid_id,
+						detached: 0,
+						auth: cronicle.getJobLogFetchAuth(valid_id, false)
+					});
+					request.get(url, { headers: { 'Accept-Encoding': 'identity' } }, function (err, resp, data) {
+						test.ok(!err, "Valid job-log request completed");
+						test.ok(resp.statusCode == 200, "Valid in-directory job log was served");
+						test.ok(String(data) == 'VALID JOB LOG', "Valid job log bytes matched");
+						test.ok(/^text\/plain/i.test(resp.headers['content-type']), "Worker log is text/plain");
+						test.ok(resp.headers['content-length'] == String(Buffer.byteLength('VALID JOB LOG')), "Worker committed the exact log byte count");
+						test.ok(resp.headers['x-content-type-options'] == 'nosniff', "Worker log disables MIME sniffing");
+						test.ok(/no-store/.test(resp.headers['cache-control']), "Worker log is not cacheable");
+						setTimeout(function () {
+							test.ok(!fs.existsSync(valid_log), "Valid job log was deleted after the complete response");
+							callback();
+						}, 50);
+					});
+				},
+				function (callback) {
+					fs.writeFileSync(empty_log, '');
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						id: empty_id,
+						detached: 0,
+						auth: cronicle.getJobLogFetchAuth(empty_id, false)
+					});
+					request.get(url, { headers: { 'Accept-Encoding': 'identity' } }, function (err, resp, data) {
+						test.ok(!err, "Empty job-log request completed");
+						test.ok(resp.statusCode == 200, "Empty in-directory job log was served");
+						test.ok(Buffer.byteLength(data || '') == 0, "Empty job log returned zero bytes");
+						test.ok(resp.headers['content-length'] == '0', "Empty job log committed a zero-byte length");
+						setTimeout(function () {
+							test.ok(!fs.existsSync(empty_log), "Empty job log was deleted after the complete response");
+							callback();
+						}, 50);
+					});
+				},
+				function (callback) {
+					// Reproduce a path replacement after the safe descriptor is opened.
+					var race_id = 'unitfetchrace';
+					var race_log = cronicle.getJobLogFilePath(race_id, false);
+					var opened_log = race_log + '.opened';
+					try { fs.unlinkSync(race_log); } catch (err) { if (err.code != 'ENOENT') throw err; }
+					try { fs.unlinkSync(opened_log); } catch (err) { if (err.code != 'ENOENT') throw err; }
+					fs.writeFileSync(race_log, 'ORIGINAL DESCRIPTOR');
+					cronicle.openJobLogFile(race_log, function (err, fd, opened) {
+						test.ok(!err, "Race test opened the original regular file");
+						fs.renameSync(race_log, opened_log);
+						fs.writeFileSync(race_log, 'REPLACEMENT FILE');
+						var buffer = Buffer.alloc(64);
+						fs.read(fd, buffer, 0, buffer.length, 0, function (err, bytes_read) {
+							test.ok(!err, "Race test read from the opened descriptor");
+							test.ok(String(buffer.subarray(0, bytes_read)) == 'ORIGINAL DESCRIPTOR', "Replacement could not change streamed bytes");
+							fs.close(fd, function () {
+								cronicle.deleteJobLogIfUnchanged(race_log, opened);
+								setTimeout(function () {
+									test.ok(fs.readFileSync(race_log, 'utf8') == 'REPLACEMENT FILE', "Cleanup did not delete a replacement path");
+									fs.unlinkSync(race_log);
+									fs.unlinkSync(opened_log);
+									callback();
+								}, 50);
+							});
+						});
+					});
+				}
+			], function (err) {
+				delete cronicle.remoteLogFetchJobs.unitsourcebinding;
+				try { fs.unlinkSync(outside_log); } catch (cleanup_err) { if (cleanup_err.code != 'ENOENT') throw cleanup_err; }
+				test.ok(!err, "Job log transfer boundary checks completed");
+				test.done();
+			});
 		},
 	
 		
@@ -462,6 +1104,48 @@ module.exports = {
 				
 				test.done();
 			} );
+		},
+
+		function testCreateScopedLogSessions(test) {
+			var records = [
+				[ 'category_denied', {
+					username: 'unit_log_category_denied',
+					full_name: 'Category Denied',
+					email: 'category-denied@example.invalid',
+					active: 1,
+					privileges: { cat_limit: 1, grp_limit: 1, grp_maingrp: 1 }
+				} ],
+				[ 'group_denied', {
+					username: 'unit_log_group_denied',
+					full_name: 'Group Denied',
+					email: 'group-denied@example.invalid',
+					active: 1,
+					privileges: { cat_limit: 1, cat_general: 1, grp_limit: 1 }
+				} ],
+				[ 'allowed', {
+					username: 'unit_log_allowed',
+					full_name: 'Log Allowed',
+					email: 'log-allowed@example.invalid',
+					active: 1,
+					privileges: { cat_limit: 1, cat_general: 1, grp_limit: 1, grp_maingrp: 1 }
+				} ]
+			];
+
+			async.eachSeries(records, function (record, callback) {
+				var session_key = log_auth_sessions[record[0]];
+				storage.put('users/' + record[1].username, record[1], function (err) {
+					if (err) return callback(err);
+					storage.put('sessions/' + session_key, {
+						id: session_key,
+						username: record[1].username,
+						created: Tools.timeNow(true),
+						modified: Tools.timeNow(true)
+					}, callback);
+				});
+			}, function (err) {
+				test.ok(!err, "Scoped log users and sessions were created");
+				test.done();
+			});
 		},
 		
 		function testAPIConfig(test) {
@@ -1111,6 +1795,99 @@ module.exports = {
 				test.done();
 			} );
 		},
+
+		function testActiveJobLogAuthorization(test) {
+			var self = this;
+			var denied_sessions = [
+				{ name: 'missing session', id: '' },
+				{ name: 'foreign category', id: log_auth_sessions.category_denied },
+				{ name: 'foreign group', id: log_auth_sessions.group_denied }
+			];
+
+			async.eachSeries(denied_sessions, function (entry, callback) {
+				var query = { id: self.job_id };
+				if (entry.id) query.session_id = entry.id;
+				request.get(api_url + '/app/get_live_job_log' + Tools.composeQueryString(query), function (err, resp, data) {
+					test.ok(!err, "Raw live-log denial completed for " + entry.name);
+					test.ok(resp.statusCode == 200, "Raw live-log denial is an API response for " + entry.name);
+					test.ok(String(data).indexOf('UNIT TEST STRING') < 0, "Raw live-log denial did not leak log bytes for " + entry.name);
+					callback();
+				});
+			}, function (err) {
+				if (err) return test.done(err);
+				async.eachSeries(denied_sessions, function (entry, callback) {
+					var params = { id: self.job_id };
+					if (entry.id) params.session_id = entry.id;
+					request.json(api_url + '/app/get_live_console', params, function (err, resp, data) {
+						test.ok(!err, "Live-console denial completed for " + entry.name);
+						test.ok(resp.statusCode == 200, "Live-console denial is an API response for " + entry.name);
+						test.ok(data.code != 0, "Live console denied " + entry.name);
+						test.ok(!data.data || (data.data.indexOf('UNIT TEST STRING') < 0), "Live-console denial did not leak log bytes for " + entry.name);
+						callback();
+					});
+				}, function (err) {
+					if (err) return test.done(err);
+					var raw_query = { id: self.job_id, session_id: log_auth_sessions.allowed };
+					request.get(api_url + '/app/get_live_job_log' + Tools.composeQueryString(raw_query), function (err, resp, data) {
+						test.ok(!err, "Scoped user requested raw live log");
+						test.ok(resp.statusCode == 200, "Scoped user received raw live log");
+						test.ok(String(data).length > 0, "Scoped user received live log bytes");
+						test.ok(/^text\/plain/i.test(resp.headers['content-type']), "Raw live log is text/plain");
+						test.ok(resp.headers['x-content-type-options'] == 'nosniff', "Raw live log disables MIME sniffing");
+						test.ok(/no-store/.test(resp.headers['cache-control']), "Raw live log is not cacheable");
+
+						request.json(api_url + '/app/get_live_console', {
+							id: self.job_id,
+							session_id: log_auth_sessions.allowed
+						}, function (err, resp, data) {
+							test.ok(!err, "Scoped user requested live console");
+							test.ok(resp.statusCode == 200, "Scoped user received live console response");
+							test.ok(!data.code, "Scoped user was authorized for live console");
+							test.ok(typeof data.data == 'string', "Live console returned log data");
+
+							var remote_id = 'unitremotelivelog';
+							var remote_file = cronicle.getJobLogFilePath(remote_id, false);
+							var old_worker = cronicle.workers['127.0.0.1'];
+							fs.writeFileSync(remote_file, 'REMOTE LIVE LOG');
+							cronicle.workers['127.0.0.1'] = {
+								hostname: '127.0.0.1',
+								ip: '127.0.0.1',
+								active_jobs: {
+									unitremotelivelog: {
+										id: remote_id,
+										hostname: '127.0.0.1',
+										category: 'general',
+										target: 'maingrp',
+										detached: 0
+									}
+								}
+							};
+							cronicle.remoteLogFetchJobs[remote_id] = {
+								id: remote_id,
+								hostname: '127.0.0.1',
+								category: 'general',
+								target: 'maingrp',
+								detached: 0
+							};
+							request.get(api_url + '/app/get_live_job_log' + Tools.composeQueryString({
+								id: remote_id,
+								session_id: log_auth_sessions.allowed
+							}), function (err, resp, data) {
+								test.ok(!err, "Manager proxied an authorized remote raw live log");
+								test.ok(resp.statusCode == 200, "Remote raw live log returned HTTP 200");
+								test.ok(String(data) == 'REMOTE LIVE LOG', "Remote raw live log returned exact bytes");
+								test.ok(/^text\/plain/i.test(resp.headers['content-type']), "Remote raw live log is text/plain");
+								fs.unlinkSync(remote_file);
+								delete cronicle.remoteLogFetchJobs[remote_id];
+								if (old_worker) cronicle.workers['127.0.0.1'] = old_worker;
+								else delete cronicle.workers['127.0.0.1'];
+								test.done();
+							});
+						});
+					});
+				});
+			});
+		},
 		
 		// app/get_live_job_log
 		
@@ -1118,12 +1895,15 @@ module.exports = {
 			// test get_live_job_log API (raw HTTP get, not a JSON API)
 			var self = this;
 			
-			request.get( api_url + '/app/get_live_job_log?id=' + this.job_id, function(err, resp, data) {
+			request.get( api_url + '/app/get_live_job_log?id=' + this.job_id + '&session_id=' + session_id, function(err, resp, data) {
 				
 				test.ok( !err, "No error requesting API" );
 				test.ok( resp.statusCode == 200, "HTTP 200 from API" );
 				test.ok( !!data, "Got data buffer" );
 				test.ok( data.length > 0, "Data buffer has length" );
+				test.ok( /^text\/plain/i.test(resp.headers['content-type']), "Live log uses text/plain" );
+				test.ok( resp.headers['x-content-type-options'] == 'nosniff', "Live log disables MIME sniffing" );
+				test.ok( /no-store/.test(resp.headers['cache-control']), "Live log is not cacheable" );
 				
 				test.done();
 				
@@ -1166,6 +1946,75 @@ module.exports = {
 		},
 		
 		// app/update_job
+
+		function testAPIRejectProtectedJobUpdates(test) {
+			var self = this;
+			var job = cronicle.getAllActiveJobs()[this.job_id];
+			var original_log_file = job.log_file;
+			var original_hostname = job.hostname;
+			var original_pid = job.pid;
+
+			request.json(api_url + '/app/update_job', {
+				session_id: session_id,
+				id: this.job_id,
+				notify_fail: 'must-not-apply@example.invalid',
+				log_file: path.join(os.tmpdir(), 'outside-mutated.log')
+			}, function (err, resp, data) {
+				test.ok(!err, "Protected single-job update completed");
+				test.ok(resp.statusCode == 200, "Protected single-job update returned an API response");
+				test.ok(data.code != 0, "Single-job update rejected log_file atomically");
+
+				var current = cronicle.getAllActiveJobs()[self.job_id];
+				test.ok(current.log_file == original_log_file, "Single-job update preserved log_file");
+				test.ok(current.hostname == original_hostname, "Single-job update preserved hostname");
+				test.ok(current.pid == original_pid, "Single-job update preserved pid");
+				test.ok(current.notify_fail == 'test@test.com', "Single-job update did not partially apply mutable fields");
+
+				request.json(api_url + '/app/update_jobs', {
+					session_id: session_id,
+					event: self.event_id,
+					updates: {
+						notify_fail: 'must-not-apply-bulk@example.invalid',
+						log_file: path.join(os.tmpdir(), 'outside-mutated-bulk.log')
+					}
+				}, function (err, resp, data) {
+					test.ok(!err, "Protected bulk update completed");
+					test.ok(resp.statusCode == 200, "Protected bulk update returned an API response");
+					test.ok(data.code != 0, "Bulk update rejected log_file atomically");
+					current = cronicle.getAllActiveJobs()[self.job_id];
+					test.ok(current.log_file == original_log_file, "Bulk update preserved log_file");
+					test.ok(current.notify_fail == 'test@test.com', "Bulk update did not partially apply mutable fields");
+
+					request.json(api_url + '/app/update_job', {
+						session_id: session_id,
+						id: self.job_id,
+						timeout: { invalid: true }
+					}, function (err, resp, data) {
+						test.ok(!err, "Invalid allowlisted value request completed");
+						test.ok(resp.statusCode == 200, "Invalid allowlisted value returned an API response");
+						test.ok(data.code != 0, "Allowlisted fields still require valid types and values");
+						test.done();
+					});
+				});
+			});
+		},
+
+		function testAPIAllowlistedBulkJobUpdate(test) {
+			var self = this;
+			request.json(api_url + '/app/update_jobs', {
+				session_id: session_id,
+				event: this.event_id,
+				updates: { notify_fail: 'bulk@example.invalid' }
+			}, function (err, resp, data) {
+				test.ok(!err, "Allowlisted bulk update completed");
+				test.ok(resp.statusCode == 200, "Allowlisted bulk update returned HTTP 200");
+				test.ok(data.code == 0, "Allowlisted bulk update succeeded");
+				test.ok(data.count == 1, "Allowlisted bulk update changed one job");
+				var job = cronicle.getAllActiveJobs()[self.job_id];
+				test.ok(job.notify_fail == 'bulk@example.invalid', "Allowlisted bulk field was applied");
+				test.done();
+			});
+		},
 		
 		function testAPIUpdateJob(test) {
 			// test app/update_job api
@@ -1246,6 +2095,38 @@ module.exports = {
 		},
 		
 		// app/get_job_log
+
+		function testCompletedJobLogAuthorization(test) {
+			var self = this;
+			var denied_sessions = [
+				{ name: 'missing session', id: '' },
+				{ name: 'foreign category', id: log_auth_sessions.category_denied },
+				{ name: 'foreign group', id: log_auth_sessions.group_denied }
+			];
+
+			async.eachSeries(denied_sessions, function (entry, callback) {
+				var query = { id: self.job_id };
+				if (entry.id) query.session_id = entry.id;
+				request.get(api_url + '/app/get_job_log' + Tools.composeQueryString(query), function (err, resp, data) {
+					test.ok(!err, "Completed-log denial completed for " + entry.name);
+					test.ok(resp.statusCode == 200, "Completed-log denial is an API response for " + entry.name);
+					test.ok(String(data).indexOf('# Job completed successfully') < 0, "Completed-log denial did not leak bytes for " + entry.name);
+					callback();
+				});
+			}, function (err) {
+				if (err) return test.done(err);
+				var query = { id: self.job_id, session_id: log_auth_sessions.allowed };
+				request.get(api_url + '/app/get_job_log' + Tools.composeQueryString(query), function (err, resp, data) {
+					test.ok(!err, "Scoped user requested completed log");
+					test.ok(resp.statusCode == 200, "Scoped user received completed log");
+					test.ok(String(data).match(/success/i), "Scoped user received completed log bytes");
+					test.ok(/^text\/plain/i.test(resp.headers['content-type']), "Completed log is text/plain");
+					test.ok(resp.headers['x-content-type-options'] == 'nosniff', "Completed log disables MIME sniffing");
+					test.ok(/no-store/.test(resp.headers['cache-control']), "Completed log is not cacheable");
+					test.done();
+				});
+			});
+		},
 		
 		function testAPIGetJobLog(test) {
 			// test get_job_log API (raw HTTP get, not a JSON API)
@@ -1258,6 +2139,9 @@ module.exports = {
 				test.ok( !!data, "Got data buffer" );
 				test.ok( data.length > 0, "Data buffer has length" );
 				test.ok( data.toString().match(/success/i), "Log buffer contains expected string" );
+				test.ok( /^text\/plain/i.test(resp.headers['content-type']), "Completed log uses text/plain" );
+				test.ok( resp.headers['x-content-type-options'] == 'nosniff', "Completed log disables MIME sniffing" );
+				test.ok( /no-store/.test(resp.headers['cache-control']), "Completed log is not cacheable" );
 				
 				test.done();
 				


### PR DESCRIPTION
## Summary

- require an authenticated session plus category and target-group authorization for completed logs, live logs, live console output, and log watchers
- bind remote worker log transfer to the manager-owned job snapshot and authenticated source socket instead of accepting a caller-controlled filesystem path
- keep the worker log file open through transfer, commit its exact byte length, reject symlinks and hardlinks, and delete it only after a complete successful response
- restrict live job updates at both API and worker boundaries so execution identity, log paths, and other control fields cannot be changed through `update_job` or `update_jobs`

## Security and compatibility boundaries

`protect_job_log=false` no longer makes job logs public. This is an intentional fail-closed policy change: all job-log access now requires authentication and the same category/group authorization as the job itself. Raw job logs can contain credentials and command output, so retaining the unauthenticated opt-out would leave the reported disclosure path open.

The manager owns the canonical job snapshot and source worker identity. A worker requests transfer by job ID; the manager validates the source socket, resolves the expected job, and accepts only the assigned log stream with an exact `Content-Length`. The implementation never accepts a worker-supplied arbitrary log path. File validation and streaming use one held descriptor with `O_NOFOLLOW` where available, regular-file and single-link checks, and exact byte-count verification.

Rolling deployment is workers first. A new manager fails closed with an old worker that does not implement the ID-bound protocol.

This proposal intentionally does not claim restart-safe or two-phase delivery. Transfer assignment is held in manager memory, so a manager restart or failover during the handoff may orphan a worker log. A durable assignment/acknowledgement state machine would be a separate persistent-state design. The pre-existing local-manager completion path also remains outside this manager-to-worker transfer scope and should receive its own descriptor-safe follow-up.

## Validation

- `npm test` — 98/98 tests, 554 assertions, 2 suites
- regression coverage for unauthenticated and cross-RBAC completed/live/console/watch access
- real HTTP transfer tests for source binding, HMAC validation, exact length, truncation, abort, symlink, hardlink, replacement, and delete-on-success behavior
- prototype-chain and bulk-update regressions for the worker update boundary
- `node --check` for all changed JavaScript sources
- `git diff --check`
- independent implementation review: approved

## Review provenance

The issues and initial patches were proposed by a Codex Ultra security review (fork PRs [frankii91/cronicle-edge#33](https://github.com/frankii91/cronicle-edge/pull/33) and [frankii91/cronicle-edge#44](https://github.com/frankii91/cronicle-edge/pull/44)). Those patches were not ported as-is: one covered only a subset of log endpoints, while the other still trusted a mutable path and remained exposed to link and time-of-check/time-of-use races. This version was manually re-analyzed across the complete manager/worker data flow, exercised with adversarial filesystem and HTTP regressions, independently reviewed, and is submitted for maintainer review in line with our prior discussion.
