### PR TITLE
fix: bind worker run-as identity to signed job dispatch

### DIFF
--- a/htdocs/js/pages/admin/Plugins.js
+++ b/htdocs/js/pages/admin/Plugins.js
@@ -187,8 +187,8 @@ Class.add( Page.Admin, {
 				newPlugin.ipc = !!plugin.ipc
 				newPlugin.wf = !!plugin.wf
 				newPlugin.stdin = !!plugin.stdin
-				if(typeof plugin.uid === 'string' || parseInt(plugin.uid)) newPlugin.uid = plugin.uid
-				if(typeof plugin.gid === 'string' || parseInt(plugin.gid)) newPlugin.gid = plugin.gid
+				if(typeof plugin.uid === 'string' || typeof plugin.uid === 'number') newPlugin.uid = plugin.uid
+				if(typeof plugin.gid === 'string' || typeof plugin.gid === 'number') newPlugin.gid = plugin.gid
 				if(typeof plugin.cwd === 'string') newPlugin.cwd = plugin.cwd
 				if(typeof plugin.script === 'string') newPlugin.script = plugin.script 
 
@@ -564,7 +564,7 @@ Class.add( Page.Admin, {
 		html += get_form_table_spacer();
 		
 		// advanced options
-		var adv_expanded = !!(plugin.cwd || plugin.uid);
+		var adv_expanded = !!(plugin.cwd || plugin.uid || plugin.gid || (plugin.uid === 0) || (plugin.gid === 0));
 		html += get_form_table_row( 'Advanced', 
 		`<div autocomplete="off" style="font-size:13px;${adv_expanded ? 'display:none;' : ''}"><span class="link addme" onMouseUp="$P().expand_fieldset($(this))"><i class="fa fa-plus-square-o">&nbsp;</i>Advanced Options</span></div>
 		<fieldset style="padding:10px 10px 0 10px; margin-bottom:5px;${adv_expanded ? '' : 'display:none;'}"><legend class="link addme" onMouseUp="$P().collapse_fieldset($(this))"><i class="fa fa-minus-square-o">&nbsp;</i>Advanced Options</legend>

--- a/lib/api.js
+++ b/lib/api.js
@@ -264,6 +264,8 @@ module.exports = Class.create({
 		delete event.uid;
 		delete event.gid;
 		delete event.env;
+		delete event.debug_sudo;
+		delete event._cronicle_run_as;
 
 
 		// make sure title doesn't contain HTML metacharacters

--- a/lib/api.js
+++ b/lib/api.js
@@ -525,6 +525,171 @@ module.exports = Class.create({
 
 	},
 
+	isSafeJobIdentifier: function(id) {
+		return (typeof id == 'string') && /^\w+$/.test(id) &&
+			[ '__proto__', 'prototype', 'constructor' ].indexOf(id) < 0;
+	},
+
+	isSafeEventIdentifier: function(id) {
+		return (typeof id == 'string') && /^\w+$/.test(id);
+	},
+
+	getWorkflowSignature: function(job_id) {
+		// Keep the existing wire format for rolling upgrades.  The signature is
+		// derived when needed, rather than retained in a manager-local bearer map.
+		return Tools.digestHex(job_id + this.server.config.get('secret_key'), 'MD5');
+	},
+
+	workflowSignatureMatches: function(job_id, supplied) {
+		if (!this.isSafeJobIdentifier(job_id) || (typeof supplied != 'string')) return false;
+		var expected = Buffer.from(this.getWorkflowSignature(job_id), 'utf8');
+		var actual = Buffer.from(supplied, 'utf8');
+		if (actual.length != expected.length) return false;
+		return crypto.timingSafeEqual(expected, actual);
+	},
+
+	isTrustedWorkflowJob: function(job, job_id) {
+		if (!job || (typeof job != 'object')) return false;
+		if (!Object.prototype.hasOwnProperty.call(job, 'id') || (job.id !== job_id)) return false;
+
+		var is_builtin = Object.prototype.hasOwnProperty.call(job, 'plugin') && (job.plugin === 'workflow');
+		var is_custom = Object.prototype.hasOwnProperty.call(job, 'is_wf') && !!job.is_wf;
+		return is_builtin || is_custom;
+	},
+
+	getWorkflowEventMap: function(job) {
+		// Authorize against the immutable workflow snapshot carried by the parent
+		// job.  This deliberately supports children in other categories / targets.
+		var allowed = Object.create(null);
+		var workflow = (job && Object.prototype.hasOwnProperty.call(job, 'workflow') && Array.isArray(job.workflow)) ?
+			job.workflow : [];
+		var options = (job && Object.prototype.hasOwnProperty.call(job, 'options') && job.options &&
+			(typeof job.options == 'object') && !Array.isArray(job.options)) ?
+			job.options : {};
+		var raw_start = options.wf_start_from_step || 1;
+		if (!raw_start) raw_start = 1;
+		var start_from;
+		try { start_from = Number(raw_start); }
+		catch (err) { return allowed; }
+		if (!Number.isFinite(start_from)) return allowed;
+
+		for (var idx = 0; idx < workflow.length; idx++) {
+			if (!Object.prototype.hasOwnProperty.call(workflow, idx)) continue;
+			var step = workflow[idx];
+			if (!step || (typeof step != 'object') || Array.isArray(step)) continue;
+			if ((idx + 1) < start_from) continue;
+			if (step.disabled) continue;
+			if (!Object.prototype.hasOwnProperty.call(step, 'id')) continue;
+			if (!this.isSafeEventIdentifier(step.id)) continue;
+			allowed[step.id] = true;
+		}
+
+		return allowed;
+	},
+
+	getWorkflowCapability: function(job_id, signature) {
+		if (!this.isSafeJobIdentifier(job_id)) return false;
+		var job = this.findJob(job_id);
+		if (!this.isTrustedWorkflowJob(job, job_id)) return false;
+		if (!this.workflowSignatureMatches(job_id, signature)) return false;
+		return { job: job, event_ids: this.getWorkflowEventMap(job) };
+	},
+
+	workflowCanRunEvent: function(user, event_id) {
+		if (!user || !this.isSafeJobIdentifier(user.workflow) || !this.isSafeEventIdentifier(event_id)) return false;
+		var parent = this.findJob(user.workflow);
+		if (!this.isTrustedWorkflowJob(parent, user.workflow)) return false;
+		var event_ids = this.getWorkflowEventMap(parent);
+		return Object.prototype.hasOwnProperty.call(event_ids, event_id);
+	},
+
+	workflowIsActive: function(user) {
+		if (!user || !this.isSafeJobIdentifier(user.workflow)) return false;
+		return this.isTrustedWorkflowJob(this.findJob(user.workflow), user.workflow);
+	},
+
+	workflowOwnsJob: function(user, job) {
+		return !!(this.workflowIsActive(user) && job && (typeof job == 'object') &&
+			Object.prototype.hasOwnProperty.call(job, 'source_id') &&
+			(job.source_id === user.workflow));
+	},
+
+	getWorkflowJobProjection: function(job, fields) {
+		var projection = Object.create(null);
+		(fields || []).forEach(function(key) {
+			if (Object.prototype.hasOwnProperty.call(job, key)) projection[key] = job[key];
+		});
+		return projection;
+	},
+
+	getWorkflowActiveJobProjections: function(user) {
+		var scoped = Object.create(null);
+		if (!this.workflowIsActive(user)) return scoped;
+
+		var self = this;
+		var append = function(jobs, pending) {
+			if (!jobs || (typeof jobs != 'object')) return;
+			Object.keys(jobs).forEach(function(key) {
+				if (!self.isSafeJobIdentifier(key)) return;
+				var job = jobs[key];
+				if (!job || (typeof job != 'object')) return;
+				if (pending && (!Object.prototype.hasOwnProperty.call(job, 'action') ||
+					(job.action !== 'launchLocalJob'))) return;
+				if (!Object.prototype.hasOwnProperty.call(job, 'id') ||
+					!self.isSafeJobIdentifier(job.id)) return;
+				if (!Object.prototype.hasOwnProperty.call(job, 'source_id') ||
+					(job.source_id !== user.workflow)) return;
+				scoped[key] = self.getWorkflowJobProjection(job, [
+					'id', 'event', 'source_id', 'when', 'retries'
+				]);
+			});
+		};
+
+		append(this.activeJobs, false);
+		append(this.internalQueue, true);
+		Object.keys(this.workers || {}).forEach(function(hostname) {
+			var worker = self.workers[hostname];
+			if (!worker || (typeof worker != 'object')) return;
+			append(worker.active_jobs, false);
+			append(worker.queue, true);
+		});
+
+		return scoped;
+	},
+
+	captureWorkflowAuthHeaders: function(args) {
+		// pixl-server-api emits `request` before its debug logging.  Capture the
+		// bearer in a non-enumerable request-local slot and remove it from headers,
+		// so API-layer debug and transaction metadata do not persist it.  The web
+		// server's raw level-9 header trace occurs earlier and is a dependency limit.
+		var headers = args && args.request && args.request.headers;
+		if (!headers || !Object.prototype.hasOwnProperty.call(headers, 'x-wf-signature')) return;
+		Object.defineProperty(args, '_workflow_auth', {
+			value: {
+				id: headers['x-wf-id'],
+				signature: headers['x-wf-signature']
+			},
+			enumerable: false,
+			configurable: true
+		});
+		delete headers['x-wf-signature'];
+	},
+
+	getWorkflowAPIAction: function(args) {
+		var url = args && args.request && args.request.url;
+		if (typeof url != 'string') return '';
+		var base_uri = (this.api && this.api.config) ? this.api.config.get('base_uri') : '/api';
+		base_uri = String(base_uri || '/api').replace(/\/$/, '');
+		var route = new RegExp('^' + Tools.escapeRegExp(base_uri + '/app/') + '(\\w+)/?$');
+		var match = url.replace(/\?.*$/, '').match(route);
+		return match ? match[1] : '';
+	},
+
+	workflowCanAccessAPI: function(args) {
+		return [ 'get_schedule', 'get_active_jobs', 'run_event', 'get_job_details', 'abort_job' ]
+			.indexOf(this.getWorkflowAPIAction(args)) >= 0;
+	},
+
 	loadSession: function (args, callback) {
 		// Load user session or validate API Key
 		var self = this;
@@ -556,19 +721,28 @@ module.exports = Class.create({
 		// if no session found - also check for Workflow/GitHub signatures 
 		// Workflow:
 
-		let wfid = args.request.headers['x-wf-id']
-		let wfsig =  args.request.headers['x-wf-signature']
+		var request_headers = args.request.headers || {};
+		var workflow_auth = Object.prototype.hasOwnProperty.call(args, '_workflow_auth') &&
+			args._workflow_auth && (typeof args._workflow_auth == 'object') ? args._workflow_auth : {};
+		let wfid = Object.prototype.hasOwnProperty.call(workflow_auth, 'id') ? workflow_auth.id :
+			(Object.prototype.hasOwnProperty.call(request_headers, 'x-wf-id') ? request_headers['x-wf-id'] : undefined);
+		let wfsig = Object.prototype.hasOwnProperty.call(workflow_auth, 'signature') ? workflow_auth.signature :
+			(Object.prototype.hasOwnProperty.call(request_headers, 'x-wf-signature') ? request_headers['x-wf-signature'] : undefined);
 
-		if (wfsig && wfid) {
-			// make sure wfid is currently running or is in retry queue
-			// let activeJobs = self.getAllActiveJobs(true)
-			// let wfJob = Object.keys(activeJobs).map(key => activeJobs[key]).filter(e => e.id == wfid)[0]
-			
-			// if(wfJob && wfsig == `sha1=${crypto.createHmac("sha1", self.server.config.get('secret_key')).update(wfid).digest("hex")}`) {
-			if( wfsig == self.workflowKeys.get(wfid) ) {
+		if (wfsig || wfid) {
+			if (!self.workflowCanAccessAPI(args)) {
+				return callback(new Error(`Workflow capability cannot access this API`), null, null);
+			}
+			var capability = self.getWorkflowCapability(wfid, wfsig);
+			if (capability) {
 				return callback(null
-				, { type: "workflow", workflow: true, username: "internal" }
-				, { username: "internal", workflow: wfid, signature: wfsig, active: true, privileges: { run_events: 1, abort_events: 1 } }
+				, { type: "workflow", workflow: true, workflow_id: wfid, username: "internal" }
+				, {
+					username: "internal",
+					workflow: wfid,
+					active: true,
+					privileges: { run_events: 1, abort_events: 1 }
+				}
 				);
 			}
 			else {

--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -454,6 +454,10 @@ module.exports = Class.create({
 		if (params.id) criteria.id = params.id;
 		else if (params.title) criteria.title = params.title;
 		else return this.doError('event', "Failed to locate event: No criteria specified", callback);
+		var requested_debug_sudo = Object.prototype.hasOwnProperty.call(params, 'debug_sudo') && (
+			(params.debug_sudo === true) || (params.debug_sudo === 1) ||
+			(params.debug_sudo === '1') || (params.debug_sudo === 'true')
+		);
 
 		// validate optional event data parameters
 		if (!this.requireValidEventData(params, callback)) return;
@@ -524,8 +528,6 @@ module.exports = Class.create({
 
 				let privs = user.privileges || {}
 				let canEdit = privs.edit_events || privs.create_events || privs.admin
-				// only admin can set debug_sudo option
-				if(!privs.admin) delete params.debug_sudo
 				
 				// Run-only callers may supply only the documented ad-hoc runtime inputs.
 				// Everything else must come from the stored event that passed RBAC above.
@@ -563,7 +565,9 @@ module.exports = Class.create({
 					}
 				}
 
-				var job = Tools.mergeHashes(Tools.copyHash(event, true), params);
+				var event_copy = Tools.copyHash(event, true);
+				delete event_copy.debug_sudo;
+				var job = Tools.mergeHashes(event_copy, params);
 				// Also discard stale provenance stored by older event records.
 				[ 'api_key', 'token', 'username', 'source', 'source_id', 'source_event', 'source_log' ].forEach(function(key) {
 					delete job[key];
@@ -611,7 +615,7 @@ module.exports = Class.create({
 					var resp = { code: 0, ids: ids };
 					if (!ids.length) resp.queue = self.eventQueue[event.id] || 1;
 					callback(resp);
-				}); // launch job
+				}, { debug_sudo: !!(privs.admin && requested_debug_sudo) }); // launch job
 			}); // find event
 		}); // load session
 	},

--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -24,10 +24,21 @@ module.exports = Class.create({
 			if (err) return self.doError('session', err.message, callback);
 			if (!self.requireValidUser(session, user, callback)) return;
 
-			self.storage.listGet('global/schedule', parseInt(params.offset || 0), parseInt(params.limit || 0), function (err, items, list) {
+			var offset = user.workflow ? 0 : parseInt(params.offset || 0);
+			var limit = user.workflow ? 0 : parseInt(params.limit || 0);
+			self.storage.listGet('global/schedule', offset, limit, function (err, items, list) {
 				if (err) {
 					// no items found, not an error for this API
 					return callback({ code: 0, rows: [], list: { length: 0 } });
+				}
+
+				if (user.workflow) {
+					var rows = [];
+					(items || []).forEach(function(item) {
+						if (!item || !self.workflowCanRunEvent(user, item.id)) return;
+						rows.push({ id: item.id, title: item.title || '' });
+					});
+					return callback({ code: 0, rows: rows, list: { length: rows.length } });
 				}
 
 				// success, return keys and list header
@@ -470,6 +481,10 @@ module.exports = Class.create({
 					return self.doError('event', "Failed to locate event: " + (params.id || params.title), callback);
 				}
 
+				if (user.workflow && (!criteria.id || !self.workflowCanRunEvent(user, event.id))) {
+					return self.doError('event', "Workflow is not authorized to run event: " + event.id, callback);
+				}
+
 				if (user.token) { // token auth
 					if (!event.salt) return self.doError('event', 'token is disabled for this event', callback);
 					let expectedToken = crypto.createHmac("sha1", `${self.server.config.get("secret_key")}`)
@@ -570,7 +585,6 @@ module.exports = Class.create({
 					job.source = `Workflow (${user.workflow})`;
 					job.source_id = user.workflow
 					job.source_log = (self.server.config.get('base_app_url') || '') + '/#JobDetails?id=' + user.workflow
-					job.api_key = user.signature;
 				}
 				else {
 					job.source = "Manual (" + user.username + ")";

--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -415,15 +415,29 @@ module.exports = Class.create({
 
 	api_run_event: function (args, callback) {
 		// run event manually (via "Run" button in UI or by API Key)
-		// can include any event overrides in params (such as 'now')
+		// can include authorized runtime overrides such as now, arg and post_data
 		var self = this;
 		if (!this.requiremanager(args, callback)) return;
 
-		// default behavor: merge post params and query together
-		// alt behavior (post_data): store post params into post_data
-		var params = Tools.copyHash(args.query, true);
-		if (args.query.post_data) params.post_data = args.params;
-		else Tools.mergeHashInto(params, args.params);
+		// Default behavior: merge request params and query using own properties only.
+		// Never assign prototype-control keys into a normal object.
+		// Alt behavior (post_data): keep the request body as opaque plugin input.
+		var params = {};
+		var blocked_keys = [ '__proto__', 'prototype', 'constructor' ];
+		var mergeRequestFields = function(source) {
+			if (!source || (typeof source != 'object')) return true;
+			var keys = Object.keys(source);
+			for (var idx = 0; idx < keys.length; idx++) {
+				var key = keys[idx];
+				if (blocked_keys.indexOf(key) >= 0) return false;
+				params[key] = source[key];
+			}
+			return true;
+		};
+
+		if (!mergeRequestFields(args.query)) return this.doError('api', "Malformed request parameter", callback);
+		if (Object.prototype.hasOwnProperty.call(args.query, 'post_data') && args.query.post_data) params.post_data = args.params;
+		else if (!mergeRequestFields(args.params)) return this.doError('api', "Malformed request parameter", callback);
 
 		var criteria = {};
 		if (params.id) criteria.id = params.id;
@@ -480,36 +494,65 @@ module.exports = Class.create({
 				delete params.session_id;
 				delete params.uid;
 				delete params.secret;
+				// Chain data is internal scheduler state, never caller input.
+				delete params.chain_data;
+				// The memo is also internal scheduler state, never caller input.
+				delete params.memo;
+				// Remove caller-supplied authentication and provenance fields.
+				delete params.api_key;
+				delete params.token;
+				delete params.username;
+				delete params.source;
+				delete params.source_id;
+				delete params.source_event;
+				delete params.source_log;
 
 				let privs = user.privileges || {}
+				let canEdit = privs.edit_events || privs.create_events || privs.admin
 				// only admin can set debug_sudo option
 				if(!privs.admin) delete params.debug_sudo
 				
-				// allow for &params/foo=bar and the like
-				for (var key in params) {
-					if (key.match(/^(\w+)\/(\w+)$/)) {
-						var parent_key = RegExp.$1;
-						var sub_key = RegExp.$2;
-						if (!params[parent_key]) params[parent_key] = {};
-						params[parent_key][sub_key] = params[key];
-						delete params[key];
-					}
+				// Run-only callers may supply only the documented ad-hoc runtime inputs.
+				// Everything else must come from the stored event that passed RBAC above.
+				if(!canEdit) {
+					let runtimeParams = {};
+					[ 'now', 'arg', 'args', 'post_data' ].forEach(function(key) {
+						if (Object.prototype.hasOwnProperty.call(params, key)) runtimeParams[key] = params[key];
+					});
+					params = runtimeParams;
 				}
-
-				// allow sparsely populated event params in request
-				if (params.params && event.params) {
-					for (var key in event.params) {
-						if (!(key in params.params)) params.params[key] = event.params[key];
+				else {
+					// Allow editors to use &params/foo=bar and similar nested overrides,
+					// without permitting prototype-chain writes.
+					for (var key in params) {
+						if (key.match(/^(\w+)\/(\w+)$/)) {
+							var parent_key = RegExp.$1;
+							var sub_key = RegExp.$2;
+							if ((blocked_keys.indexOf(parent_key) >= 0) || (blocked_keys.indexOf(sub_key) >= 0)) {
+								return self.doError('api', "Malformed nested parameter", callback);
+							}
+							if (!Object.prototype.hasOwnProperty.call(params, parent_key)) params[parent_key] = {};
+							if (!params[parent_key] || (typeof params[parent_key] != 'object') || Tools.isaArray(params[parent_key])) {
+								return self.doError('api', "Malformed nested parameter container: " + parent_key, callback);
+							}
+							params[parent_key][sub_key] = params[key];
+							delete params[key];
+						}
 					}
-				}
 
-				// only allow customize event params (like script in shell plug) to users with edit priv
-				let canEdit = user.privileges.edit_events || user.privileges.create_events ||  user.privileges.admin
-				if(!canEdit && params.params) {
-					delete params.params;
+					// allow sparsely populated event params in editor requests
+					if (params.params && event.params) {
+						for (var key in event.params) {
+							if (!(key in params.params)) params.params[key] = event.params[key];
+						}
+					}
 				}
 
 				var job = Tools.mergeHashes(Tools.copyHash(event, true), params);
+				// Also discard stale provenance stored by older event records.
+				[ 'api_key', 'token', 'username', 'source', 'source_id', 'source_event', 'source_log' ].forEach(function(key) {
+					delete job[key];
+				});
 				if (user.key) {
 					// API Key
 					job.source = "API Key (" + user.title + ")";

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -3,48 +3,212 @@
 // Released under the MIT License
 
 const fs = require('fs');
+const path = require('path');
 const async = require('async');
 const Class = require("pixl-class");
 const Tools = require("pixl-tools");
 const readLastLines = require('read-last-lines');
+const PassThrough = require('stream').PassThrough;
 
 module.exports = Class.create({
 
+	getRawJobLogHeaders: function () {
+		return {
+			'Content-Type': 'text/plain; charset=utf-8',
+			'X-Content-Type-Options': 'nosniff',
+			'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+			'Pragma': 'no-cache',
+			'Expires': '0'
+		};
+	},
+
+	abortJobLogHTTPResponse: function (response, destination, message) {
+		// Returning false from pixl-request preflight switches it to buffer mode.
+		// Destroy the network response first so an incompatible/unbounded body can
+		// never be accumulated in manager memory.
+		if (response && response.destroy && !response.destroyed) {
+			response.destroy(new Error(message || "Incompatible job-log response"));
+		}
+		if (destination && destination.destroy && !destination.destroyed) destination.destroy();
+	},
+
+	requireJobLogAccess: function (args, user, job, callback) {
+		// Authorize against the immutable job snapshot, rather than the current
+		// event (which may have been edited or deleted after the job ran).
+		if (!job || !job.category || !job.target) {
+			this.doError('job', "Job authorization metadata is unavailable.", callback);
+			return false;
+		}
+		if (!this.requireCategoryPrivilege(user, job.category, callback)) return false;
+		if (!this.requireGroupPrivilege(args, user, job.target, callback)) return false;
+		return true;
+	},
+
+	sameFileIdentity: function (left, right) {
+		return !!left && !!right &&
+			(String(left.dev) == String(right.dev)) &&
+			(String(left.ino) == String(right.ino));
+	},
+
+	openJobLogFile: function (file_path, callback) {
+		// Validate the directory entry, open it once without following links where
+		// supported, and verify that the descriptor still refers to that entry.
+		// All reads below use this descriptor, never a second path lookup.
+		var self = this;
+		fs.lstat(file_path, function (err, before) {
+			if (err) return callback(err);
+			if (!before.isFile() || (before.nlink != 1)) {
+				return callback(new Error("Job log is not a single-link regular file"));
+			}
+
+			var flags = fs.constants.O_RDONLY;
+			if (typeof fs.constants.O_NOFOLLOW == 'number') flags |= fs.constants.O_NOFOLLOW;
+			if (typeof fs.constants.O_NONBLOCK == 'number') flags |= fs.constants.O_NONBLOCK;
+
+			fs.open(file_path, flags, function (err, fd) {
+				if (err) return callback(err);
+				fs.fstat(fd, function (err, opened) {
+					if (err || !opened.isFile() || (opened.nlink != 1) || !self.sameFileIdentity(before, opened)) {
+						return fs.close(fd, function () {
+							callback(err || new Error("Job log changed while it was being opened"));
+						});
+					}
+					callback(null, fd, opened);
+				});
+			});
+		});
+	},
+
+	deleteJobLogIfUnchanged: function (file_path, opened) {
+		// Node does not expose a portable unlink-by-descriptor operation.  Recheck
+		// identity and file type immediately before deleting the fixed job slot.
+		// Eliminating the final lstat/unlink window altogether would require a
+		// private quarantine plus retry lifecycle (or a two-phase transfer).
+		var self = this;
+		fs.lstat(file_path, function (err, current) {
+			if (err) return;
+			if (!current.isFile() || (current.nlink != 1) || !self.sameFileIdentity(opened, current)) {
+				return self.logError('file', "Refusing to delete a replaced job log: " + file_path);
+			}
+			fs.unlink(file_path, function (err) {
+				if (err) self.logError('file', "Failed to delete fetched job log: " + file_path + ": " + err);
+			});
+		});
+	},
+
+	deleteJobLogAfterCompleteTransfer: function (response, source, file_path, opened, expected_size) {
+		// HTTP `finish` only means the response was ended.  pixl-server also ends a
+		// response after a source-stream error, so require a clean source `end` too.
+		var self = this;
+		var source_ended = false;
+		var response_finished = false;
+		var source_failed = false;
+		var deleted = false;
+		var maybe_delete = function () {
+			if (deleted || source_failed || !source_ended || !response_finished) return;
+			deleted = true;
+			self.deleteJobLogIfUnchanged(file_path, opened);
+		};
+		source.once('error', function () { source_failed = true; });
+		source.once('end', function () {
+			source_ended = true;
+			if ((typeof expected_size == 'number') &&
+				(!source.jobLogComplete || (source.jobLogBytesRead != expected_size))) {
+				source_failed = true;
+			}
+			maybe_delete();
+		});
+		response.once('finish', function () { response_finished = true; maybe_delete(); });
+		response.once('close', function () {
+			// A client disconnect can leave a backpressured source paused after
+			// unpipe, so destroy it explicitly and let its descriptor owner close
+			// after any pending positional read completes.  Never delete the log.
+			if (!response_finished) {
+				source_failed = true;
+				if (source && source.destroy) source.destroy();
+			}
+		});
+	},
+
+	getMutableJobUpdates: function (updates, callback) {
+		var allowed = [
+			'title', 'timeout', 'repeat', 'interval', 'enabled', 'retries',
+			'retry_delay', 'chain', 'chain_error', 'notify_success', 'notify_fail',
+			'web_hook', 'cpu_limit', 'cpu_sustain', 'memory_limit',
+			'memory_sustain', 'log_max_size', 'suspended'
+		];
+		if (!updates || (typeof updates != 'object') || Array.isArray(updates)) {
+			this.doError('api', "Job updates must be an object.", callback);
+			return false;
+		}
+
+		var clean = Object.create(null);
+		var keys = Object.keys(updates);
+		for (var idx = 0; idx < keys.length; idx++) {
+			var key = keys[idx];
+			if (allowed.indexOf(key) < 0) {
+				this.doError('api', "Cannot update protected job property: " + key, callback);
+				return false;
+			}
+			clean[key] = updates[key];
+		}
+		if (!this.requireValidEventData(clean, callback)) return false;
+		if (!this.validateOptionalParams(clean, {
+			repeat: [ /^(boolean|number)$/, /^(\d+|false)$/ ],
+			interval: [ /^(boolean|number)$/, /^(\d+|false)$/ ],
+			suspended: [ /^(boolean|number)$/, /^(\d+|true|false)$/ ]
+		}, callback)) return false;
+		return clean;
+	},
+
+	buildMutableJobStub: function (id, updates) {
+		// updateLocalJob historically iterates with `for...in`, so hand it a
+		// null-prototype object even if another API polluted Object.prototype.
+		var stub = Object.create(null);
+		stub.id = id;
+		Object.keys(updates).forEach(function (key) { stub[key] = updates[key]; });
+		return stub;
+	},
+
 	api_get_job_log: function (args, callback) {
 		// view job log (plain text or download)
-		// client API, no auth
 		var self = this;
+		if (!this.requiremanager(args, callback)) return;
 
 		if (!this.requireParams(args.query, {
 			id: /^\w+$/
 		}, callback)) return;
 
 		this.loadSession(args, function (err, session, user) {
-
-			if(self.server.config.get('protect_job_log')) {
-				if (err) return self.doError('session', err.message, callback);
-				if (!self.requireValidUser(session, user, callback)) return;
-			}
+			if (err) return self.doError('session', err.message, callback);
+			if (!self.requireValidUser(session, user, callback)) return;
+			args.user = user;
+			args.session = session;
 
 			let key = 'jobs/' + args.query.id + '/log.txt.gz';
 
-			self.storage.getStream(key, function (err, stream) {
+			self.storage.get('jobs/' + args.query.id, function (err, job) {
 				if (err) {
 					return callback("404 Not Found", {}, "(No log file found.)\n");
 				}
-	
-				let headers = {
-					'Content-Type': "text/plain; charset=utf-8",
-					'Content-Encoding': "gzip"
-				};
-	
-				// optional download instead of view
-				if (args.query.download) {
-					headers['Content-disposition'] = "attachment; filename=Cronicle-Job-Log-" + args.query.id + '.txt';
-				}
-	
-				// pass stream to web server
-				callback("200 OK", headers, stream);
+				if (!self.requireJobLogAccess(args, user, job, callback)) return;
+
+				self.storage.getStream(key, function (err, stream) {
+					if (err) {
+						return callback("404 Not Found", {}, "(No log file found.)\n");
+					}
+
+					let headers = self.getRawJobLogHeaders();
+					headers['Content-Encoding'] = 'gzip';
+
+					// optional download instead of view
+					if (args.query.download) {
+						headers['Content-Disposition'] = "attachment; filename=Cronicle-Job-Log-" + args.query.id + '.txt';
+					}
+
+					// pass stream to web server
+					callback("200 OK", headers, stream);
+				});
 			});
 		
 		});
@@ -52,6 +216,11 @@ module.exports = Class.create({
 	},
 
 	get_active_job_by_id(id) {
+		// On a manager, prefer the immutable launch snapshot.  worker.active_jobs
+		// is status telemetry and must not define log authorization metadata.
+		let managerJob = this.getManagerJobLogSnapshot(id)
+		if (managerJob) return managerJob
+		if (this.multi.manager) return undefined
 
 		let activeJobs = this.getAllActiveJobs(true)
 		if (activeJobs[id]) return activeJobs[id]
@@ -85,7 +254,7 @@ module.exports = Class.create({
 
 		if(!filePath) return self.doError('log', 'Missing log_file parameter', callback)
 
-		fs.stat(filePath, (err, stats) => {
+		self.openJobLogFile(filePath, (err, fd, stats) => {
 			if (err) {
 			   return  callback({ error: err.message || true, dur: new Date - start, next: offset })
 			}
@@ -103,7 +272,9 @@ module.exports = Class.create({
 	
 			// if offset exceeds file size, return right away
 			if (availableBytes < 1) {
-				return callback({ skipBytes: skipBytes, fileSize: fileSize, next: offset, dur: new Date - start })
+				return fs.close(fd, function () {
+					callback({ skipBytes: skipBytes, fileSize: fileSize, next: offset, dur: new Date - start })
+				});
 			}
 	
 			let bytesToRead = availableBytes
@@ -112,25 +283,15 @@ module.exports = Class.create({
 				bytesToRead = maxBytes
 			}
 	
-			fs.open(filePath, 'r', (err, fd) => {
-	
-				if (err) {
-					return callback({ error: err.message || true, skipBytes: skipBytes, fileSize: fileSize, next: offset, dur: new Date - start, })
-				}
-	
-				let buffer = Buffer.alloc(bytesToRead);
-				fs.read(fd, buffer, 0, bytesToRead, offset, (err, bytesRead, buffer) => {
-	
-					fs.close(fd, () => {
-						let dur = new Date - start
-						if (err) {
-							return callback({ error: err.message || true, skipBytes: skipBytes, fileSize: fileSize, next: offset, dur: dur})
-						}
-	
-						return callback({ data: String(buffer), fileSize: fileSize, skipBytes: skipBytes, next: offset + bytesRead, dur: dur})    
-					
-					}); 
-					 
+			let buffer = Buffer.alloc(bytesToRead);
+			fs.read(fd, buffer, 0, bytesToRead, offset, (err, bytesRead) => {
+				fs.close(fd, () => {
+					let dur = new Date - start
+					if (err) {
+						return callback({ error: err.message || true, skipBytes: skipBytes, fileSize: fileSize, next: offset, dur: dur})
+					}
+
+					return callback({ data: String(buffer.subarray(0, bytesRead)), fileSize: fileSize, skipBytes: skipBytes, next: offset + bytesRead, dur: dur})
 				});
 			});
 	
@@ -138,14 +299,16 @@ module.exports = Class.create({
 	},
     
 	// this is proxy between and user and logs on different nodes
-	api_get_live_console: async function (args, callback) {
+	api_get_live_console: function (args, callback) {
 		// runs on manager 
 		const self = this;
 
+		if (!self.requiremanager(args, callback)) return;
 		self.loadSession(args, function (err, session, user) {
 			if (err) return self.doError('session', err.message, callback);
-			if (!self.requiremanager(args, callback)) return;
-			if (!self.requireValidUser(session, user, callback)) return;			
+			if (!self.requireValidUser(session, user, callback)) return;
+			args.user = user;
+			args.session = session;
 
 			//let query = args.query;
 			let params = Tools.mergeHashes(args.params, args.query);
@@ -157,12 +320,13 @@ module.exports = Class.create({
 			let job = self.get_active_job_by_id(params.id)
 
 			if (!job) return self.doError('job', "Invalid or Completed job", callback);
+			if (!self.requireJobLogAccess(args, user, job, callback)) return;
 
 			let pageSize = self.server.config.get('live_log_page_size') || 8192
 
 			if(self.server.hostname === job.hostname) { 
 				// if job is running on this server (manager), read file right away
-                params.log_file = job.log_file
+				params.log_file = self.getJobLogFilePath(job.id, job.detached)
 				params.event_title = job.event_title 
 				params.hostname = job.hostname				
 				params.max_bytes = params.download ? pageSize*16 : pageSize
@@ -212,7 +376,7 @@ module.exports = Class.create({
 			return callback("404 Not Found", {}, "Completed or Invalid job")
 		}
 
-		params.log_file= job.log_file
+		params.log_file = self.getJobLogFilePath(job.id, job.detached)
 		params.event_title = job.event_title 
 		params.hostname = job.hostname
 
@@ -220,40 +384,102 @@ module.exports = Class.create({
 		self.get_job_log_chunk(params, callback)
 	},
 
+	api_get_live_job_log_file: function (args, callback) {
+		// Internal manager-to-worker raw stream.  User authorization happens on
+		// the manager before it calls this endpoint.
+		var self = this;
+		var params = Tools.mergeHashes(args.params, args.query);
+		if (!this.requireParams(params, {
+			id: /^\w+$/,
+			auth: /^[a-f0-9]{64}$/i
+		}, callback)) return;
+
+		var expected = Tools.digestHex(params.id + this.server.config.get('secret_key'));
+		if (!this.secureCompareStrings(params.auth, expected)) {
+			return callback("403 Forbidden", {}, "Authentication failure.\n");
+		}
+
+		var job = this.get_active_job_by_id(params.id);
+		if (!job) return callback("404 Not Found", {}, "Completed or invalid job.\n");
+
+		var log_file = this.getJobLogFilePath(job.id, job.detached);
+		this.openJobLogFile(log_file, function (err, fd) {
+			if (err) return callback("404 Not Found", {}, "Live job log is unavailable.\n");
+			var headers = self.getRawJobLogHeaders();
+			headers['X-Cronicle-Live-Job-Log-Protocol'] = '2';
+			callback("200 OK", headers, fs.createReadStream(null, { fd: fd, autoClose: true }));
+		});
+	},
+
 
 	api_get_live_job_log: function (args, callback) {
 		// get live job job, as it is being written
-		// client API, no auth
 		var self = this;
 		var query = args.query;
+		if (!this.requiremanager(args, callback)) return;
 
 		if (!this.requireParams(query, {
 			id: /^\w+$/
 		}, callback)) return;
 
-		job = this.activeJobs[query.id] || {};
+		this.loadSession(args, function (err, session, user) {
+			if (err) return self.doError('session', err.message, callback);
+			if (!self.requireValidUser(session, user, callback)) return;
+			args.user = user;
+			args.session = session;
 
-		// see if log file exists on this server
-		// var log_file = this.server.config.get('log_dir') + '/jobs/' + query.id + '.log';
-		var log_file = this.server.config.get('log_dir') + '/jobs/' + query.id + (job.detached ? '-detached' : '') + '.log';
-
-		fs.stat(log_file, function (err, stats) {
-			if (err) {
-				return self.doError('job', "Failed to fetch job log: " + err, callback);
-			}
-
-			var headers = { 'Content-Type': "text/html; charset=utf-8" };
-
-			// optional download instead of view
+			var job = self.get_active_job_by_id(query.id);
+			if (!job) return self.doError('job', "Failed to locate job: " + query.id, callback);
+			if (!self.requireJobLogAccess(args, user, job, callback)) return;
+			var headers = self.getRawJobLogHeaders();
 			if (query.download) {
-				headers['Content-disposition'] = "attachment; filename=Cronicle-Partial-Job-Log-" + query.id + '.txt';
+				headers['Content-Disposition'] = "attachment; filename=Cronicle-Partial-Job-Log-" + query.id + '.txt';
 			}
 
-			// get readable stream to file
-			var stream = fs.createReadStream(log_file);
+			if (job.hostname == self.server.hostname) {
+				var log_file = self.getJobLogFilePath(job.id, job.detached);
+				return self.openJobLogFile(log_file, function (err, fd) {
+					if (err) return self.doError('job', "Failed to fetch job log: " + err, callback);
+					callback("200 OK", headers, fs.createReadStream(null, { fd: fd, autoClose: true }));
+				});
+			}
 
-			// stream to client as plain text
-			callback("200 OK", headers, stream);
+			var worker = self.workers[job.hostname];
+			if (!worker) return self.doError('job', "Failed to locate job server: " + job.hostname, callback);
+			var api_url = self.getWorkerServerBaseAPIURL(worker.hostname, worker.ip) + '/app/get_live_job_log_file';
+			api_url += Tools.composeQueryString({
+				id: job.id,
+				auth: Tools.digestHex(job.id + self.server.config.get('secret_key'))
+			});
+
+			var proxy = new PassThrough();
+			var response_started = false;
+			self.request.get(api_url, {
+				download: proxy,
+				headers: { 'Accept-Encoding': 'identity' },
+				preflight: function (err, resp, stream) {
+					var valid = !err && resp && (resp.statusCode == 200) &&
+						(resp.headers['x-cronicle-live-job-log-protocol'] == '2') &&
+						/^text\/plain\b/i.test(resp.headers['content-type'] || '');
+					if (!valid) {
+						self.abortJobLogHTTPResponse(resp, stream, "Incompatible live job-log response");
+						return false;
+					}
+					response_started = true;
+					callback("200 OK", headers, proxy);
+					resp.pipe(stream);
+				}
+			}, function (err) {
+				if (err && response_started) return proxy.destroy(err);
+				if (err) {
+					proxy.destroy();
+					return self.doError('job', "Failed to fetch live job log: " + err.message, callback);
+				}
+				if (!response_started) {
+					proxy.destroy();
+					return self.doError('job', "Job server returned an incompatible live-log response.", callback);
+				}
+			});
 		});
 	},
 
@@ -263,41 +489,70 @@ module.exports = Class.create({
 		var self = this;
 		var query = args.query;
 
-		if (!this.requireParams(query, {
-			path: /^[\w\-\.\/\\\:]+\.log$/,
-			auth: /^\w+$/
-		}, callback)) return;
+		var id = '';
+		var detached = false;
 
-		if (query.auth != Tools.digestHex(query.path + this.server.config.get('secret_key'))) {
-			return callback("403 Forbidden", {}, "Authentication failure.\n");
+		if (('id' in query) || ('detached' in query)) {
+			// Protocol v2: the manager supplies only immutable job identity.
+			if (!this.requireParams(query, {
+				id: /^\w+$/,
+				detached: /^[01]$/,
+				auth: /^[a-f0-9]{64}$/i
+			}, callback)) return;
+			id = query.id;
+			detached = (query.detached == '1');
+			if (!this.verifyJobLogFetchAuth(id, detached, query.auth)) {
+				return callback("403 Forbidden", {}, "Authentication failure.\n");
+			}
+		}
+		else {
+			// Worker-first rolling upgrade compatibility.  Old managers send the
+			// worker path back to it.  Accept it only when it is exactly the locally
+			// derived canonical job slot; a correctly signed outside path still fails.
+			if (!this.requireParams(query, { auth: /^[a-f0-9]{64}$/i }, callback)) return;
+			if ((typeof query.path != 'string') || !query.path.match(/\.log$/i) ||
+				(Buffer.byteLength(query.path, 'utf8') > 32768)) {
+				return callback("403 Forbidden", {}, "Invalid job log path.\n");
+			}
+			var resolved = path.resolve(query.path);
+			var filename_match = path.basename(resolved).match(/^(\w+)(-detached)?\.log$/);
+			if (!filename_match) return callback("403 Forbidden", {}, "Invalid job log path.\n");
+			id = filename_match[1];
+			detached = !!filename_match[2];
+			if (resolved != this.getJobLogFilePath(id, detached)) {
+				return callback("403 Forbidden", {}, "Invalid job log path.\n");
+			}
+			var legacy_auth = Tools.digestHex(query.path + this.server.config.get('secret_key'));
+			if (!this.secureCompareStrings(query.auth, legacy_auth)) {
+				return callback("403 Forbidden", {}, "Authentication failure.\n");
+			}
 		}
 
-		var log_file = query.path;
+		var log_file = this.getJobLogFilePath(id, detached);
 
-		fs.stat(log_file, function (err, stats) {
+		this.openJobLogFile(log_file, function (err, fd, opened) {
 			if (err) {
-				return callback("404 Not Found", {}, "Log file not found: " + log_file + ".\n");
+				return callback("404 Not Found", {}, "Job log file is unavailable.\n");
 			}
 
-			var headers = { 'Content-Type': "text/plain" };
+			var headers = self.getRawJobLogHeaders();
+			headers['X-Cronicle-Job-Log-Protocol'] = '2';
+			headers['Content-Length'] = String(opened.size);
+			var descriptor = self.createJobLogDescriptorOwner(fd);
+			var stream = self.createJobLogDescriptorStream(descriptor, opened.size);
+			var close_descriptor = function () { descriptor.close(function () {}); };
+			stream.once('end', close_descriptor);
+			stream.once('error', close_descriptor);
+			stream.once('close', close_descriptor);
 
-			// get readable stream to file
-			var stream = fs.createReadStream(log_file);
+			// Delete only after the committed number of bytes reached a clean source
+			// EOF and the HTTP response completed.
+			self.deleteJobLogAfterCompleteTransfer(args.response, stream, log_file, opened, opened.size);
 
-			// stream to client as plain text
+			// stream to manager as plain text
 			callback("200 OK", headers, stream);
 
-			args.response.on('finish', function () {
-				// only delete local log file once log is COMPLETELY sent
-				self.logDebug(4, "Deleting log file: " + log_file);
-
-				fs.unlink(log_file, function (err) {
-					// ignore error
-				});
-
-			}); // response finish
-
-		}); // fs.stat
+		}); // openJobLogFile
 	},
 
 	api_get_log_watch_auth: function (args, callback) {
@@ -323,13 +578,12 @@ module.exports = Class.create({
 			// due to a race condition, the job may not be registered yet
 			async.retry( { times: 20, interval: 250 },
 				async.ensureAsync( function(callback) {
-					job = self.findJob(params);
+					job = self.get_active_job_by_id(params.id);
 					return job ? callback() : callback("NOPE");
 				} ),
 				function(err) {
 					if (err) return self.doError('job', "Failed to locate job for log watch auth: " + params.id, callback);
-					if (!self.requireCategoryPrivilege(user, job.category, callback)) return;
-					if (!self.requireGroupPrivilege(args, user, job.target, callback)) return;
+					if (!self.requireJobLogAccess(args, user, job, callback)) return;
 
 					// generate token
 					var token = Tools.digestHex(params.id + self.server.config.get('secret_key'));
@@ -363,10 +617,20 @@ module.exports = Class.create({
 			if (!self.requireCategoryPrivilege(user, job.category, callback)) return;
 			if (!self.requireGroupPrivilege(args, user, job.target, callback)) return;
 
-			var result = self.updateJob(params);
+			// `hostname` was historically sent by the UI as a lookup hint.  Keep
+			// accepting it, but never let it (or any other invariant) reach the job.
+			var requested_updates = {};
+			Object.keys(params).forEach(function (key) {
+				if ((key != 'id') && (key != 'hostname')) requested_updates[key] = params[key];
+			});
+			var updates = self.getMutableJobUpdates(requested_updates, callback);
+			if (updates === false) return;
+			var stub = self.buildMutableJobStub(params.id, updates);
+
+			var result = self.updateJob(stub);
 			if (!result) return self.doError('job', "Failed to update job.", callback);
 
-			self.logTransaction('job_update', params.id, self.getClientInfo(args, params));
+			self.logTransaction('job_update', params.id, self.getClientInfo(args, stub));
 
 			callback({ code: 0 });
 		});
@@ -387,7 +651,8 @@ module.exports = Class.create({
 			args.user = user;
 			args.session = session;
 
-			var updates = params.updates;
+			var updates = self.getMutableJobUpdates(params.updates, callback);
+			if (updates === false) return;
 			delete params.updates;
 
 			var all_jobs = self.getAllActiveJobs(true);
@@ -406,7 +671,8 @@ module.exports = Class.create({
 
 			for (var idx = 0, len = jobs.length; idx < len; idx++) {
 				var job = jobs[idx];
-				var result = self.updateJob(Tools.mergeHashes(updates, { id: job.id }));
+				var stub = self.buildMutableJobStub(job.id, updates);
+				var result = self.updateJob(stub);
 				if (result) {
 					count++;
 					self.logTransaction('job_update', job.id, self.getClientInfo(args, updates));

--- a/lib/api/job.js
+++ b/lib/api/job.js
@@ -703,6 +703,9 @@ module.exports = Class.create({
 
 			var job = self.findJob(params);
 			if (!job) return self.doError('job', "Failed to locate job: " + params.id, callback);
+			if (user.workflow && !self.workflowOwnsJob(user, job)) {
+				return self.doError('job', "Workflow is not authorized to abort job: " + params.id, callback);
+			}
 			if (!self.requireCategoryPrivilege(user, job.category, callback)) return;
 			if (!self.requireGroupPrivilege(args, user, job.target, callback)) return;
 
@@ -738,6 +741,7 @@ module.exports = Class.create({
 			if (err) return self.doError('session', err.message, callback);
 			if (!self.requireValidUser(session, user, callback)) return;
 			if (!self.requirePrivilege(user, "abort_events", callback)) return;
+			if (user.workflow) return self.doError('job', "Workflow capabilities cannot abort jobs in bulk.", callback);
 
 			args.user = user;
 			args.session = session;
@@ -812,6 +816,18 @@ module.exports = Class.create({
 				self.storage.get('jobs/' + params.id, function (err, job) {
 					if (err) {
 						return self.doError('job', "Failed to fetch job details: " + err, callback);
+					}
+
+					if (user.workflow) {
+						if (!self.workflowOwnsJob(user, job)) {
+							return self.doError('job', "Workflow is not authorized to read job: " + job.id, callback);
+						}
+						return callback({
+							code: 0,
+							job: self.getWorkflowJobProjection(job, [
+								'id', 'event', 'source_id', 'code', 'description', 'elapsed', 'memo'
+							])
+						});
 					}
 
 					if (!self.requireCategoryPrivilege(user, job.category, callback)) return;
@@ -964,6 +980,10 @@ module.exports = Class.create({
 		this.loadSession(args, function (err, session, user) {
 			if (err) return self.doError('session', err.message, callback);
 			if (!self.requireValidUser(session, user, callback)) return;
+
+			if (user.workflow) {
+				return callback({ code: 0, jobs: self.getWorkflowActiveJobProjections(user) });
+			}
 
 			// make a copy of active job, remove .params property since it might contain key info
 			let activeJobs = JSON.parse(JSON.stringify(self.getAllActiveJobs(true)));

--- a/lib/api/plugin.js
+++ b/lib/api/plugin.js
@@ -118,7 +118,7 @@ module.exports = Class.create({
 			enabled: [ 'number|boolean', /^(1|0|true|false)$/ ], 
 			cwd: [ 'string', /^[\w\s\-\/\.]*$/ ], 
 			uid: [ 'number|string', /^[\w\-\.]*$/ ], 
-			gid: [ 'string', /^[\w\-\.]*$/ ]
+			gid: [ 'number|string', /^[\w\-\.]*$/ ]
 		}, callback)) return;
 
 		// make sure title doesn't contain HTML metacharacters

--- a/lib/comm.js
+++ b/lib/comm.js
@@ -14,7 +14,35 @@ module.exports = Class.create({
 
 	workers: null,
 	sockets: null,
-	
+
+	updateLocalJobFromManager: function(stub) {
+		// Enforce the public runtime-field contract again at the worker trust
+		// boundary.  This protects worker-first rolling upgrades from a legacy
+		// manager forwarding client-controlled invariant fields.
+		if (!stub || (typeof stub != 'object') || Array.isArray(stub) ||
+			!Object.prototype.hasOwnProperty.call(stub, 'id') ||
+			(typeof stub.id != 'string') || !stub.id.match(/^\w+$/) ||
+			([ '__proto__', 'prototype', 'constructor' ].indexOf(stub.id) >= 0)) {
+			this.logError('job', "Refusing malformed job update from manager");
+			return false;
+		}
+
+		var requested_updates = Object.create(null);
+		Object.keys(stub).forEach(function (key) {
+			if ((key != 'id') && (key != 'hostname')) requested_updates[key] = stub[key];
+		});
+		var validation_error = '';
+		var updates = this.getMutableJobUpdates(requested_updates, function (data) {
+			validation_error = (data && data.description) ? data.description : String(data || '');
+		});
+		if (updates === false) {
+			this.logError('job', "Refusing protected job update from manager for " + stub.id +
+				(validation_error ? ": " + validation_error : ''));
+			return false;
+		}
+		return this.updateLocalJob(this.buildMutableJobStub(stub.id, updates));
+	},
+
 	setupCluster: function() {
 		// establish communication channel with all workers
 		var self = this;
@@ -66,14 +94,26 @@ module.exports = Class.create({
 	connectToworker: function(worker) {
 		// establish communication with worker via socket.io
 		var self = this;
+		// Status payloads are merged into `worker` below.  Retain the originally
+		// registered identity in a hidden, immutable property so both this socket and
+		// later reconnects remain bound to it even if telemetry mutates `worker`.
+		if (!Object.prototype.hasOwnProperty.call(worker, '_registeredSource')) {
+			Object.defineProperty(worker, '_registeredSource', {
+				value: Object.freeze({ hostname: worker.hostname, ip: worker.ip || '' }),
+				enumerable: false,
+				writable: false,
+				configurable: false
+			});
+		}
+		var source_worker = worker._registeredSource;
 		var port = this.server.config.get('remote_server_port') || this.web.config.get('http_port');
 		
 		var url = '';
 		if (this.server.config.get('server_comm_use_hostnames')) {
-			url = 'http://' + worker.hostname + ':' + port;
+			url = 'http://' + source_worker.hostname + ':' + port;
 		}
 		else {
-			url = 'http://' + (worker.ip || worker.hostname) + ':' + port;
+			url = 'http://' + (source_worker.ip || source_worker.hostname) + ':' + port;
 		}
 		
 		this.logDebug(8, "Connecting to worker via socket.io: " + url);
@@ -186,11 +226,11 @@ module.exports = Class.create({
 		} );
 		
 		socket.on('finish_job', function(job) {
-			self.finishJob( job );
+			self.finishJob( job, source_worker );
 		} );
 		
 		socket.on('fetch_job_log', function(job) {
-			self.fetchStoreJobLog( job );
+			self.fetchStoreJobLog( job, source_worker );
 		} );
 		
 		socket.on('auth_failure', function(data) {
@@ -404,8 +444,11 @@ module.exports = Class.create({
 		} );
 		
 		socket.on('update_job', function(stub) {
-			// update job (server-to-server comm)
-			if (socket._pixl_manager) self.updateLocalJob( stub );
+			// Update job (server-to-server comm).  Enforce the same runtime-field
+			// allowlist on the worker so a worker-first rolling upgrade remains safe
+			// while its manager is still running the legacy API implementation.
+			if (!socket._pixl_manager) return;
+			self.updateLocalJobFromManager(stub);
 		} );
 		
 		socket.on('restart_server', function(args) {

--- a/lib/comm.js
+++ b/lib/comm.js
@@ -3,6 +3,7 @@
 // Released under the MIT License
 
 const cp = require('child_process');
+const crypto = require('crypto');
 const os = require('os')
 const SocketIO = require('socket.io');
 const SocketIOClient = require('socket.io-client');
@@ -41,6 +42,51 @@ module.exports = Class.create({
 			return false;
 		}
 		return this.updateLocalJob(this.buildMutableJobStub(stub.id, updates));
+	},
+
+	resetWorkerJobDispatchNegotiation: function(worker) {
+		if (Object.prototype.hasOwnProperty.call(worker, 'jobDispatchNegotiationTimer') &&
+			worker.jobDispatchNegotiationTimer) {
+			clearTimeout(worker.jobDispatchNegotiationTimer);
+			delete worker.jobDispatchNegotiationTimer;
+		}
+		delete worker.job_dispatch_capabilities;
+		delete worker.job_dispatch_session;
+		delete worker.job_dispatch_sequence;
+		worker.job_dispatch_ready = false;
+	},
+
+	completeWorkerJobDispatchNegotiation: function(worker, socket, capabilities, dispatch_session) {
+		// Only the current socket may publish its negotiated state.  This prevents
+		// a delayed ACK from a replaced connection from restoring stale capabilities.
+		if (!worker || (worker.socket !== socket)) return false;
+		var signed_dispatch = this.supportsSignedJobDispatch(capabilities);
+		if (signed_dispatch && !this.isValidJobDispatchSession(dispatch_session)) {
+			if (Object.prototype.hasOwnProperty.call(worker, 'jobDispatchNegotiationTimer') &&
+				worker.jobDispatchNegotiationTimer) {
+				clearTimeout(worker.jobDispatchNegotiationTimer);
+				delete worker.jobDispatchNegotiationTimer;
+			}
+			delete worker.job_dispatch_capabilities;
+			delete worker.job_dispatch_session;
+			delete worker.job_dispatch_sequence;
+			worker.job_dispatch_ready = false;
+			return false;
+		}
+		if (Object.prototype.hasOwnProperty.call(worker, 'jobDispatchNegotiationTimer') &&
+			worker.jobDispatchNegotiationTimer) {
+			clearTimeout(worker.jobDispatchNegotiationTimer);
+			delete worker.jobDispatchNegotiationTimer;
+		}
+
+		worker.job_dispatch_capabilities = Object.create(null);
+		if (signed_dispatch) {
+			worker.job_dispatch_capabilities = this.getJobDispatchCapabilities();
+			worker.job_dispatch_session = dispatch_session;
+			worker.job_dispatch_sequence = 0;
+		}
+		worker.job_dispatch_ready = true;
+		return true;
 	},
 
 	setupCluster: function() {
@@ -94,6 +140,7 @@ module.exports = Class.create({
 	connectToworker: function(worker) {
 		// establish communication with worker via socket.io
 		var self = this;
+		this.resetWorkerJobDispatchNegotiation(worker);
 		// Status payloads are merged into `worker` below.  Retain the originally
 		// registered identity in a hidden, immutable property so both this socket and
 		// later reconnects remain bound to it even if telemetry mutates `worker`.
@@ -141,11 +188,30 @@ module.exports = Class.create({
 			var now = Tools.timeNow(true);
 			var token = Tools.digestHex( self.server.hostname + now + self.server.config.get('secret_key') );
 			
-			// authenticate server-to-server with time-based token
+			// Authenticate and negotiate signed job dispatch.  Old workers do not
+			// acknowledge capabilities, so they are enabled after the bounded timeout
+			// with a clean legacy payload and no debug elevation authority.
+			worker.jobDispatchNegotiationTimer = setTimeout(function() {
+				if (self.completeWorkerJobDispatchNegotiation(worker, socket, null, null)) {
+					self.logDebug(4, "Worker uses legacy job dispatch; debug_sudo will use Plugin identity: " + worker.hostname);
+				}
+			}, 5000);
 			socket.emit( 'authenticate', {
 				token: token,
 				now: now,
-				manager_hostname: self.server.hostname
+				manager_hostname: self.server.hostname,
+				job_dispatch_capabilities: self.getJobDispatchCapabilities()
+			}, function(response) {
+				if (!response || response.code) return;
+				if (self.completeWorkerJobDispatchNegotiation(
+					worker, socket, response.job_dispatch_capabilities,
+					response.job_dispatch_session
+				)) {
+					self.logDebug(5, "Negotiated signed job dispatch with worker: " + worker.hostname);
+				}
+				else if (worker.socket === socket) {
+					self.logError('server', "Worker returned an invalid signed job-dispatch session: " + worker.hostname);
+				}
 			} );
 			
 			// remove disabled flag, in case this is a reconnect
@@ -188,6 +254,7 @@ module.exports = Class.create({
 		} );*/
 		
 		socket.on('disconnect', function() {
+			if (worker.socket === socket) self.resetWorkerJobDispatchNegotiation(worker);
 			if (!socket._pixl_disconnected) {
 				self.logError('server', "worker disconnected unexpectedly: " + worker.hostname);
 				self.reconnectToworker(worker);
@@ -217,7 +284,15 @@ module.exports = Class.create({
 		
 		socket.on('status', function(status) {
 			self.logDebug(10, "Got status from worker: " + worker.hostname, status);
+			var dispatch_capabilities = worker.job_dispatch_capabilities;
+			var dispatch_session = worker.job_dispatch_session;
+			var dispatch_sequence = worker.job_dispatch_sequence;
+			var dispatch_ready = worker.job_dispatch_ready;
 			Tools.mergeHashInto( worker, status );
+			worker.job_dispatch_capabilities = dispatch_capabilities;
+			worker.job_dispatch_session = dispatch_session;
+			worker.job_dispatch_sequence = dispatch_sequence;
+			worker.job_dispatch_ready = dispatch_ready;
 			self.checkServerClock(worker);
 			self.checkServerJobs(worker);
 			
@@ -337,6 +412,7 @@ module.exports = Class.create({
 			clearTimeout( worker.socketReconnectTimer );
 			delete worker.socketReconnectTimer;
 		}
+		this.resetWorkerJobDispatchNegotiation(worker);
 		
 		delete this.workers[ worker.hostname ];
 		
@@ -385,13 +461,20 @@ module.exports = Class.create({
 		this.sockets[ socket.id ] = socket;
 		this.logDebug(5, "New socket.io client connected: " + socket.id + " (IP: " + ip + ")");
 		
-		socket.on('authenticate', function(params) {
+		socket.on('authenticate', function(params, auth_callback) {
 			// client is trying to authenticate
+			params = params || {};
 			if (params.manager_hostname && params.now && params.token) {
 				// manager-to-worker connection (we are the worker)
 				var correct_token = Tools.digestHex( params.manager_hostname + params.now + self.server.config.get('secret_key') );
 				if (params.token != correct_token) {
 					socket.emit( 'auth_failure', { description: "Secret Keys do not match." } );
+					return;
+				}
+				if (!self.supportsSignedJobDispatch(params.job_dispatch_capabilities)) {
+					socket.emit( 'auth_failure', {
+						description: "Manager does not support signed job dispatch. Upgrade managers before workers."
+					} );
 					return;
 				}
 				/*if (Math.abs(Tools.timeNow() - params.now) > 60) {
@@ -402,6 +485,11 @@ module.exports = Class.create({
 				self.logDebug(4, "Socket client " + socket.id + " has authenticated via secret key (IP: "+ip+")");
 				socket._pixl_auth = true;
 				socket._pixl_manager = true;
+				socket._pixl_manager_hostname = params.manager_hostname;
+				socket._pixl_job_dispatch_state = {
+					session: crypto.randomBytes(32).toString('hex'),
+					last_sequence: 0
+				};
 				
 				// force multi-server init (quick startup: to skip waiting for the tock)
 				self.logDebug(3, "manager server is: " + params.manager_hostname);
@@ -417,6 +505,12 @@ module.exports = Class.create({
 				
 				// need to recheck this
 				self.checkmanagerEligibility();
+
+				if (typeof(auth_callback) == 'function') auth_callback({
+					code: 0,
+					job_dispatch_capabilities: self.getJobDispatchCapabilities(),
+					job_dispatch_session: socket._pixl_job_dispatch_state.session
+				});
 			} // secret_key
 			else {
 				// web client to server connection
@@ -435,7 +529,18 @@ module.exports = Class.create({
 		
 		socket.on('launch_job', function(job) {
 			// launch job (server-to-server comm)
-			if (socket._pixl_manager) self.launchLocalJob( job );
+			if (!socket._pixl_manager) return;
+			if (!self.launchJobFromManager(
+				job, socket._pixl_manager_hostname, socket._pixl_job_dispatch_state
+			)) {
+				self.logError('server', "Refusing job with invalid signed dispatch context from manager: " +
+					socket._pixl_manager_hostname);
+				socket._pixl_auth = false;
+				socket._pixl_manager = false;
+				delete socket._pixl_manager_hostname;
+				delete socket._pixl_job_dispatch_state;
+				socket.emit('auth_failure', { description: "Invalid signed job dispatch context." });
+			}
 		} );
 		
 		socket.on('abort_job', function(stub) {
@@ -476,6 +581,8 @@ module.exports = Class.create({
 			// user wants out?  okay then
 			socket._pixl_auth = false;
 			socket._pixl_manager = false;
+			delete socket._pixl_manager_hostname;
+			delete socket._pixl_job_dispatch_state;
 		} );
 		
 		socket.on('manager_ping', function(args) {
@@ -617,6 +724,7 @@ module.exports = Class.create({
 					clearTimeout( worker.socketReconnectTimer );
 					delete worker.socketReconnectTimer;
 				}
+				this.resetWorkerJobDispatchNegotiation(worker);
 			}
 			this.workers = {};
 		} // manager

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -42,6 +42,7 @@ module.exports = Class.create({
 	],
 
 	activeJobs: null,
+	remoteLogFetchJobs: null,
 	deadJobs: null,
 	eventQueue: null,
 	kids: null,
@@ -76,6 +77,9 @@ module.exports = Class.create({
 
 		// keep track of jobs
 		this.activeJobs = {};
+		// Manager-owned immutable launch snapshots used for remote log
+		// authorization.  Never merge worker status payloads into this map.
+		this.remoteLogFetchJobs = Object.create(null);
 		this.deadJobs = {};
 		this.eventQueue = {};
 		this.kids = {};

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -87,7 +87,6 @@ module.exports = Class.create({
 		this.normalShutdown = false;
 		// this.secrets = {};
 		this.eKey = crypto.scryptSync(this.server.config.get('secret_key'), '', 32),
-		this.workflowKeys = new Map()
         this.winmonShuttingDown = false;
 		
 
@@ -110,6 +109,7 @@ module.exports = Class.create({
 		this.web = this.server.WebServer;
 		this.api = this.server.API;
 		this.usermgr = this.server.User;
+		this.api.on('request', this.captureWorkflowAuthHeaders.bind(this));
 
 		// register custom storage type for dual-metadata-log delete
 		this.storage.addRecordType('cronicle_job', {

--- a/lib/job.js
+++ b/lib/job.js
@@ -474,9 +474,6 @@ module.exports = Class.create({
 					job.env['BASE_URL'] = base_url
 
 					job.env['BASE_APP_URL'] = self.server.config.get('base_app_url') || ''
-					if(plugin.id === 'workflow' || plugin.wf) {
-						self.workflowKeys.set(job.id, Tools.digestHex(job.id + self.config.get('secret_key'), 'MD5'))
-				    }
 
 					// for shell plug - resolve parameter placeholders using params object on config
 					let xparams = JSON.parse(JSON.stringify(self.server.config.get('params') || {}));
@@ -803,7 +800,7 @@ module.exports = Class.create({
 
 		if (job.is_wf || job.plugin == 'workflow') { 
 			// job_env['WF_SIGNATURE'] = 'sha1=' + crypto.createHmac("sha1", self.server.config.get('secret_key')).update(job.id).digest("hex")
-			job_env['WF_SIGNATURE'] = Tools.digestHex(job.id + self.config.get('secret_key'), 'MD5')
+			job_env['WF_SIGNATURE'] = self.getWorkflowSignature(job.id)
 		}
 
 		// setup environment for child
@@ -1182,21 +1179,34 @@ module.exports = Class.create({
 		// stub should have: id
 		if (!this.multi.manager) return false;
 		if (typeof (stub) == 'string') stub = { id: stub };
+		if (!stub || (typeof stub != 'object') || !this.isSafeJobIdentifier(stub.id)) return false;
 
-		// check all jobs, local, remote and pending
-		var all_jobs = this.getAllActiveJobs(true);
-		var job = all_jobs[stub.id];
-		if (!job) {
-			// check pending jobs (they have separate IDs)
-			for (var key in all_jobs) {
-				if (all_jobs[key].id == stub.id) {
-					job = all_jobs[key];
-					break;
-				}
+		var id = stub.id;
+		var findOwnJob = function(jobs, pending) {
+			if (!jobs || (typeof jobs != 'object')) return false;
+			var keys = Object.keys(jobs);
+			for (var idx = 0; idx < keys.length; idx++) {
+				var job = jobs[keys[idx]];
+				if (!job || (typeof job != 'object')) continue;
+				if (pending && (!Object.prototype.hasOwnProperty.call(job, 'action') ||
+					(job.action !== 'launchLocalJob'))) continue;
+				if (Object.prototype.hasOwnProperty.call(job, 'id') && (job.id === id)) return job;
 			}
+			return false;
+		};
+
+		var job = findOwnJob(this.activeJobs, false) || findOwnJob(this.internalQueue, true);
+		if (job) return job;
+
+		var worker_names = Object.keys(this.workers || {});
+		for (var idx = 0; idx < worker_names.length; idx++) {
+			var worker = this.workers[worker_names[idx]];
+			if (!worker || (typeof worker != 'object')) continue;
+			job = findOwnJob(worker.active_jobs, false) || findOwnJob(worker.queue, true);
+			if (job) return job;
 		}
 
-		return job || false;
+		return false;
 	},
 
 	updateJob: function (stub) {
@@ -2249,9 +2259,6 @@ module.exports = Class.create({
 
 		// just in case job was in limbo, we can remove it now
 		delete this.deadJobs[job.id];
-
-		// delete workflow key if exist
-		self.workflowKeys.delete(job.id)
 
 		// we can clear high mem/cpu flags too, if applicable
 		if (this.state.flagged_jobs) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -19,9 +19,231 @@ const PixlMail = require('pixl-mail');
 const dotenv = require('dotenv');
 
 //const si = require('systeminformation');
-const isUnix = os.platform() != 'win32';
+const hasOwn = function(object, key) {
+	return !!object && Object.prototype.hasOwnProperty.call(object, key);
+};
+
+const hasRunAsValue = function(value) {
+	return (typeof(value) == 'number') || ((typeof(value) == 'string') && (value !== ''));
+};
+
+const hasOwnRunAsValue = function(object, key) {
+	return hasOwn(object, key) && hasRunAsValue(object[key]);
+};
+
+const stableJSONStringify = function(node) {
+	// Input is normalized through a JSON round-trip before reaching this helper.
+	// Use Array.isArray rather than pixl-tools' legacy length-based array test, so
+	// ordinary JSON objects containing a `length` field remain valid payloads.
+	if (node === null) return 'null';
+	if (Array.isArray(node)) {
+		return '[' + node.map(function(item) { return stableJSONStringify(item); }).join(',') + ']';
+	}
+	if (typeof(node) == 'object') {
+		return '{' + Object.keys(node).sort().map(function(key) {
+			return JSON.stringify(key) + ':' + stableJSONStringify(node[key]);
+		}).join(',') + '}';
+	}
+	return JSON.stringify(node);
+};
+
+const JOB_RUN_AS_CONTEXT_FIELD = '_cronicle_run_as';
+const JOB_RUN_AS_CONTEXT_VERSION = 2;
+const JOB_RUN_AS_CAPABILITY = 'signed_job_run_as_v2';
+const JOB_RUN_AS_PLUGIN_MODE = 'plugin';
+const JOB_RUN_AS_SERVICE_MODE = 'service';
 
 module.exports = Class.create({
+
+	setJobRunAsFromPlugin: function(job, plugin) {
+		// Plugin launch context is administrator-controlled and must be copied by
+		// the manager even when the manager itself is running on Windows.
+		delete job.uid;
+		delete job.gid;
+		if (hasOwnRunAsValue(plugin, 'uid')) job.uid = plugin.uid;
+		if (hasOwnRunAsValue(plugin, 'gid')) job.gid = plugin.gid;
+		return job;
+	},
+
+	getJobDispatchCapabilities: function() {
+		var capabilities = Object.create(null);
+		capabilities[JOB_RUN_AS_CAPABILITY] = JOB_RUN_AS_CONTEXT_VERSION;
+		return capabilities;
+	},
+
+	isValidJobDispatchSession: function(session) {
+		return (typeof(session) == 'string') && !!session.match(/^[a-f0-9]{64}$/);
+	},
+
+	supportsSignedJobDispatch: function(capabilities) {
+		return !!capabilities && (typeof(capabilities) == 'object') && !Array.isArray(capabilities) &&
+			hasOwn(capabilities, JOB_RUN_AS_CAPABILITY) &&
+			(capabilities[JOB_RUN_AS_CAPABILITY] === JOB_RUN_AS_CONTEXT_VERSION);
+	},
+
+	isWorkerJobDispatchReady: function(worker) {
+		return !!worker && (!hasOwn(worker, 'job_dispatch_ready') || (worker.job_dispatch_ready === true));
+	},
+
+	getJobDispatchPayloadDigest: function(job) {
+		// Sign the exact JSON-compatible wire payload, excluding only the top-level
+		// transport context that carries the digest and signature.  copyHash's JSON
+		// round-trip matches Socket.IO serialization semantics, while stable ordering
+		// makes object key order irrelevant and considers only own properties.
+		var payload = Tools.copyHash(job, true);
+		delete payload[JOB_RUN_AS_CONTEXT_FIELD];
+		return crypto.createHash('sha256')
+			.update(stableJSONStringify(payload), 'utf8')
+			.digest('hex');
+	},
+
+	getJobRunAsSignaturePayload: function(job, mode, manager_hostname, worker_hostname, dispatch_session, sequence, payload_sha256) {
+		return [
+			'cronicle-job-dispatch',
+			String(JOB_RUN_AS_CONTEXT_VERSION),
+			mode,
+			String(job.id || ''),
+			String(manager_hostname || ''),
+			String(worker_hostname || ''),
+			String(dispatch_session || ''),
+			String(sequence || ''),
+			String(payload_sha256 || '')
+		].join('\0');
+	},
+
+	createJobRunAsContext: function(job, worker, trusted_debug_sudo) {
+		var mode = trusted_debug_sudo ? JOB_RUN_AS_SERVICE_MODE : JOB_RUN_AS_PLUGIN_MODE;
+		var manager_hostname = this.server.hostname;
+		var worker_hostname = worker.hostname;
+		var sequence = hasOwn(worker, 'job_dispatch_sequence') ? worker.job_dispatch_sequence + 1 : 1;
+		if (!Number.isSafeInteger(sequence) || (sequence < 1)) {
+			throw new Error('Signed job dispatch sequence is exhausted for worker: ' + worker_hostname);
+		}
+		var payload_sha256 = this.getJobDispatchPayloadDigest(job);
+		worker.job_dispatch_sequence = sequence;
+		return {
+			version: JOB_RUN_AS_CONTEXT_VERSION,
+			mode: mode,
+			job_id: job.id,
+			manager_hostname: manager_hostname,
+			worker_hostname: worker_hostname,
+			dispatch_session: worker.job_dispatch_session,
+			sequence: sequence,
+			payload_sha256: payload_sha256,
+			signature: crypto.createHmac('sha256', String(this.server.config.get('secret_key')))
+				.update(this.getJobRunAsSignaturePayload(
+					job, mode, manager_hostname, worker_hostname,
+					worker.job_dispatch_session, sequence, payload_sha256
+				))
+				.digest('hex')
+		};
+	},
+
+	createJobDispatchPayload: function(job, worker, trusted_debug_sudo) {
+		// A new manager signs every dispatch to a capable worker.  Legacy workers
+		// receive no unknown marker; an admin debug request therefore degrades to
+		// the Plugin identity until that worker is upgraded.
+		var payload = Tools.copyHash(job, true);
+		if (hasOwnRunAsValue(job, 'uid')) payload.uid = job.uid;
+		else delete payload.uid;
+		if (hasOwnRunAsValue(job, 'gid')) payload.gid = job.gid;
+		else delete payload.gid;
+		delete payload.debug_sudo;
+		delete payload[JOB_RUN_AS_CONTEXT_FIELD];
+
+		var worker_capabilities = hasOwn(worker, 'job_dispatch_capabilities') ?
+			worker.job_dispatch_capabilities : null;
+		if (!this.supportsSignedJobDispatch(worker_capabilities) ||
+			!hasOwn(worker, 'job_dispatch_session') ||
+			!this.isValidJobDispatchSession(worker.job_dispatch_session)) {
+			if (trusted_debug_sudo) {
+				this.logDebug(4, 'Worker does not support signed debug run-as context; using Plugin identity: ' +
+					String(worker && worker.hostname || 'unknown'));
+			}
+			return payload;
+		}
+
+		payload[JOB_RUN_AS_CONTEXT_FIELD] = this.createJobRunAsContext(
+			payload, worker, trusted_debug_sudo
+		);
+		return payload;
+	},
+
+	verifyJobRunAsContext: function(job, manager_hostname, dispatch_state) {
+		if (!job || (typeof(job) != 'object') || Array.isArray(job) ||
+			!hasOwn(job, JOB_RUN_AS_CONTEXT_FIELD)) return false;
+		var context = job[JOB_RUN_AS_CONTEXT_FIELD];
+		if (!context || (typeof(context) != 'object') || Array.isArray(context) ||
+			!hasOwn(context, 'version') || (context.version !== JOB_RUN_AS_CONTEXT_VERSION) ||
+			!hasOwn(context, 'mode') ||
+			((context.mode !== JOB_RUN_AS_PLUGIN_MODE) && (context.mode !== JOB_RUN_AS_SERVICE_MODE)) ||
+			!hasOwn(context, 'job_id') || (typeof(context.job_id) != 'string') ||
+			!hasOwn(context, 'manager_hostname') || (typeof(context.manager_hostname) != 'string') ||
+			!hasOwn(context, 'worker_hostname') || (typeof(context.worker_hostname) != 'string') ||
+			!hasOwn(context, 'dispatch_session') || !this.isValidJobDispatchSession(context.dispatch_session) ||
+			!hasOwn(context, 'sequence') || !Number.isSafeInteger(context.sequence) || (context.sequence < 1) ||
+			!hasOwn(context, 'payload_sha256') || (typeof(context.payload_sha256) != 'string') ||
+			!context.payload_sha256.match(/^[a-f0-9]{64}$/) ||
+			!hasOwn(context, 'signature') || (typeof(context.signature) != 'string') ||
+			!context.signature.match(/^[a-f0-9]{64}$/)) return false;
+
+		if (!hasOwn(job, 'id') || (context.job_id !== job.id) ||
+			!hasOwn(job, 'hostname') || (job.hostname !== this.server.hostname) ||
+			(context.worker_hostname !== this.server.hostname) ||
+			(context.manager_hostname !== manager_hostname) ||
+			!dispatch_state || !hasOwn(dispatch_state, 'session') ||
+			(context.dispatch_session !== dispatch_state.session)) return false;
+
+		var actual_payload_sha256 = '';
+		try { actual_payload_sha256 = this.getJobDispatchPayloadDigest(job); }
+		catch (err) { return false; }
+		if (!this.secureCompareStrings(context.payload_sha256, actual_payload_sha256)) return false;
+
+		var expected = crypto.createHmac('sha256', String(this.server.config.get('secret_key')))
+			.update(this.getJobRunAsSignaturePayload(
+				job, context.mode, context.manager_hostname, context.worker_hostname,
+				context.dispatch_session, context.sequence, context.payload_sha256
+			))
+			.digest('hex');
+		if (!this.secureCompareStrings(context.signature, expected)) return false;
+		return context;
+	},
+
+	launchJobFromManager: function(job, manager_hostname, dispatch_state) {
+		var context = this.verifyJobRunAsContext(job, manager_hostname, dispatch_state);
+		if (!context) return false;
+		var last_sequence = hasOwn(dispatch_state, 'last_sequence') ? dispatch_state.last_sequence : 0;
+		if (!Number.isSafeInteger(last_sequence) || (last_sequence < 0) ||
+			(context.sequence <= last_sequence)) return false;
+		dispatch_state.last_sequence = context.sequence;
+		this.launchLocalJob(job, { service_uid: context.mode === JOB_RUN_AS_SERVICE_MODE });
+		return true;
+	},
+
+	consumeJobDispatchContext: function(job, launch_options, platform, serviceUid) {
+		// Never trust the legacy top-level debug_sudo marker.  Only an in-memory
+		// decision produced by successful HMAC verification can select service UID.
+		platform = platform || os.platform();
+		if ((platform != 'win32') && hasOwn(launch_options, 'service_uid') && launch_options.service_uid) {
+			if (serviceUid === undefined) serviceUid = process.getuid();
+			job.uid = serviceUid;
+		}
+		delete job.debug_sudo;
+		delete job[JOB_RUN_AS_CONTEXT_FIELD];
+		return job;
+	},
+
+	getChildRunAsOptions: function(job, platform, serviceUid, serviceGid) {
+		// Spawn identity belongs to the executing worker, not the manager.
+		platform = platform || os.platform();
+		if (platform == 'win32') return {};
+		if (serviceUid === undefined) serviceUid = process.getuid();
+		if (serviceGid === undefined) serviceGid = process.getgid();
+		return {
+			uid: hasOwnRunAsValue(job, 'uid') ? job.uid : serviceUid,
+			gid: hasOwnRunAsValue(job, 'gid') ? job.gid : serviceGid
+		};
+	},
 
 	getJobLogFilePath: function (id, detached) {
 		// Derive job log paths locally.  Never accept a filesystem path from a
@@ -180,7 +402,7 @@ module.exports = Class.create({
 		return stream;
 	},
 
-	launchOrQueueJob: function (event, callback) {
+	launchOrQueueJob: function (event, callback, launch_options) {
 		// launch job, or queue upon failure (if event desires)
 		var self = this;
 
@@ -205,8 +427,12 @@ module.exports = Class.create({
 					// add now time if not already set
 					if (!event.now) event.now = Tools.timeNow(true);
 
-					// add job to actual queue in storage, async
-					self.storage.listPush('global/event_queue/' + event.id, event, function (err) {
+					// Request authorization is never durable.  A capacity-deferred job
+					// retries under the normal administrator-controlled Plugin identity.
+					var queued_event = Tools.copyHash(event, true);
+					delete queued_event.debug_sudo;
+					delete queued_event[JOB_RUN_AS_CONTEXT_FIELD];
+					self.storage.listPush('global/event_queue/' + event.id, queued_event, function (err) {
 						if (err) {
 							self.logError('queue', "Failed to push job onto event queue: " + err);
 						}
@@ -218,7 +444,7 @@ module.exports = Class.create({
 				}
 			}
 			callback(err, jobs);
-		});
+		}, launch_options);
 	},
 
 	// safeJobLog(job) { // print less verbose, more readable job data on logging
@@ -228,7 +454,7 @@ module.exports = Class.create({
 	// 	return Object.keys(jc).filter(e => !excl.includes(e)).map(e => e + ': ' + ("params|workflow|perf".indexOf(e) > -1 ? JSON.stringify(jc[e]) : jc[e]) ).join(" | ")
 	// },
 
-	launchJob: function (event, callback) {
+	launchJob: function (event, callback, launch_options) {
 		// locate suitable server and launch job
 		let self = this;
 		let orig_event = null;
@@ -240,6 +466,7 @@ module.exports = Class.create({
 		let cat_secret = {};
 		let plug_secret = {};
 		let lag = Date.now();
+		let trusted_debug_sudo = !!(hasOwn(launch_options, 'debug_sudo') && launch_options.debug_sudo);
 
 		// must be manager to do this
 		if (!this.multi.manager) return callback(new Error("Only a manager server can launch jobs."));
@@ -248,7 +475,7 @@ module.exports = Class.create({
 			function (callback) {
 				// event target may refer to server group OR hostname
 				var worker = self.workers[event.target] || null;
-				if (worker && !worker.disabled) {
+				if (worker && !worker.disabled && self.isWorkerJobDispatchReady(worker)) {
 					servers.push(worker);
 					return callback();
 				}
@@ -348,7 +575,7 @@ module.exports = Class.create({
 						var worker = self.workers[hostname];
 
 						// only consider workers that match the group hostname pattern, and are not disabled
-						if (hostname.match(regex) && !worker.disabled) {
+						if (hostname.match(regex) && !worker.disabled && self.isWorkerJobDispatchReady(worker)) {
 							candidates.push(self.workers[hostname]);
 						}
 					}
@@ -392,6 +619,8 @@ module.exports = Class.create({
 				    delete job.uid;
 				    delete job.gid;
 				    delete job.env;
+				    delete job.debug_sudo;
+				    delete job[JOB_RUN_AS_CONTEXT_FIELD];
 	
 
 					delete job.id;
@@ -451,12 +680,8 @@ module.exports = Class.create({
 					}
 
 					job.command = plugin.command;
-					if (plugin.cwd) job.cwd = plugin.cwd;
-					if (isUnix) {
-						if (plugin.uid) job.uid = plugin.uid;
-						if (job.debug_sudo) job.uid = process.getuid();
-						if (plugin.gid) job.gid = plugin.gid;
-					}
+					if (hasOwn(plugin, 'cwd') && plugin.cwd) job.cwd = plugin.cwd;
+					self.setJobRunAsFromPlugin(job, plugin);
 
 					job.env = self.server.config.get('job_env') || {} 
 					let proto = 'http://'
@@ -527,7 +752,7 @@ module.exports = Class.create({
 					// if(self.server.config.get('profile')) self.logDebug(6, `PROFILE: LAG ${job.id} manager`, Date.now() - lag)
 					if (worker.manager) {
 						// run the event here
-						self.launchLocalJob(job);						
+						self.launchLocalJob(job, { service_uid: trusted_debug_sudo });
 					}
 					else if (worker.socket) {
 						// Record an immutable manager-owned assignment before the worker can
@@ -551,7 +776,7 @@ module.exports = Class.create({
 
 						// send the job to remote worker server
 						self.logDebug(6, "Sending remote job to: " + worker.hostname, job);
-						worker.socket.emit('launch_job', job);
+						worker.socket.emit('launch_job', self.createJobDispatchPayload(job, worker, trusted_debug_sudo));
 					}
 
 					// fire web hook
@@ -718,11 +943,12 @@ module.exports = Class.create({
 		return server;
 	},
 
-	launchLocalJob: function (job) {
+	launchLocalJob: function (job, launch_options) {
 		// launch job as a local child process
 		var self = this;
 		var child = null;
 		var worker = null;
+		this.consumeJobDispatchContext(job, launch_options);
 		// if(self.server.config.get('profile')) self.logDebug(6, `PROFILE: LAG ${job.id} manager`, Date.now() - job.lag)
 
 		// check for job delay request (multiplex stagger)
@@ -809,9 +1035,10 @@ module.exports = Class.create({
 			env: job_env
 		};
 
-		if (isUnix) {
-			child_opts['uid'] = job.uid || process.getuid()
-			child_opts['gid'] = process.getgid()
+		var run_as = this.getChildRunAsOptions(job);
+		if (hasOwn(run_as, 'uid')) {
+			child_opts.uid = run_as.uid;
+			child_opts.gid = run_as.gid;
 		}
 
 		child_opts.env['CRONICLE'] = this.server.__version;
@@ -835,7 +1062,7 @@ module.exports = Class.create({
 		}
 
 		// get uid / gid info for child env vars. Ignore for Win32
-		if (isUnix) {
+		if (hasOwn(run_as, 'uid')) {
 			var user_info = Tools.getpwnam(child_opts.uid, true);
 			if (user_info) {
 				child_opts.uid = user_info.uid;
@@ -856,7 +1083,7 @@ module.exports = Class.create({
 			}
 
 
-			if (job.gid) {
+			if (hasOwnRunAsValue(job, 'gid')) {
 				var grp_info = Tools.getgrnam(job.gid, true);
 				if (grp_info) {
 					child_opts.gid = grp_info.gid;
@@ -2019,6 +2246,8 @@ module.exports = Class.create({
 				return false;
 			}
 		}
+		delete job.debug_sudo;
+		delete job[JOB_RUN_AS_CONTEXT_FIELD];
 
 		if (!job.time_end) job.time_end = Tools.timeNow();
 		job.elapsed = Math.max(0, job.time_end - job.time_start);

--- a/lib/job.js
+++ b/lib/job.js
@@ -4,9 +4,12 @@
 
 const async = require('async');
 const cp = require('child_process');
+const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const Readable = require('stream').Readable;
+const Writable = require('stream').Writable;
 const sqparse = require('shell-quote').parse;
 const zlib = require('zlib');
 const Class = require("pixl-class");
@@ -19,6 +22,163 @@ const dotenv = require('dotenv');
 const isUnix = os.platform() != 'win32';
 
 module.exports = Class.create({
+
+	getJobLogFilePath: function (id, detached) {
+		// Derive job log paths locally.  Never accept a filesystem path from a
+		// client or another server as authorization to read a file.
+		if (!String(id || '').match(/^\w+$/)) return false;
+		return path.resolve(path.join(
+			this.server.config.get('log_dir'), 'jobs',
+			id + (detached ? '-detached' : '') + '.log'
+		));
+	},
+
+	getManagerJobLogSnapshot: function (id) {
+		if (this.multi.manager && this.remoteLogFetchJobs && this.remoteLogFetchJobs[id]) {
+			return this.remoteLogFetchJobs[id];
+		}
+		if (this.activeJobs && this.activeJobs[id]) return this.activeJobs[id];
+		if (this.multi.manager && this.internalQueue) {
+			for (var key in this.internalQueue) {
+				var task = this.internalQueue[key];
+				if (task && (task.action === 'launchLocalJob') && (task.id === id)) return task;
+			}
+		}
+		return undefined;
+	},
+
+	bindRemoteFinishedJob: function (job, source_worker) {
+		if (!job || !String(job.id || '').match(/^\w+$/) || !source_worker || !source_worker.hostname) {
+			return false;
+		}
+		var snapshot = this.remoteLogFetchJobs && this.remoteLogFetchJobs[job.id];
+		if (!snapshot || (snapshot.hostname != source_worker.hostname)) return false;
+		if (job.hostname && (job.hostname != source_worker.hostname)) return false;
+
+		var bound = Tools.copyHash(job);
+		[ 'id', 'hostname', 'detached', 'category', 'target', 'event', 'event_title', 'plugin' ].forEach(function (key) {
+			if (key in snapshot) bound[key] = snapshot[key];
+		});
+		return bound;
+	},
+
+	getJobLogFetchAuth: function (id, detached) {
+		// Domain-separate this capability from the other cluster tokens.
+		return crypto.createHmac('sha256', String(this.server.config.get('secret_key')))
+			.update('fetch-job-log\0' + id + '\0' + (detached ? '1' : '0'))
+			.digest('hex');
+	},
+
+	secureCompareStrings: function (supplied, expected) {
+		var supplied_buffer = Buffer.from(String(supplied || ''));
+		var expected_buffer = Buffer.from(String(expected || ''));
+		if (supplied_buffer.length != expected_buffer.length) return false;
+		return crypto.timingSafeEqual(supplied_buffer, expected_buffer);
+	},
+
+	verifyJobLogFetchAuth: function (id, detached, auth) {
+		var expected = this.getJobLogFetchAuth(id, detached);
+		return this.secureCompareStrings(auth, expected);
+	},
+
+	createJobLogDescriptorOwner: function (fd, io) {
+		// Serialize descriptor shutdown behind all outstanding positional I/O.
+		// Streams may be destroyed on protocol/storage errors, but close(2) is not
+		// called until every fs.read/fs.write callback has returned.
+		io = io || fs;
+		var pending = 0;
+		var closing = false;
+		var close_started = false;
+		var closed = false;
+		var close_callbacks = [];
+
+		var maybe_close = function () {
+			if (!closing || pending || close_started) return;
+			close_started = true;
+			io.close(fd, function (err) {
+				closed = true;
+				var callbacks = close_callbacks.splice(0);
+				callbacks.forEach(function (callback) { callback(err); });
+			});
+		};
+		var start = function (callback) {
+			if (!closing && !closed) {
+				pending++;
+				return true;
+			}
+			process.nextTick(function () { callback(new Error("Job log descriptor is closing")); });
+			return false;
+		};
+		var finish = function (callback, args) {
+			pending--;
+			try { callback.apply(null, args); }
+			finally { maybe_close(); }
+		};
+
+		return {
+			fd: fd,
+			read: function (buffer, offset, length, position, callback) {
+				if (!start(callback)) return;
+				io.read(fd, buffer, offset, length, position, function () {
+					finish(callback, Array.prototype.slice.call(arguments));
+				});
+			},
+			write: function (buffer, offset, length, position, callback) {
+				if (!start(callback)) return;
+				io.write(fd, buffer, offset, length, position, function () {
+					finish(callback, Array.prototype.slice.call(arguments));
+				});
+			},
+			close: function (callback) {
+				if (!callback) callback = function () {};
+				if (closed) return process.nextTick(function () { callback(); });
+				close_callbacks.push(callback);
+				closing = true;
+				maybe_close();
+			},
+			isClosing: function () { return closing; }
+		};
+	},
+
+	createJobLogDescriptorStream: function (descriptor, byte_limit) {
+		// A positional descriptor reader which never owns or closes the fd.
+		// This lets the caller keep one capability across storage and archive copies.
+		var limited = Number.isSafeInteger(byte_limit) && (byte_limit >= 0);
+		var position = 0;
+		var reading = false;
+		var ended = false;
+		var stream = new Readable({
+			read: function (requested) {
+				if (reading || ended || stream.destroyed) return;
+				if (limited && (position >= byte_limit)) {
+					ended = true;
+					stream.jobLogComplete = true;
+					return stream.push(null);
+				}
+				reading = true;
+				var length = Math.max(1, Math.min(requested || 65536, 1024 * 1024));
+				if (limited) length = Math.min(length, byte_limit - position);
+				var buffer = Buffer.alloc(length);
+				descriptor.read(buffer, 0, length, position, function (err, bytes_read) {
+					reading = false;
+					if (stream.destroyed) return;
+					if (err) return stream.destroy(err);
+					if (!bytes_read) {
+						ended = true;
+						stream.jobLogComplete = !limited || (position == byte_limit);
+						return stream.push(null);
+					}
+					position += bytes_read;
+					stream.jobLogBytesRead = position;
+					stream.push(buffer.subarray(0, bytes_read));
+				});
+			}
+		});
+		stream.jobLogExpectedSize = limited ? byte_limit : null;
+		stream.jobLogBytesRead = 0;
+		stream.jobLogComplete = false;
+		return stream;
+	},
 
 	launchOrQueueJob: function (event, callback) {
 		// launch job, or queue upon failure (if event desires)
@@ -373,14 +533,28 @@ module.exports = Class.create({
 						self.launchLocalJob(job);						
 					}
 					else if (worker.socket) {
-						// send the job to remote worker server
-						self.logDebug(6, "Sending remote job to: " + worker.hostname, job);
-						worker.socket.emit('launch_job', job);
+						// Record an immutable manager-owned assignment before the worker can
+						// acknowledge or complete it.  Worker status is never authoritative for
+						// log identity or category/group authorization.
+						self.remoteLogFetchJobs[job.id] = {
+							id: job.id,
+							hostname: worker.hostname,
+							detached: job.detached ? 1 : 0,
+							category: job.category,
+							target: job.target,
+							event: job.event,
+							event_title: job.event_title,
+							plugin: job.plugin
+						};
 
 						// Pre-insert job into worker's active_jobs, so something will show in getAllActiveJobs() right away.
 						// Important for when the scheduler is catching up, and may try to launch a bunch of jobs in a row.
 						if (!worker.active_jobs) worker.active_jobs = {};
 						worker.active_jobs[job.id] = job;
+
+						// send the job to remote worker server
+						self.logDebug(6, "Sending remote job to: " + worker.hostname, job);
+						worker.socket.emit('launch_job', job);
 					}
 
 					// fire web hook
@@ -578,10 +752,7 @@ module.exports = Class.create({
 		else {
 
 			// construct fully qualified path to job log file
-			job.log_file = path.resolve(path.join(
-				this.server.config.get('log_dir'), 'jobs',
-				job.id + (job.detached ? '-detached' : '') + '.log'
-			));
+			job.log_file = this.getJobLogFilePath(job.id, job.detached);
 		}
 
 		this.logDebug(6, "Launching local job", this.safeJobLog(job));
@@ -1062,13 +1233,16 @@ module.exports = Class.create({
 
 	updateLocalJob: function (stub) {
 		// update local job properties
-		var job = this.activeJobs[stub.id];
+		if (!stub || (typeof stub != 'object') || (typeof stub.id != 'string')) return false;
+		var job = (this.activeJobs && Object.prototype.hasOwnProperty.call(this.activeJobs, stub.id)) ?
+			this.activeJobs[stub.id] : null;
 		if (!job) {
 			// must be a pending job
 			if (this.internalQueue) {
 				for (var key in this.internalQueue) {
+					if (!Object.prototype.hasOwnProperty.call(this.internalQueue, key)) continue;
 					var task = this.internalQueue[key];
-					if ((task.action == 'launchLocalJob') && (task.id == stub.id)) {
+					if (task && (task.action == 'launchLocalJob') && (task.id === stub.id)) {
 						job = task;
 						break;
 					}
@@ -1084,9 +1258,9 @@ module.exports = Class.create({
 		this.logDebug(4, "Updating local job: " + stub.id, stub);
 
 		// update properties
-		for (var key in stub) {
+		Object.keys(stub).forEach(function (key) {
 			if (key != 'id') job[key] = stub[key];
-		}
+		});
 
 		return true;
 	},
@@ -1590,53 +1764,251 @@ module.exports = Class.create({
 		} // worker
 	},
 
-	fetchStoreJobLog: function (job) {
+	storeJobLogFromDescriptor: function (job, descriptor, callback) {
+		// Store a fetched worker log from the descriptor that was already verified.
+		// Do not reopen its temporary pathname: a job running under the same local
+		// account could otherwise replace the pathname between download and upload.
+		var self = this;
+		var storage_path = 'jobs/' + job.id + '/log.txt.gz';
+		var settled = false;
+		var finish = function (err) {
+			if (settled) return;
+			settled = true;
+			callback(err);
+		};
+		var source = this.createJobLogDescriptorStream(descriptor);
+		var gzip = zlib.createGzip(this.server.config.get('gzip_opts') || {});
+		source.on('error', finish);
+		gzip.on('error', finish);
+		source.pipe(gzip);
+
+		this.storage.putStream(storage_path, gzip, function (err) {
+			if (err) {
+				self.logError('storage', "Failed to store job log: " + storage_path + ": " + err);
+				return finish(err);
+			}
+
+			self.logDebug(9, "Job log stored successfully: " + storage_path);
+			if (!self.server.config.get('copy_job_logs_to')) return finish();
+
+			var dargs = Tools.getDateArgs(Tools.timeNow());
+			var dest_path = self.server.config.get('copy_job_logs_to').replace(/\/$/, '') + '/';
+			if (job.event_title) dest_path += job.event_title.replace(/\W+/g, '') + '.';
+			dest_path += job.id + '.' + (dargs.yyyy_mm_dd + '-' + dargs.hh_mi_ss).replace(/\W+/g, '-') + '.log';
+
+			// Copy from the held descriptor as well.  Exclusive creation prevents a
+			// pre-planted destination symlink from becoming an overwrite primitive.
+			var copy_source = self.createJobLogDescriptorStream(descriptor);
+			var copy_dest = fs.createWriteStream(dest_path, { flags: 'wx', mode: 0o600 });
+			var copy_failed = false;
+			var copy_error = function (err) {
+				if (copy_failed) return;
+				copy_failed = true;
+				copy_source.destroy();
+				copy_dest.destroy();
+				self.logError('file', "Failed to copy fetched job log to: " + dest_path + ": " + err);
+				// Match the historical behavior: archival-copy failure does not turn a
+				// successful primary storage upload into a failed job-log transfer.
+				finish();
+			};
+			copy_source.on('error', copy_error);
+			copy_dest.on('error', copy_error);
+			copy_dest.on('finish', function () {
+				if (!copy_failed) finish();
+			});
+			copy_source.pipe(copy_dest);
+		});
+	},
+
+	fetchStoreJobLog: function (job, source_worker) {
 		// fetch remote job log from worker, and then store in storage
 		var self = this;
 		if (!this.multi.manager) return;
 
-		var worker = this.workers[job.hostname];
-		if (!worker) {
-			this.logError('job', "Failed to locate worker: " + job.hostname + " for job: " + job.id);
-			worker = { hostname: job.hostname }; // hail mary
+		// The worker connection is the authority for the source host.  Do not let
+		// the socket payload redirect the manager to a different server.
+		if (!source_worker || !source_worker.hostname) {
+			return this.logError('job', "Refusing job log fetch without a source worker");
 		}
+		if (!job || !String(job.id || '').match(/^\w+$/)) {
+			return this.logError('job', "Refusing job log fetch with an invalid job ID");
+		}
+		if (job.hostname && (job.hostname != source_worker.hostname)) {
+			return this.logError('job', "Refusing job log fetch with a mismatched source worker: " + job.id);
+		}
+
+		var worker = source_worker;
+		var known_job = this.remoteLogFetchJobs && this.remoteLogFetchJobs[job.id];
+		if (!known_job || (known_job.hostname != worker.hostname)) {
+			return this.logError('job', "Refusing job log fetch for a job not assigned to the source worker: " + job.id);
+		}
+		if (known_job.log_fetch_in_flight) {
+			return this.logError('job', "Refusing duplicate in-flight job log fetch: " + job.id);
+		}
+		known_job.log_fetch_in_flight = 1;
+		var release_fetch = function () {
+			if (self.remoteLogFetchJobs && (self.remoteLogFetchJobs[job.id] === known_job)) {
+				delete known_job.log_fetch_in_flight;
+			}
+		};
+
+		// Use the manager-owned launch snapshot for all identity fields.  The
+		// completion payload may contain results, but cannot choose a storage slot.
+		job = Tools.copyHash(job);
+		job.id = known_job.id;
+		job.hostname = worker.hostname;
+		job.detached = known_job.detached ? 1 : 0;
+		var detached = job.detached;
 
 		// construct url to API on remote server w/auth key
 		var api_url = this.getWorkerServerBaseAPIURL(worker.hostname, worker.ip) + '/app/fetch_delete_job_log';
 
 		api_url += Tools.composeQueryString({
-			path: job.log_file,
-			auth: Tools.digestHex(job.log_file + this.server.config.get('secret_key'))
+			id: job.id,
+			detached: detached,
+			auth: this.getJobLogFetchAuth(job.id, detached)
 		});
 
-		this.logDebug(6, "Fetching remote job log via HTTP GET: " + api_url);
+		this.logDebug(6, "Fetching remote job log via HTTP GET", {
+			id: job.id,
+			hostname: worker.hostname,
+			detached: detached
+		});
 
-		// just in case remote server has different base dir than manager
-		job.log_file = this.server.config.get('log_dir') + '/jobs/' + path.basename(job.log_file);
-
-		this.request.get(api_url, { download: job.log_file }, function (err, resp) {
-			// check for error
+		// Never download into the world-writable jobs directory.  Use a private,
+		// unpredictable directory and an exclusive file, then retain its descriptor;
+		// directory permissions alone do not isolate a job running under the same UID.
+		fs.mkdtemp(path.join(os.tmpdir(), 'cronicle-job-log-'), function (err, temp_dir) {
 			if (err) {
-				var err_msg = "Failed to fetch job log file: " + api_url + ": " + err;
-				self.logError('job', err_msg);
+				release_fetch();
+				return self.logError('file', "Failed to create private job-log download directory: " + err);
 			}
-			else if (resp.statusCode != 200) {
-				var err_msg = "Failed to fetch job log file: " + api_url + ": HTTP " + resp.statusCode + " " + resp.statusMessage;
-				self.logError('job', err_msg);
-			}
-			else {
-				// success
-				self.logDebug(5, "Job log was fetched successfully", api_url);
 
-				// then call uploadJobLog again to store it (this also deletes the file)
-				self.uploadJobLog(job);
-			} // http success
-		}); // request.get
+			job.log_file = path.join(temp_dir, job.id + (detached ? '-detached' : '') + '.log');
+			var flags = fs.constants.O_RDWR | fs.constants.O_CREAT | fs.constants.O_EXCL;
+			if (typeof fs.constants.O_NOFOLLOW == 'number') flags |= fs.constants.O_NOFOLLOW;
+
+			fs.open(job.log_file, flags, 0o600, function (err, fd) {
+				if (err) {
+					release_fetch();
+					fs.rmdir(temp_dir, function () {;});
+					return self.logError('file', "Failed to create private job-log download file: " + err);
+				}
+
+				fs.fstat(fd, function (err, opened) {
+					if (err || !opened.isFile() || (opened.nlink != 1)) {
+						release_fetch();
+						return fs.close(fd, function () {
+							fs.unlink(job.log_file, function () { fs.rmdir(temp_dir, function () {;}); });
+						});
+					}
+
+					// Keep this exact O_EXCL descriptor from the first response byte through
+					// gzip/storage.  A small descriptor-backed Writable deliberately has no
+					// path-open or fd-close behavior of its own.
+					var descriptor = self.createJobLogDescriptorOwner(fd);
+					var download_offset = 0;
+					var download = new Writable({
+						write: function (chunk, encoding, done) {
+							var buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+							var buffer_offset = 0;
+							var write_next = function () {
+								descriptor.write(buffer, buffer_offset, buffer.length - buffer_offset, download_offset, function (err, bytes_written) {
+									if (err) return done(err);
+									if (!bytes_written) return done(new Error("Failed to write fetched job log"));
+									buffer_offset += bytes_written;
+									download_offset += bytes_written;
+									if (buffer_offset < buffer.length) return write_next();
+									done();
+								});
+							};
+							write_next();
+						}
+					});
+					download.path = job.log_file;
+					var protocol_ok = false;
+					var expected_size = null;
+					var close_fd = function (callback) {
+						descriptor.close(function () { callback(); });
+					};
+					var cleanup_temp = function () {
+						release_fetch();
+						if (!download.destroyed) download.destroy();
+						close_fd(function () {
+							fs.unlink(job.log_file, function () {
+								fs.rmdir(temp_dir, function () {;});
+							});
+						});
+					};
+
+					self.request.get(api_url, {
+						download: download,
+						headers: { 'Accept-Encoding': 'identity' },
+						preflight: function (err, resp, stream) {
+							var length_header = resp && resp.headers && resp.headers['content-length'];
+							var valid_length = (typeof length_header == 'string') && /^\d+$/.test(length_header);
+							expected_size = valid_length ? Number(length_header) : null;
+							valid_length = valid_length && Number.isSafeInteger(expected_size) && (expected_size >= 0);
+							protocol_ok = !err && resp && (resp.statusCode == 200) && resp.headers &&
+								(resp.headers['x-cronicle-job-log-protocol'] == '2') && valid_length &&
+								/^text\/plain\b/i.test(resp.headers['content-type'] || '');
+							if (!protocol_ok) {
+								self.abortJobLogHTTPResponse(resp, stream, "Incompatible job-log transfer response");
+								return false;
+							}
+							resp.pipe(stream);
+						}
+					}, function (err) {
+						if (err) {
+							self.logError('job', "Failed to fetch job log file from " + worker.hostname + " for job " + job.id + ": " + err);
+							return cleanup_temp();
+						}
+						if (!protocol_ok) {
+							self.logError('job', "Worker returned an incompatible job-log transfer response for job " + job.id);
+							return cleanup_temp();
+						}
+						if (download_offset != expected_size) {
+							self.logError('job', "Worker returned an incomplete job log for " + job.id +
+								": expected " + expected_size + " bytes, received " + download_offset);
+							return cleanup_temp();
+						}
+
+						self.logDebug(5, "Job log was fetched successfully", { id: job.id, hostname: worker.hostname });
+						self.storeJobLogFromDescriptor(job, descriptor, function (upload_err) {
+							if (upload_err) {
+								release_fetch();
+								return close_fd(function () {
+									self.logError('storage', "Retaining fetched job log after upload failure: " + job.log_file);
+								});
+							}
+
+							close_fd(function () {
+								fs.lstat(job.log_file, function (err, current) {
+									if (err || !current.isFile() || (current.nlink != 1) || !self.sameFileIdentity(opened, current)) {
+										return self.logError('file', "Retaining replaced fetched job log: " + job.log_file);
+									}
+									fs.unlink(job.log_file, function () {
+										fs.rmdir(temp_dir, function () {;});
+									});
+								});
+							});
+						});
+					}); // request.get
+				}); // fstat
+			}); // open
+		}); // mkdtemp
 	},
 
-	finishJob: function (job) {
+	finishJob: function (job, source_worker) {
 		// finish cleaning up job
 		var self = this;
+		if (source_worker) {
+			job = this.bindRemoteFinishedJob(job, source_worker);
+			if (!job) {
+				this.logError('job', "Refusing finished job not assigned to source worker");
+				return false;
+			}
+		}
 
 		if (!job.time_end) job.time_end = Tools.timeNow();
 		job.elapsed = Math.max(0, job.time_end - job.time_start);
@@ -1873,6 +2245,7 @@ module.exports = Class.create({
 		if (worker && worker.active_jobs && worker.active_jobs[job.id]) {
 			delete worker.active_jobs[job.id];
 		}
+		if (this.remoteLogFetchJobs) delete this.remoteLogFetchJobs[job.id];
 
 		// just in case job was in limbo, we can remove it now
 		delete this.deadJobs[job.id];
@@ -2303,7 +2676,7 @@ module.exports = Class.create({
 		}
 
 		// prepare to log watch
-		var log_file = job.log_file;
+		var log_file = this.getJobLogFilePath(job.id, job.detached);
 		var log_fd = null;
 		var log_stats = null;
 		var log_chunk_size = 32678;
@@ -2336,14 +2709,11 @@ module.exports = Class.create({
 				callback();
 			},
 			function (callback) {
-				fs.open(log_file, 'r', function (err, fd) {
-					if (!err) log_fd = fd;
-					callback(err);
-				});
-			},
-			function (callback) {
-				fs.fstat(log_fd, function (err, stats) {
-					log_stats = stats;
+				self.openJobLogFile(log_file, function (err, fd, stats) {
+					if (!err) {
+						log_fd = fd;
+						log_stats = stats;
+					}
 					callback(err);
 				});
 			},

--- a/lib/test.js
+++ b/lib/test.js
@@ -1738,7 +1738,519 @@ module.exports = {
 				
 			} );
 		},
-		
+
+		function testWorkflowCapabilityScope(test) {
+			var self = this;
+			var parent_id = 'unitwfparent';
+			var skipped_id = 'unitwfskipped';
+			var disabled_id = 'unitwfdisabled';
+			var allowed_id = 'unitwfallowed';
+			var outside_id = 'unitwfoutside';
+			var owned_job_id = 'unitwfowned';
+			var inherited_job_id = 'unitwfinherited';
+			var foreign_job_id = 'unitwfforeign';
+			var remote_worker = 'unit-workflow-worker';
+			var pending_key = 'unit_workflow_pending';
+			var fixture_event_ids = [ skipped_id, disabled_id, allowed_id, outside_id ];
+			var original_secret = server.config.get('secret_key');
+			var signature = Tools.digestHex(parent_id + original_secret, 'MD5');
+			var original_launch = cronicle.launchOrQueueJob;
+			var original_abort = cronicle.abortJob;
+			var original_transaction = cronicle.logTransaction;
+			var captured_launch = null;
+			var captured_abort = null;
+			var captured_transaction = null;
+			var parent = null;
+			var finished = false;
+
+			function clone(value) {
+				return JSON.parse(JSON.stringify(value));
+			}
+
+			function workflowHeaders(custom_signature, custom_id) {
+				return {
+					'x-wf-id': (typeof custom_id == 'undefined') ? parent_id : custom_id,
+					'x-wf-signature': (typeof custom_signature == 'undefined') ? signature : custom_signature
+				};
+			}
+
+			function workflowRequest(action, data, callback, custom_signature, custom_id) {
+				request.json(api_url + '/app/' + action, data || {}, {
+					headers: workflowHeaders(custom_signature, custom_id)
+				}, callback);
+			}
+
+			function workflowRequestPath(path, data, callback) {
+				request.json(api_url + path, data || {}, {
+					headers: workflowHeaders()
+				}, callback);
+			}
+
+			function expectDenied(action, data, message, callback, custom_signature, custom_id) {
+				workflowRequest(action, data, function(err, resp, body) {
+					test.ok(!err, message + " returned an API response");
+					test.ok(resp && resp.statusCode == 200, message + " returned HTTP 200");
+					test.ok(body && body.code != 0, message + " was denied");
+					callback();
+				}, custom_signature, custom_id);
+			}
+
+			function expectDeniedPath(path, data, message, callback) {
+				workflowRequestPath(path, data, function(err, resp, body) {
+					test.ok(!err, message + " returned an API response");
+					test.ok(resp && resp.statusCode == 200, message + " returned HTTP 200");
+					test.ok(body && body.code != 0, message + " was denied");
+					callback();
+				});
+			}
+
+			function installParentActive(value) {
+				cronicle.activeJobs[parent_id] = clone(value || parent);
+			}
+
+			function removeParentLocations() {
+				delete cronicle.activeJobs[parent_id];
+				delete cronicle.internalQueue[pending_key];
+				delete cronicle.workers[remote_worker];
+				delete cronicle.deadJobs[parent_id];
+			}
+
+			function cleanup(callback) {
+				if (finished) return callback();
+				finished = true;
+				server.config.set('secret_key', original_secret);
+				cronicle.launchOrQueueJob = original_launch;
+				cronicle.abortJob = original_abort;
+				cronicle.logTransaction = original_transaction;
+				removeParentLocations();
+				[ owned_job_id, inherited_job_id, foreign_job_id ].forEach(function(id) {
+					delete cronicle.activeJobs[id];
+				});
+
+				async.eachSeries(fixture_event_ids, function(id, next) {
+					storage.listFindDelete('global/schedule', { id: id }, function() { next(); });
+				}, function() {
+					async.eachSeries([ owned_job_id, foreign_job_id ], function(id, next) {
+						storage.delete('jobs/' + id, function() { next(); });
+					}, callback);
+				});
+			}
+
+			cronicle.launchOrQueueJob = function(job, callback) {
+				captured_launch = job;
+				callback(null, [ { id: 'unitwflaunched', event: job.id } ]);
+			};
+			cronicle.abortJob = function(stub) {
+				captured_abort = stub;
+				return true;
+			};
+			cronicle.logTransaction = function(action, item, data) {
+				if (action == 'job_run') captured_transaction = data;
+				return original_transaction.apply(cronicle, arguments);
+			};
+
+			async.series([
+				function setupFixtures(callback) {
+					storage.listFind('global/schedule', { id: self.event_id }, function(err, event) {
+						test.ok(!err && !!event, "Workflow test loaded an event template");
+						if (err || !event) return callback(err || new Error('Missing event template'));
+
+						var events = fixture_event_ids.map(function(id) {
+							var item = clone(event);
+							item.id = id;
+							item.title = 'Workflow fixture ' + id;
+							item.category = 'general';
+							item.target = 'maingrp';
+							item.params = { duration: '1', secret: 'must-not-leak' };
+							return item;
+						});
+
+						async.eachSeries(events, function(item, next) {
+							storage.listPush('global/schedule', item, next);
+						}, function(err) {
+							if (err) return callback(err);
+
+							parent = {
+								id: parent_id,
+								hostname: server.hostname,
+								plugin: 'workflow',
+								category: 'workflow_parent_category',
+								target: 'workflow_parent_target',
+								workflow: [
+									{ id: skipped_id },
+									{ id: disabled_id, disabled: 1 },
+									{ id: allowed_id }
+								],
+								options: { wf_start_from_step: 2 }
+							};
+
+							cronicle.activeJobs[owned_job_id] = {
+								id: owned_job_id,
+								hostname: server.hostname,
+								event: allowed_id,
+								category: 'general',
+								target: 'maingrp',
+								source_id: parent_id,
+								when: Tools.timeNow(true) + 30,
+								retries: 2,
+								params: { secret: 'active-secret' }
+							};
+							cronicle.activeJobs[foreign_job_id] = {
+								id: foreign_job_id,
+								hostname: server.hostname,
+								event: outside_id,
+								category: 'general',
+								target: 'maingrp',
+								source_id: 'anotherworkflow',
+								params: { secret: 'foreign-secret' }
+							};
+
+							var inherited = Object.create({ source_id: parent_id });
+							Object.assign(inherited, {
+								id: inherited_job_id,
+								hostname: server.hostname,
+								event: allowed_id,
+								category: 'general',
+								target: 'maingrp'
+							});
+							cronicle.activeJobs[inherited_job_id] = inherited;
+
+							async.series([
+								function(next) {
+									storage.put('jobs/' + owned_job_id, {
+										id: owned_job_id,
+										event: allowed_id,
+										source_id: parent_id,
+										category: 'general',
+										target: 'maingrp',
+										code: 0,
+										description: 'owned complete',
+										elapsed: 1.25,
+										memo: 'owned memo',
+										secret: 'completed-secret',
+										params: { secret: 'completed-param-secret' }
+									}, next);
+								},
+								function(next) {
+									storage.put('jobs/' + foreign_job_id, {
+										id: foreign_job_id,
+										event: outside_id,
+										source_id: 'anotherworkflow',
+										category: 'general',
+										target: 'maingrp',
+										code: 1,
+										description: 'foreign complete',
+										secret: 'foreign-completed-secret'
+									}, next);
+								}
+							], callback);
+						});
+					});
+				},
+				function helperAndPrototypeChecks(callback) {
+					test.ok(signature == cronicle.getWorkflowSignature(parent_id), "Workflow signature kept the legacy wire format");
+					test.ok(signature.length == 32, "Workflow signature remained 32 hexadecimal characters");
+					test.ok(!cronicle.workflowSignatureMatches(parent_id, signature.substring(1)), "Short signature failed closed without throwing");
+
+					var event_map = cronicle.getWorkflowEventMap(parent);
+					test.ok(!Object.prototype.hasOwnProperty.call(event_map, skipped_id), "Start-step excluded an earlier child");
+					test.ok(!Object.prototype.hasOwnProperty.call(event_map, disabled_id), "Disabled child was excluded");
+					test.ok(Object.prototype.hasOwnProperty.call(event_map, allowed_id), "Later cross-scope child was allowed");
+
+					var invalid_start = clone(parent);
+					invalid_start.options.wf_start_from_step = 'not-a-number';
+					test.ok(Object.keys(cronicle.getWorkflowEventMap(invalid_start)).length == 0, "NaN start-step allowed no child");
+					invalid_start.options.wf_start_from_step = Infinity;
+					test.ok(Object.keys(cronicle.getWorkflowEventMap(invalid_start)).length == 0, "Infinite start-step allowed no child");
+					invalid_start.options.wf_start_from_step = Symbol('invalid-start');
+					test.ok(Object.keys(cronicle.getWorkflowEventMap(invalid_start)).length == 0, "Throwing start-step coercion failed closed");
+
+					var sparse = new Array(1);
+					Object.defineProperty(Array.prototype, '0', {
+						value: { id: outside_id }, enumerable: true, configurable: true
+					});
+					try {
+						test.ok(Object.keys(cronicle.getWorkflowEventMap({ workflow: sparse })).length == 0, "Inherited sparse-array step was ignored");
+					}
+					finally { delete Array.prototype[0]; }
+
+					var inherited_disabled = Object.create({ disabled: true });
+					inherited_disabled.id = allowed_id;
+					test.ok(Object.keys(cronicle.getWorkflowEventMap({ workflow: [ inherited_disabled ] })).length == 0, "Inherited truthy disabled flag failed closed");
+
+					var inherited_options = Object.create({ wf_start_from_step: Infinity });
+					test.ok(Object.keys(cronicle.getWorkflowEventMap({ workflow: [ { id: allowed_id } ], options: inherited_options })).length == 0, "Inherited invalid start-step failed closed");
+
+					var inherited_workflow = Object.create({ workflow: [ { id: outside_id } ] });
+					inherited_workflow.id = parent_id;
+					inherited_workflow.plugin = 'workflow';
+					test.ok(Object.keys(cronicle.getWorkflowEventMap(inherited_workflow)).length == 0, "Inherited workflow snapshot was ignored");
+
+					Object.defineProperty(Object.prototype, parent_id, {
+						value: clone(parent), enumerable: true, configurable: true
+					});
+					try {
+						test.ok(!cronicle.findJob(parent_id), "Inherited parent hash entry was not treated as a job");
+						test.ok(!cronicle.getWorkflowCapability(parent_id, signature), "Inherited parent could not mint a workflow capability");
+					}
+					finally { delete Object.prototype[parent_id]; }
+
+					var inherited_id_job = Object.create({ id: parent_id });
+					inherited_id_job.plugin = 'workflow';
+					cronicle.activeJobs.unitwfinheritedid = inherited_id_job;
+					test.ok(!cronicle.findJob(parent_id), "Inherited job id was not selected");
+					delete cronicle.activeJobs.unitwfinheritedid;
+
+					var inherited_action_job = Object.create({ action: 'launchLocalJob' });
+					Object.assign(inherited_action_job, clone(parent));
+					cronicle.internalQueue.unitwfinheritedaction = inherited_action_job;
+					test.ok(!cronicle.findJob(parent_id), "Inherited pending action was not selected");
+					delete cronicle.internalQueue.unitwfinheritedaction;
+					test.ok(!cronicle.findJob('__proto__'), "Prototype-control job id was rejected");
+
+					var raw_args = {
+						request: { headers: workflowHeaders(), url: '/api/app/run_event' }
+					};
+					cronicle.captureWorkflowAuthHeaders(raw_args);
+					test.ok(!Object.prototype.hasOwnProperty.call(raw_args.request.headers, 'x-wf-signature'), "Workflow signature was removed before API logging");
+					test.ok(raw_args._workflow_auth && raw_args._workflow_auth.signature == signature, "Workflow signature remained request-local");
+					test.ok(JSON.stringify(raw_args).indexOf(signature) < 0, "Request-local workflow bearer was non-enumerable");
+					callback();
+				},
+				function rejectInvalidAndUntrustedParents(callback) {
+					installParentActive();
+					async.series([
+						function(next) {
+							Object.defineProperties(Object.prototype, {
+								'_workflow_auth': {
+									value: { id: parent_id, signature: signature }, configurable: true
+								},
+								'x-wf-id': { value: parent_id, configurable: true },
+								'x-wf-signature': { value: signature, configurable: true }
+							});
+							cronicle.loadSession({
+								cookies: {}, params: {}, query: {},
+								request: { headers: {}, url: '/api/app/run_event' }
+							}, function(err) {
+								delete Object.prototype._workflow_auth;
+								delete Object.prototype['x-wf-id'];
+								delete Object.prototype['x-wf-signature'];
+								test.ok(!!err, "Inherited workflow authentication material was ignored");
+								next();
+							});
+						},
+						function(next) {
+							expectDenied('run_event', { id: allowed_id }, "Wrong workflow signature", next, 'short');
+						},
+						function(next) {
+							cronicle.activeJobs[parent_id].plugin = 'testplug';
+							expectDenied('run_event', { id: allowed_id }, "Non-workflow parent", function() {
+								cronicle.activeJobs[parent_id].plugin = 'workflow';
+								next();
+							});
+						}
+					], callback);
+				},
+				function enforceWorkflowChildScope(callback) {
+					async.eachSeries([
+						{ data: { id: skipped_id }, name: 'Start-step-skipped child' },
+						{ data: { id: disabled_id }, name: 'Disabled child' },
+						{ data: { id: outside_id }, name: 'Unlisted child' },
+						{ data: { title: 'Workflow fixture ' + allowed_id }, name: 'Title-only child lookup' }
+					], function(entry, next) {
+						expectDenied('run_event', entry.data, entry.name, next);
+					}, callback);
+				},
+				function allowOnlyRuntimeInputs(callback) {
+					captured_launch = null;
+					captured_transaction = null;
+					var allowed_now = Tools.timeNow(true) - 10;
+					workflowRequest('run_event', {
+						id: allowed_id,
+						now: allowed_now,
+						arg: 'allowed-arg',
+						args: 'allowed-args',
+						post_data: { allowed: true },
+						plugin: 'attacker_plugin',
+						target: 'attacker_target',
+						params: { secret: 'attacker-secret' },
+						workflow: [ { id: outside_id } ],
+						source: 'attacker-source',
+						source_id: 'attacker-parent',
+						api_key: signature
+					}, function(err, resp, body) {
+						test.ok(!err && body && body.code == 0, "Allowed workflow child launched");
+						test.ok(captured_launch && captured_launch.id == allowed_id, "Workflow launched the allowlisted event");
+						test.ok(captured_launch && captured_launch.source_id == parent_id, "Child provenance was server-bound to the workflow");
+						test.ok(captured_launch && captured_launch.source == 'Workflow (' + parent_id + ')', "Child source was server-derived");
+						test.ok(captured_launch && !Object.prototype.hasOwnProperty.call(captured_launch, 'api_key'), "Workflow bearer was not persisted on the child");
+						test.ok(captured_launch && captured_launch.plugin != 'attacker_plugin', "Workflow could not replace the child plugin");
+						test.ok(captured_launch && captured_launch.target != 'attacker_target', "Workflow could not replace the child target");
+						test.ok(captured_launch && captured_launch.params && captured_launch.params.secret == 'must-not-leak', "Stored child parameters replaced caller parameters");
+						test.ok(captured_launch && captured_launch.now == allowed_now, "Workflow retained the allowed now input");
+						test.ok(captured_launch && captured_launch.arg == 'allowed-arg', "Workflow retained the allowed arg input");
+						test.ok(captured_launch && captured_launch.args == 'allowed-args', "Workflow retained the allowed args input");
+						test.ok(captured_launch && captured_launch.post_data && captured_launch.post_data.allowed, "Workflow retained the allowed POST input");
+						test.ok(captured_transaction && captured_transaction.headers &&
+							!Object.prototype.hasOwnProperty.call(captured_transaction.headers, 'x-wf-signature'),
+							"Workflow bearer was absent from transaction metadata");
+						callback();
+					});
+				},
+				function projectWorkflowReads(callback) {
+					async.series([
+						function(next) {
+							workflowRequest('get_schedule', {}, function(err, resp, body) {
+								test.ok(!err && body && body.code == 0, "Workflow read its scoped schedule");
+								test.ok(body.rows && body.rows.length == 1 && body.rows[0].id == allowed_id, "Scoped schedule contained only the runnable child");
+								test.ok(body.rows && Object.keys(body.rows[0]).sort().join(',') == 'id,title', "Scoped schedule returned only id and title");
+								next();
+							});
+						},
+						function(next) {
+							var active_jobs_prototype = Object.getPrototypeOf(cronicle.activeJobs);
+							Object.setPrototypeOf(cronicle.activeJobs, {
+								unitwfprototypechild: {
+									id: 'unitwfprototypechild', event: allowed_id,
+									source_id: parent_id, params: { secret: 'prototype-secret' }
+								}
+							});
+							workflowRequest('get_active_jobs', {}, function(err, resp, body) {
+								Object.setPrototypeOf(cronicle.activeJobs, active_jobs_prototype);
+								test.ok(!err && body && body.code == 0, "Workflow read its scoped active jobs");
+								test.ok(body.jobs && body.jobs[owned_job_id] && !body.jobs[foreign_job_id], "Active projection contained only an owned child");
+								test.ok(body.jobs && !body.jobs.unitwfprototypechild, "Inherited active-job entry was ignored");
+								test.ok(body.jobs && !body.jobs[owned_job_id].params && !body.jobs[owned_job_id].category, "Active projection omitted private job fields");
+								next();
+							});
+						},
+						function(next) {
+							workflowRequest('get_job_details', { id: owned_job_id }, function(err, resp, body) {
+								test.ok(!err && body && body.code == 0, "Workflow read an owned completed child");
+								test.ok(body.job && body.job.memo == 'owned memo', "Completed projection retained workflow status fields");
+								test.ok(body.job && !body.job.secret && !body.job.params && !body.job.category, "Completed projection omitted private fields");
+								next();
+							});
+						},
+						function(next) {
+							expectDenied('get_job_details', { id: foreign_job_id }, "Foreign completed job read", next);
+						}
+					], callback);
+				},
+				function denyRoutesAndForeignAborts(callback) {
+					captured_abort = null;
+					async.series([
+						function(next) { expectDenied('get_event', { id: allowed_id }, "Non-capability API", next); },
+						function(next) { expectDenied('flush_event_queue', { id: allowed_id }, "Workflow queue flush", next); },
+						function(next) { expectDenied('abort_jobs', { event: allowed_id }, "Workflow bulk abort", next); },
+						function(next) { expectDenied('abort_job', { id: foreign_job_id }, "Foreign workflow child abort", next); },
+						function(next) { expectDenied('abort_job', { id: inherited_job_id }, "Inherited source-id child abort", next); },
+						function(next) {
+							workflowRequest('abort_job', { id: owned_job_id }, function(err, resp, body) {
+								test.ok(!err && body && body.code == 0, "Workflow aborted its owned child");
+								test.ok(captured_abort && captured_abort.id == owned_job_id, "Abort reached only the owned child");
+								next();
+							});
+						}
+					], callback);
+				},
+				function rejectPathConfusion(callback) {
+					var allowed_actions = [
+						'get_schedule', 'get_active_jobs', 'run_event', 'get_job_details', 'abort_job'
+					];
+					var cases = [];
+					allowed_actions.forEach(function(action) {
+						cases.push({
+							path: '/app/get_event/path-confusion/app/' + action,
+							name: 'Denied handler with allowed route suffix ' + action
+						});
+						cases.push({
+							path: '/app/' + action + '/extra-path',
+							name: 'Allowed handler with non-canonical trailing path ' + action
+						});
+					});
+					cases.push({ path: '/app//get_schedule', name: 'Malformed empty action path' });
+					cases.push({ path: '/app/get-schedule', name: 'Malformed non-router action path' });
+
+					async.eachSeries(cases, function(entry, next) {
+						expectDeniedPath(entry.path, { id: allowed_id }, entry.name, next);
+					}, callback);
+				},
+				function reconstructPendingAndRemoteParents(callback) {
+					removeParentLocations();
+					cronicle.internalQueue[pending_key] = Object.assign({
+						action: 'launchLocalJob',
+						when: Tools.timeNow(true) + 30
+					}, clone(parent));
+					async.series([
+						function(next) {
+							workflowRequest('run_event', { id: allowed_id }, function(err, resp, body) {
+								test.ok(!err && body && body.code == 0, "Pending/retry parent retained its workflow capability");
+								next();
+							});
+						},
+						function(next) {
+							delete cronicle.internalQueue[pending_key];
+							cronicle.workers[remote_worker] = { active_jobs: {} };
+							cronicle.workers[remote_worker].active_jobs[parent_id] = clone(parent);
+							workflowRequest('run_event', { id: allowed_id }, function(err, resp, body) {
+								test.ok(!err && body && body.code == 0, "Current manager reconstructed the capability from a remote active snapshot");
+								next();
+							});
+						},
+						function(next) {
+							cronicle.workers[remote_worker] = { active_jobs: {}, queue: {} };
+							cronicle.workers[remote_worker].queue[pending_key] = Object.assign({
+								action: 'launchLocalJob',
+								when: Tools.timeNow(true) + 30
+							}, clone(parent));
+							workflowRequest('run_event', { id: allowed_id }, function(err, resp, body) {
+								test.ok(!err && body && body.code == 0, "Current manager reconstructed the capability from a remote pending/retry snapshot");
+								next();
+							});
+						}
+					], callback);
+				},
+				function expireCapabilityWithParent(callback) {
+					removeParentLocations();
+					async.series([
+						function(next) {
+							expectDenied('run_event', { id: allowed_id }, "Expired workflow capability", next);
+						},
+						function(next) {
+							cronicle.deadJobs[parent_id] = clone(parent);
+							expectDenied('run_event', { id: allowed_id }, "Dead-job-only workflow capability", function() {
+								delete cronicle.deadJobs[parent_id];
+								next();
+							});
+						}
+					], callback);
+				},
+				function rotateSecretFailClosed(callback) {
+					installParentActive();
+					server.config.set('secret_key', 'UNIT_TEST_ROTATED_WORKFLOW_SECRET');
+					async.series([
+						function(next) {
+							expectDenied('run_event', { id: allowed_id }, "Pre-rotation workflow signature", next, signature);
+						},
+						function(next) {
+							var rotated = cronicle.getWorkflowSignature(parent_id);
+							workflowRequest('run_event', { id: allowed_id }, function(err, resp, body) {
+								test.ok(!err && body && body.code == 0, "Current-secret workflow signature was accepted");
+								next();
+							}, rotated);
+						}
+					], function(err) {
+						server.config.set('secret_key', original_secret);
+						callback(err);
+					});
+				}
+			], function(err) {
+				test.ok(!err, "Workflow capability regression flow completed");
+				cleanup(function() { test.done(); });
+			});
+		},
+
 		// app/run_event
 		
 		function testAPIRunEvent(test) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -4,6 +4,11 @@
 
 var cp = require('child_process');
 var fs = require('fs');
+var os = require('os');
+var path = require('path');
+var EventEmitter = require('events').EventEmitter;
+var Readable = require('stream').Readable;
+var zlib = require('zlib');
 var async = require('async');
 var moment = require('moment-timezone');
 
@@ -65,6 +70,11 @@ var cronicle = null;
 var request = null;
 var api_url = '';
 var session_id = '';
+var log_auth_sessions = {
+	category_denied: 'unit_log_category_denied',
+	group_denied: 'unit_log_group_denied',
+	allowed: 'unit_log_allowed'
+};
 
 module.exports = {
 	logDebug: function(level, msg, data) {
@@ -249,18 +259,650 @@ module.exports = {
 			test.ok( !cronicle.internalQueue.launch, "Launch abort task was removed from queue" );
 			test.ok( launch_task.abort_reason == 'unit test', "Launch abort task received abort reason" );
 			
-			other_task = { action: 'someOtherAction', id: 'unit-watch-job' };
-			launch_task = { action: 'launchLocalJob', id: 'unit-watch-job', hostname: server.hostname };
+			other_task = { action: 'someOtherAction', id: 'unitwatchjob' };
+			launch_task = { action: 'launchLocalJob', id: 'unitwatchjob', hostname: server.hostname };
 			cronicle.internalQueue = { other: other_task, launch: launch_task };
 			
 			cronicle.watchJobLog(
-				{ id: 'unit-watch-job' },
+				{ id: 'unitwatchjob' },
 				{ id: 'unitSocket', request: { connection: { remoteAddress: '127.0.0.1' } } }
 			);
 			test.ok( other_task.action == 'someOtherAction', "Non-launch watch task action was not mutated" );
+			test.ok(cronicle.getManagerJobLogSnapshot('unitwatchjob') === launch_task, "Manager log authorization found the canonical pending launch task");
+
+			// Existing prototype pollution must not extend the API update allowlist
+			// when updateLocalJob later iterates its stub with `for...in`.
+			launch_task.log_file = 'ORIGINAL-PENDING-LOG';
+			Object.defineProperty(Object.prototype, 'log_file', {
+				value: 'POLLUTED-PROTOTYPE-LOG', enumerable: true, configurable: true, writable: true
+			});
+			try {
+				var clean_updates = cronicle.getMutableJobUpdates({ notify_fail: 'safe@example.invalid' }, function () {});
+				var safe_stub = cronicle.buildMutableJobStub('unitwatchjob', clean_updates);
+				cronicle.updateLocalJob(safe_stub);
+				test.ok(Object.getPrototypeOf(clean_updates) === null, "Sanitized updates have no polluted prototype");
+				test.ok(Object.getPrototypeOf(safe_stub) === null, "Job update stub has no polluted prototype");
+				test.ok(launch_task.log_file == 'ORIGINAL-PENDING-LOG', "Inherited protected field did not mutate pending job");
+				test.ok(launch_task.notify_fail == 'safe@example.invalid', "Own allowlisted field still updated pending job");
+			}
+			finally {
+				delete Object.prototype.log_file;
+			}
+
+			var protected_manager_update = cronicle.updateLocalJobFromManager({
+				id: 'unitwatchjob',
+				log_file: 'FORGED-MANAGER-LOG'
+			});
+			test.ok(!protected_manager_update, "Worker rejected a protected field from a legacy manager update");
+			test.ok(launch_task.log_file == 'ORIGINAL-PENDING-LOG', "Legacy manager could not mutate the worker log path");
+			var allowed_manager_update = cronicle.updateLocalJobFromManager({
+				id: 'unitwatchjob',
+				suspended: true
+			});
+			test.ok(!!allowed_manager_update, "Worker accepted an allowlisted field from its manager");
+			test.ok(launch_task.suspended === true, "Allowlisted manager update reached the pending job");
+
+			// A locally polluted prototype must not supply the job identity for a
+			// manager update that omitted its own id field.
+			Object.defineProperty(Object.prototype, 'id', {
+				value: 'unitwatchjob', enumerable: true, configurable: true, writable: true
+			});
+			try {
+				var inherited_id_update = cronicle.updateLocalJobFromManager({
+					notify_fail: 'polluted-id@example.invalid'
+				});
+				test.ok(!inherited_id_update, "Worker rejected an update with only an inherited job ID");
+				test.ok(launch_task.notify_fail == 'safe@example.invalid', "Inherited job ID could not select and mutate a pending job");
+			}
+			finally {
+				delete Object.prototype.id;
+			}
+
+			var array_id_update = cronicle.updateLocalJobFromManager({
+				id: [ 'unitwatchjob' ],
+				notify_success: 'array-id@example.invalid'
+			});
+			test.ok(!array_id_update, "Worker rejected a coerced array job ID");
+			test.ok(!launch_task.notify_success, "Array job ID could not select and mutate a pending job");
+
+			var proto_had_suspended = Object.prototype.hasOwnProperty.call(Object.prototype, 'suspended');
+			var proto_suspended = Object.prototype.suspended;
+			try {
+				var magic_id_update = cronicle.updateLocalJobFromManager({
+					id: '__proto__',
+					suspended: false
+				});
+				test.ok(!magic_id_update, "Worker rejected the __proto__ job ID");
+				test.ok(
+					(Object.prototype.hasOwnProperty.call(Object.prototype, 'suspended') === proto_had_suspended) &&
+					(Object.prototype.suspended === proto_suspended),
+					"Magic job ID did not mutate Object.prototype"
+				);
+				test.ok(!cronicle.updateLocalJob({ id: '__proto__', suspended: false }), "Local job lookup rejected an inherited prototype target");
+				test.ok(
+					(Object.prototype.hasOwnProperty.call(Object.prototype, 'suspended') === proto_had_suspended) &&
+					(Object.prototype.suspended === proto_suspended),
+					"Direct local lookup did not mutate Object.prototype"
+				);
+			}
+			finally {
+				if (proto_had_suspended) Object.prototype.suspended = proto_suspended;
+				else delete Object.prototype.suspended;
+			}
 			
 			cronicle.internalQueue = old_queue;
 			test.done();
+		},
+
+		function testJobLogTransferBoundary(test) {
+			var outside_log = path.join(os.tmpdir(), 'cronicle-edge-unit-outside-' + process.pid + '.log');
+			var traversal_id = '../cronicle-edge-unit-outside-' + process.pid;
+			var symlink_id = 'unitfetchsymlink';
+			var hardlink_id = 'unitfetchhardlink';
+			var legacy_id = 'unitfetchlegacy';
+			var valid_id = 'unitfetchvalid';
+			var empty_id = 'unitfetchempty';
+			var symlink_log = cronicle.getJobLogFilePath(symlink_id, false);
+			var hardlink_log = cronicle.getJobLogFilePath(hardlink_id, false);
+			var hardlink_copy = hardlink_log + '.copy';
+			var legacy_log = cronicle.getJobLogFilePath(legacy_id, false);
+			var valid_log = cronicle.getJobLogFilePath(valid_id, false);
+			var empty_log = cronicle.getJobLogFilePath(empty_id, false);
+
+			[ outside_log, symlink_log, hardlink_log, hardlink_copy, legacy_log, valid_log, empty_log ].forEach(function (file) {
+				try { fs.unlinkSync(file); }
+				catch (err) { if (err.code != 'ENOENT') throw err; }
+			});
+			fs.writeFileSync(outside_log, 'OUTSIDE SECRET');
+
+			var original_request_get = cronicle.request.get;
+			var fetch_calls = [];
+			var source_worker = {
+				hostname: 'real-worker.example',
+				ip: '127.0.0.1',
+				active_jobs: {
+					unitsourcebinding: { id: 'unitsourcebinding', hostname: 'real-worker.example', detached: 0 },
+					unitunknownsource: { id: 'unitunknownsource', hostname: 'real-worker.example', detached: 0 }
+				}
+			};
+			cronicle.remoteLogFetchJobs.unitsourcebinding = {
+				id: 'unitsourcebinding',
+				hostname: 'real-worker.example',
+				detached: 0,
+				category: 'general',
+				target: 'maingrp'
+			};
+			cronicle.request.get = function () { fetch_calls.push(true); };
+			cronicle.fetchStoreJobLog({
+				id: 'unitsourcebinding',
+				hostname: 'forged-worker.example',
+				log_file: outside_log
+			}, source_worker);
+			test.ok(fetch_calls.length == 0, "Worker payload cannot redirect a fetch to another host");
+			cronicle.fetchStoreJobLog({
+				id: 'unitunknownsource',
+				hostname: 'real-worker.example'
+			}, source_worker);
+			test.ok(fetch_calls.length == 0, "Worker cannot choose an ID absent from the manager snapshot");
+			cronicle.request.get = original_request_get;
+
+			cronicle.remoteLogFetchJobs.unitfinishbinding = {
+				id: 'unitfinishbinding',
+				hostname: 'real-worker.example',
+				detached: 1,
+				category: 'manager-category',
+				target: 'manager-group',
+				event: 'manager-event',
+				event_title: 'Manager Event',
+				plugin: 'manager-plugin'
+			};
+			var bound_finished_job = cronicle.bindRemoteFinishedJob({
+				id: 'unitfinishbinding',
+				hostname: 'real-worker.example',
+				detached: 0,
+				category: 'forged-category',
+				target: 'forged-group',
+				event: 'forged-event',
+				event_title: 'Forged Event',
+				plugin: 'forged-plugin',
+				code: 7,
+				description: 'worker result'
+			}, source_worker);
+			test.ok(!!bound_finished_job, "Assigned worker completion was accepted");
+			test.ok(bound_finished_job.hostname == 'real-worker.example', "Completion hostname came from the manager snapshot");
+			test.ok(bound_finished_job.detached == 1, "Completion detached mode came from the manager snapshot");
+			test.ok(bound_finished_job.category == 'manager-category', "Completion category came from the manager snapshot");
+			test.ok(bound_finished_job.target == 'manager-group', "Completion group came from the manager snapshot");
+			test.ok(bound_finished_job.event == 'manager-event', "Completion event came from the manager snapshot");
+			test.ok(bound_finished_job.event_title == 'Manager Event', "Completion title came from the manager snapshot");
+			test.ok(bound_finished_job.plugin == 'manager-plugin', "Completion plugin came from the manager snapshot");
+			test.ok((bound_finished_job.code == 7) && (bound_finished_job.description == 'worker result'), "Worker result fields were retained");
+			test.ok(!cronicle.bindRemoteFinishedJob({ id: 'unitfinishbinding' }, {
+				hostname: 'different-worker.example'
+			}), "A different worker could not finish the assigned job");
+			delete cronicle.remoteLogFetchJobs.unitfinishbinding;
+
+			async.series([
+				function (callback) {
+					// Descriptor close must wait for delayed read and write callbacks on
+					// protocol/storage error paths.
+					var events = [];
+					var fake_io = {
+						read: function (fd, buffer, offset, length, position, done) {
+							setTimeout(function () {
+								buffer.write('R', offset);
+								events.push('read');
+								done(null, 1, buffer);
+							}, 30);
+						},
+						write: function (fd, buffer, offset, length, position, done) {
+							setTimeout(function () {
+								events.push('write');
+								done(null, length, buffer);
+							}, 20);
+						},
+						close: function (fd, done) {
+							events.push('close');
+							done();
+						}
+					};
+					var owner = cronicle.createJobLogDescriptorOwner(123, fake_io);
+					owner.read(Buffer.alloc(1), 0, 1, 0, function (err) { test.ok(!err, "Delayed descriptor read completed"); });
+					owner.write(Buffer.from('W'), 0, 1, 0, function (err) { test.ok(!err, "Delayed descriptor write completed"); });
+					owner.close(function (err) {
+						test.ok(!err, "Descriptor owner closed without error");
+						test.ok(events.indexOf('close') > events.indexOf('read'), "Descriptor close waited for pending read");
+						test.ok(events.indexOf('close') > events.indexOf('write'), "Descriptor close waited for pending write");
+						callback();
+					});
+					test.ok(events.indexOf('close') < 0, "Descriptor did not close synchronously over pending I/O");
+				},
+				function (callback) {
+					var original_delete = cronicle.deleteJobLogIfUnchanged;
+					var delete_calls = 0;
+					cronicle.deleteJobLogIfUnchanged = function () { delete_calls++; };
+					var failed_response = new EventEmitter();
+					var failed_source = new EventEmitter();
+					cronicle.deleteJobLogAfterCompleteTransfer(failed_response, failed_source, 'failed.log', {});
+					failed_response.emit('finish');
+					failed_source.emit('error', new Error('deliberate read failure'));
+					test.ok(delete_calls == 0, "Response finish after source error did not delete worker log");
+
+					var good_response = new EventEmitter();
+					var good_source = new EventEmitter();
+					cronicle.deleteJobLogAfterCompleteTransfer(good_response, good_source, 'good.log', {});
+					good_source.emit('end');
+					test.ok(delete_calls == 0, "Clean source EOF alone did not delete before response finish");
+					good_response.emit('finish');
+					test.ok(delete_calls == 1, "Clean source EOF plus response finish deleted exactly once");
+
+					var short_response = new EventEmitter();
+					var short_source = new EventEmitter();
+					short_source.jobLogComplete = false;
+					short_source.jobLogBytesRead = 4;
+					cronicle.deleteJobLogAfterCompleteTransfer(short_response, short_source, 'short.log', {}, 10);
+					short_source.emit('end');
+					short_response.emit('finish');
+					test.ok(delete_calls == 1, "Clean EOF shorter than the committed size preserved the worker log");
+					cronicle.deleteJobLogIfUnchanged = original_delete;
+					callback();
+				},
+				function (callback) {
+					// A disconnected HTTP client must destroy a paused source and close
+					// its held descriptor after any pending positional read, without
+					// deleting the worker log.
+					var original_delete = cronicle.deleteJobLogIfUnchanged;
+					var delete_calls = 0;
+					var events = [];
+					cronicle.deleteJobLogIfUnchanged = function () { delete_calls++; };
+					var fake_io = {
+						read: function (fd, buffer, offset, length, position, done) {
+							setTimeout(function () {
+								buffer.write('R', offset);
+								events.push('read');
+								done(null, 1, buffer);
+							}, 20);
+						},
+						close: function (fd, done) {
+							events.push('close');
+							test.ok(events.indexOf('close') > events.indexOf('read'), "Aborted transfer waited for pending descriptor read");
+							test.ok(delete_calls == 0, "Aborted transfer preserved the worker log");
+							cronicle.deleteJobLogIfUnchanged = original_delete;
+							done();
+							callback();
+						}
+					};
+					var owner = cronicle.createJobLogDescriptorOwner(456, fake_io);
+					var source = cronicle.createJobLogDescriptorStream(owner, 1024);
+					var close_descriptor = function () { owner.close(function () {}); };
+					source.once('end', close_descriptor);
+					source.once('error', close_descriptor);
+					source.once('close', close_descriptor);
+					var response = new EventEmitter();
+					cronicle.deleteJobLogAfterCompleteTransfer(response, source, 'aborted.log', {}, 1024);
+					source.read(1);
+					response.emit('close');
+					test.ok(source.destroyed, "Response close destroyed the paused source stream");
+					test.ok(events.indexOf('close') < 0, "Descriptor remained open while its read was pending");
+				},
+				function (callback) {
+					var original_upload = cronicle.uploadJobLog;
+					var upload_calls = 0;
+					cronicle.uploadJobLog = function () { upload_calls++; };
+					cronicle.request.get = function (url, options, request_callback) {
+						fetch_calls.push({ url: url, options: options });
+						cronicle.request.get = original_request_get;
+						var private_dir = path.dirname(options.download.path);
+						test.ok(url.indexOf('path=') < 0, "Manager protocol has no path parameter");
+						test.ok((url.indexOf(outside_log) < 0) && (url.indexOf(encodeURIComponent(outside_log)) < 0), "Manager did not forward worker-supplied log_file");
+						test.ok(path.basename(options.download.path) == 'unitsourcebinding.log', "Manager tied the temporary filename to the known job ID");
+						test.ok((fs.statSync(private_dir).mode & 0o777) == 0o700, "Manager download directory is private");
+						var response_aborted = false;
+						var response = {
+							statusCode: 200,
+							headers: { 'content-type': 'application/json' },
+							destroy: function () { response_aborted = true; this.destroyed = true; }
+						};
+						var accepted = options.preflight(null, response, options.download);
+						test.ok(accepted === false, "Manager rejected HTTP 200 without the transfer protocol header");
+						test.ok(response_aborted, "Manager aborted incompatible response instead of buffering its body");
+						request_callback(null, response, Buffer.from('{"code":"api"}'));
+						setTimeout(function () {
+							test.ok(upload_calls == 0, "Incompatible HTTP 200 body was not uploaded as a job log");
+							test.ok(!fs.existsSync(private_dir), "Rejected manager download was cleaned from the private directory");
+							cronicle.uploadJobLog = original_upload;
+							callback();
+						}, 50);
+					};
+					cronicle.fetchStoreJobLog({
+						id: 'unitsourcebinding',
+						hostname: 'real-worker.example',
+						log_file: outside_log
+					}, source_worker);
+				},
+				function (callback) {
+					// A protocol-valid 200 response is not sufficient: storage must only
+					// begin after the downloaded bytes exactly match Content-Length.
+					cronicle.remoteLogFetchJobs.unitsourcebinding = {
+						id: 'unitsourcebinding',
+						hostname: 'real-worker.example',
+						detached: 0,
+						category: 'general',
+						target: 'maingrp'
+					};
+					var original_descriptor_store = cronicle.storeJobLogFromDescriptor;
+					var store_calls = 0;
+					var private_dir = '';
+					cronicle.storeJobLogFromDescriptor = function () { store_calls++; };
+					cronicle.request.get = function (url, options, request_callback) {
+						cronicle.request.get = original_request_get;
+						private_dir = path.dirname(options.download.path);
+						var response = Readable.from([ 'SHORT' ]);
+						response.statusCode = 200;
+						response.headers = {
+							'content-type': 'text/plain; charset=utf-8',
+							'x-cronicle-job-log-protocol': '2',
+							'content-length': '6'
+						};
+						options.download.once('finish', function () {
+							request_callback(null, response);
+							setTimeout(function () {
+								test.ok(store_calls == 0, "Short manager download was not stored");
+								test.ok(!fs.existsSync(private_dir), "Short manager download was cleaned up");
+								cronicle.storeJobLogFromDescriptor = original_descriptor_store;
+								callback();
+							}, 50);
+						});
+						options.preflight(null, response, options.download);
+					};
+					cronicle.fetchStoreJobLog({
+						id: 'unitsourcebinding',
+						hostname: 'real-worker.example'
+					}, source_worker);
+				},
+				function (callback) {
+					// A same-UID job can discover and replace a manager temp pathname.
+					// Prove the storage upload remains bound to the O_EXCL descriptor.
+					cronicle.remoteLogFetchJobs.unitsourcebinding = {
+						id: 'unitsourcebinding',
+						hostname: 'real-worker.example',
+						detached: 0,
+						category: 'general',
+						target: 'maingrp'
+					};
+					var original_put_stream = cronicle.storage.putStream;
+					var original_descriptor_store = cronicle.storeJobLogFromDescriptor;
+					var original_copy_dir = server.config.get('copy_job_logs_to');
+					var archive_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cronicle-job-archive-'));
+					server.config.set('copy_job_logs_to', archive_dir);
+					var manager_temp_path = '';
+					var held_path = '';
+					var stored_bytes = '';
+					var descriptor_store_done = false;
+					var replacement_skipped = false;
+					cronicle.storeJobLogFromDescriptor = function (job, fd, store_callback) {
+						original_descriptor_store.call(cronicle, job, fd, function (err) {
+							descriptor_store_done = true;
+							store_callback(err);
+						});
+					};
+					cronicle.storage.putStream = function (key, gzip_stream, put_callback) {
+						var chunks = [];
+						test.ok(key == 'jobs/unitsourcebinding/log.txt.gz', "Manager stored the known job ID slot");
+						gzip_stream.on('data', function (chunk) { chunks.push(chunk); });
+						gzip_stream.on('end', function () {
+							zlib.gunzip(Buffer.concat(chunks), function (err, data) {
+								test.ok(!err, "Descriptor-backed manager upload produced valid gzip");
+								stored_bytes = String(data || '');
+								put_callback(err);
+							});
+						});
+					};
+					cronicle.request.get = function (url, options, request_callback) {
+						cronicle.request.get = original_request_get;
+						manager_temp_path = options.download.path;
+						held_path = manager_temp_path + '.held';
+						var response = Readable.from([ 'ORIGINAL MANAGER DOWNLOAD' ]);
+						response.statusCode = 200;
+						response.headers = {
+							'content-type': 'text/plain; charset=utf-8',
+							'x-cronicle-job-log-protocol': '2',
+							'content-length': String(Buffer.byteLength('ORIGINAL MANAGER DOWNLOAD'))
+						};
+						options.download.once('finish', function () {
+							fs.renameSync(manager_temp_path, held_path);
+							try { fs.symlinkSync(outside_log, manager_temp_path); }
+							catch (err) {
+								if ((err.code != 'EPERM') && (err.code != 'EACCES') && (err.code != 'ENOTSUP')) throw err;
+								replacement_skipped = true;
+								test.ok(true, "Manager replacement regression skipped because this platform forbids symlink creation");
+							}
+							request_callback(null, response);
+						});
+						options.preflight(null, response, options.download);
+					};
+					cronicle.fetchStoreJobLog({
+						id: 'unitsourcebinding',
+						hostname: 'real-worker.example',
+						event_title: 'Descriptor Archive',
+						log_file: outside_log
+					}, source_worker);
+
+					var check_upload = function () {
+						var archive_files = fs.readdirSync(archive_dir);
+						if (!stored_bytes || !descriptor_store_done || !archive_files.length) return setTimeout(check_upload, 10);
+						test.ok(stored_bytes == 'ORIGINAL MANAGER DOWNLOAD', "Path replacement could not change manager upload bytes");
+						if (!replacement_skipped) test.ok(stored_bytes.indexOf('OUTSIDE SECRET') < 0, "Manager did not upload replacement symlink contents");
+						test.ok(archive_files.length == 1, "Descriptor-backed manager upload created one optional archive");
+						test.ok(fs.readFileSync(path.join(archive_dir, archive_files[0]), 'utf8') == 'ORIGINAL MANAGER DOWNLOAD', "Optional archive used the same held descriptor bytes");
+						cronicle.storage.putStream = original_put_stream;
+						cronicle.storeJobLogFromDescriptor = original_descriptor_store;
+						server.config.set('copy_job_logs_to', original_copy_dir);
+						fs.unlinkSync(path.join(archive_dir, archive_files[0]));
+						fs.rmdirSync(archive_dir);
+						try { fs.unlinkSync(manager_temp_path); } catch (err) { if (err.code != 'ENOENT') return callback(err); }
+						try { fs.unlinkSync(held_path); } catch (err) { if (err.code != 'ENOENT') return callback(err); }
+						try { fs.rmdirSync(path.dirname(manager_temp_path)); } catch (err) { if (err.code != 'ENOENT') return callback(err); }
+						callback();
+					};
+					check_upload();
+				},
+				function (callback) {
+					// The old protocol allowed an authenticated caller to select any path.
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						path: outside_log,
+						auth: Tools.digestHex(outside_log + config.secret_key)
+					});
+					request.get(url, function (err, resp, data) {
+						test.ok(!err, "Signed outside-path request completed");
+						test.ok(resp.statusCode == 403, "Signed outside path was rejected");
+						test.ok(String(data).indexOf('OUTSIDE SECRET') < 0, "Outside file contents were not disclosed");
+						test.ok(fs.existsSync(outside_log), "Outside file was not deleted");
+						callback();
+					});
+				},
+				function (callback) {
+					// A new worker safely accepts the exact canonical request from an old
+					// manager, allowing worker-first rolling upgrades.
+					fs.writeFileSync(legacy_log, 'LEGACY CANONICAL LOG');
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						path: legacy_log,
+						auth: Tools.digestHex(legacy_log + config.secret_key)
+					});
+					request.get(url, function (err, resp, data) {
+						test.ok(!err, "Canonical legacy request completed");
+						test.ok(resp.statusCode == 200, "Canonical legacy request remained compatible");
+						test.ok(String(data) == 'LEGACY CANONICAL LOG', "Canonical legacy request returned exact bytes");
+						test.ok(resp.headers['x-cronicle-job-log-protocol'] == '2', "Compatible worker advertises protocol v2");
+						setTimeout(function () {
+							test.ok(!fs.existsSync(legacy_log), "Canonical legacy job log was deleted after transfer");
+							callback();
+						}, 50);
+					});
+				},
+				function (callback) {
+					// Canonical equality, not a restrictive character allowlist, is the
+					// security boundary for worker-first compatibility.
+					var old_log_dir = server.config.get('log_dir');
+					var spaced_log_dir = path.join(os.tmpdir(), 'cronicle edge logs ' + process.pid);
+					fs.mkdirSync(path.join(spaced_log_dir, 'jobs'), { recursive: true });
+					server.config.set('log_dir', spaced_log_dir);
+					var spaced_id = 'unitfetchlegacyspace';
+					var spaced_log = cronicle.getJobLogFilePath(spaced_id, false);
+					fs.writeFileSync(spaced_log, 'LEGACY PATH WITH SPACE');
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						path: spaced_log,
+						auth: Tools.digestHex(spaced_log + config.secret_key)
+					});
+					request.get(url, function (err, resp, data) {
+						test.ok(!err, "Canonical legacy path with spaces completed");
+						test.ok(resp.statusCode == 200, "Canonical legacy path with spaces remained compatible");
+						test.ok(String(data) == 'LEGACY PATH WITH SPACE', "Legacy path with spaces returned exact bytes");
+						setTimeout(function () {
+							test.ok(!fs.existsSync(spaced_log), "Legacy path with spaces was deleted after complete transfer");
+							server.config.set('log_dir', old_log_dir);
+							fs.rmdirSync(path.join(spaced_log_dir, 'jobs'));
+							fs.rmdirSync(spaced_log_dir);
+							callback();
+						}, 50);
+					});
+				},
+				function (callback) {
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						id: traversal_id,
+						detached: 0,
+						auth: cronicle.getJobLogFetchAuth(traversal_id, false)
+					});
+					request.get(url, function (err, resp, data) {
+						test.ok(!err, "Traversal request completed");
+						test.ok(resp.statusCode == 200, "Traversal ID returned an API error");
+						test.ok(String(data).indexOf('OUTSIDE SECRET') < 0, "Traversal did not disclose outside contents");
+						test.ok(fs.existsSync(outside_log), "Traversal did not delete the outside file");
+						callback();
+					});
+				},
+				function (callback) {
+					try { fs.symlinkSync(outside_log, symlink_log); }
+					catch (err) {
+						if ((err.code == 'EPERM') || (err.code == 'EACCES') || (err.code == 'ENOTSUP')) {
+							test.ok(true, "Symlink regression skipped because this platform forbids symlink creation");
+							return callback();
+						}
+						return callback(err);
+					}
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						id: symlink_id,
+						detached: 0,
+						auth: cronicle.getJobLogFetchAuth(symlink_id, false)
+					});
+					request.get(url, function (err, resp, data) {
+						test.ok(!err, "Symlink request completed");
+						test.ok(resp.statusCode == 404, "Symlink job log was rejected");
+						test.ok(String(data).indexOf('OUTSIDE SECRET') < 0, "Symlink target contents were not disclosed");
+						test.ok(fs.lstatSync(symlink_log).isSymbolicLink(), "Rejected symlink was preserved");
+						test.ok(fs.existsSync(outside_log), "Symlink target was preserved");
+						fs.unlinkSync(symlink_log);
+						callback();
+					});
+				},
+				function (callback) {
+					fs.writeFileSync(hardlink_log, 'HARD LINK LOG');
+					try { fs.linkSync(hardlink_log, hardlink_copy); }
+					catch (err) {
+						fs.unlinkSync(hardlink_log);
+						if ((err.code == 'EPERM') || (err.code == 'EACCES') || (err.code == 'ENOTSUP')) {
+							test.ok(true, "Hardlink regression skipped because this platform forbids hardlink creation");
+							return callback();
+						}
+						return callback(err);
+					}
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						id: hardlink_id,
+						detached: 0,
+						auth: cronicle.getJobLogFetchAuth(hardlink_id, false)
+					});
+					request.get(url, function (err, resp) {
+						test.ok(!err, "Hardlink request completed");
+						test.ok(resp.statusCode == 404, "Multiply linked job log was rejected");
+						test.ok(fs.existsSync(hardlink_log) && fs.existsSync(hardlink_copy), "Rejected hardlinks were preserved");
+						fs.unlinkSync(hardlink_log);
+						fs.unlinkSync(hardlink_copy);
+						callback();
+					});
+				},
+				function (callback) {
+					fs.writeFileSync(valid_log, 'VALID JOB LOG');
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						id: valid_id,
+						detached: 0,
+						auth: cronicle.getJobLogFetchAuth(valid_id, false)
+					});
+					request.get(url, { headers: { 'Accept-Encoding': 'identity' } }, function (err, resp, data) {
+						test.ok(!err, "Valid job-log request completed");
+						test.ok(resp.statusCode == 200, "Valid in-directory job log was served");
+						test.ok(String(data) == 'VALID JOB LOG', "Valid job log bytes matched");
+						test.ok(/^text\/plain/i.test(resp.headers['content-type']), "Worker log is text/plain");
+						test.ok(resp.headers['content-length'] == String(Buffer.byteLength('VALID JOB LOG')), "Worker committed the exact log byte count");
+						test.ok(resp.headers['x-content-type-options'] == 'nosniff', "Worker log disables MIME sniffing");
+						test.ok(/no-store/.test(resp.headers['cache-control']), "Worker log is not cacheable");
+						setTimeout(function () {
+							test.ok(!fs.existsSync(valid_log), "Valid job log was deleted after the complete response");
+							callback();
+						}, 50);
+					});
+				},
+				function (callback) {
+					fs.writeFileSync(empty_log, '');
+					var url = api_url + '/app/fetch_delete_job_log' + Tools.composeQueryString({
+						id: empty_id,
+						detached: 0,
+						auth: cronicle.getJobLogFetchAuth(empty_id, false)
+					});
+					request.get(url, { headers: { 'Accept-Encoding': 'identity' } }, function (err, resp, data) {
+						test.ok(!err, "Empty job-log request completed");
+						test.ok(resp.statusCode == 200, "Empty in-directory job log was served");
+						test.ok(Buffer.byteLength(data || '') == 0, "Empty job log returned zero bytes");
+						test.ok(resp.headers['content-length'] == '0', "Empty job log committed a zero-byte length");
+						setTimeout(function () {
+							test.ok(!fs.existsSync(empty_log), "Empty job log was deleted after the complete response");
+							callback();
+						}, 50);
+					});
+				},
+				function (callback) {
+					// Reproduce a path replacement after the safe descriptor is opened.
+					var race_id = 'unitfetchrace';
+					var race_log = cronicle.getJobLogFilePath(race_id, false);
+					var opened_log = race_log + '.opened';
+					try { fs.unlinkSync(race_log); } catch (err) { if (err.code != 'ENOENT') throw err; }
+					try { fs.unlinkSync(opened_log); } catch (err) { if (err.code != 'ENOENT') throw err; }
+					fs.writeFileSync(race_log, 'ORIGINAL DESCRIPTOR');
+					cronicle.openJobLogFile(race_log, function (err, fd, opened) {
+						test.ok(!err, "Race test opened the original regular file");
+						fs.renameSync(race_log, opened_log);
+						fs.writeFileSync(race_log, 'REPLACEMENT FILE');
+						var buffer = Buffer.alloc(64);
+						fs.read(fd, buffer, 0, buffer.length, 0, function (err, bytes_read) {
+							test.ok(!err, "Race test read from the opened descriptor");
+							test.ok(String(buffer.subarray(0, bytes_read)) == 'ORIGINAL DESCRIPTOR', "Replacement could not change streamed bytes");
+							fs.close(fd, function () {
+								cronicle.deleteJobLogIfUnchanged(race_log, opened);
+								setTimeout(function () {
+									test.ok(fs.readFileSync(race_log, 'utf8') == 'REPLACEMENT FILE', "Cleanup did not delete a replacement path");
+									fs.unlinkSync(race_log);
+									fs.unlinkSync(opened_log);
+									callback();
+								}, 50);
+							});
+						});
+					});
+				}
+			], function (err) {
+				delete cronicle.remoteLogFetchJobs.unitsourcebinding;
+				try { fs.unlinkSync(outside_log); } catch (cleanup_err) { if (cleanup_err.code != 'ENOENT') throw cleanup_err; }
+				test.ok(!err, "Job log transfer boundary checks completed");
+				test.done();
+			});
 		},
 	
 		
@@ -462,6 +1104,48 @@ module.exports = {
 				
 				test.done();
 			} );
+		},
+
+		function testCreateScopedLogSessions(test) {
+			var records = [
+				[ 'category_denied', {
+					username: 'unit_log_category_denied',
+					full_name: 'Category Denied',
+					email: 'category-denied@example.invalid',
+					active: 1,
+					privileges: { cat_limit: 1, grp_limit: 1, grp_maingrp: 1 }
+				} ],
+				[ 'group_denied', {
+					username: 'unit_log_group_denied',
+					full_name: 'Group Denied',
+					email: 'group-denied@example.invalid',
+					active: 1,
+					privileges: { cat_limit: 1, cat_general: 1, grp_limit: 1 }
+				} ],
+				[ 'allowed', {
+					username: 'unit_log_allowed',
+					full_name: 'Log Allowed',
+					email: 'log-allowed@example.invalid',
+					active: 1,
+					privileges: { cat_limit: 1, cat_general: 1, grp_limit: 1, grp_maingrp: 1 }
+				} ]
+			];
+
+			async.eachSeries(records, function (record, callback) {
+				var session_key = log_auth_sessions[record[0]];
+				storage.put('users/' + record[1].username, record[1], function (err) {
+					if (err) return callback(err);
+					storage.put('sessions/' + session_key, {
+						id: session_key,
+						username: record[1].username,
+						created: Tools.timeNow(true),
+						modified: Tools.timeNow(true)
+					}, callback);
+				});
+			}, function (err) {
+				test.ok(!err, "Scoped log users and sessions were created");
+				test.done();
+			});
 		},
 		
 		function testAPIConfig(test) {
@@ -1111,6 +1795,99 @@ module.exports = {
 				test.done();
 			} );
 		},
+
+		function testActiveJobLogAuthorization(test) {
+			var self = this;
+			var denied_sessions = [
+				{ name: 'missing session', id: '' },
+				{ name: 'foreign category', id: log_auth_sessions.category_denied },
+				{ name: 'foreign group', id: log_auth_sessions.group_denied }
+			];
+
+			async.eachSeries(denied_sessions, function (entry, callback) {
+				var query = { id: self.job_id };
+				if (entry.id) query.session_id = entry.id;
+				request.get(api_url + '/app/get_live_job_log' + Tools.composeQueryString(query), function (err, resp, data) {
+					test.ok(!err, "Raw live-log denial completed for " + entry.name);
+					test.ok(resp.statusCode == 200, "Raw live-log denial is an API response for " + entry.name);
+					test.ok(String(data).indexOf('UNIT TEST STRING') < 0, "Raw live-log denial did not leak log bytes for " + entry.name);
+					callback();
+				});
+			}, function (err) {
+				if (err) return test.done(err);
+				async.eachSeries(denied_sessions, function (entry, callback) {
+					var params = { id: self.job_id };
+					if (entry.id) params.session_id = entry.id;
+					request.json(api_url + '/app/get_live_console', params, function (err, resp, data) {
+						test.ok(!err, "Live-console denial completed for " + entry.name);
+						test.ok(resp.statusCode == 200, "Live-console denial is an API response for " + entry.name);
+						test.ok(data.code != 0, "Live console denied " + entry.name);
+						test.ok(!data.data || (data.data.indexOf('UNIT TEST STRING') < 0), "Live-console denial did not leak log bytes for " + entry.name);
+						callback();
+					});
+				}, function (err) {
+					if (err) return test.done(err);
+					var raw_query = { id: self.job_id, session_id: log_auth_sessions.allowed };
+					request.get(api_url + '/app/get_live_job_log' + Tools.composeQueryString(raw_query), function (err, resp, data) {
+						test.ok(!err, "Scoped user requested raw live log");
+						test.ok(resp.statusCode == 200, "Scoped user received raw live log");
+						test.ok(String(data).length > 0, "Scoped user received live log bytes");
+						test.ok(/^text\/plain/i.test(resp.headers['content-type']), "Raw live log is text/plain");
+						test.ok(resp.headers['x-content-type-options'] == 'nosniff', "Raw live log disables MIME sniffing");
+						test.ok(/no-store/.test(resp.headers['cache-control']), "Raw live log is not cacheable");
+
+						request.json(api_url + '/app/get_live_console', {
+							id: self.job_id,
+							session_id: log_auth_sessions.allowed
+						}, function (err, resp, data) {
+							test.ok(!err, "Scoped user requested live console");
+							test.ok(resp.statusCode == 200, "Scoped user received live console response");
+							test.ok(!data.code, "Scoped user was authorized for live console");
+							test.ok(typeof data.data == 'string', "Live console returned log data");
+
+							var remote_id = 'unitremotelivelog';
+							var remote_file = cronicle.getJobLogFilePath(remote_id, false);
+							var old_worker = cronicle.workers['127.0.0.1'];
+							fs.writeFileSync(remote_file, 'REMOTE LIVE LOG');
+							cronicle.workers['127.0.0.1'] = {
+								hostname: '127.0.0.1',
+								ip: '127.0.0.1',
+								active_jobs: {
+									unitremotelivelog: {
+										id: remote_id,
+										hostname: '127.0.0.1',
+										category: 'general',
+										target: 'maingrp',
+										detached: 0
+									}
+								}
+							};
+							cronicle.remoteLogFetchJobs[remote_id] = {
+								id: remote_id,
+								hostname: '127.0.0.1',
+								category: 'general',
+								target: 'maingrp',
+								detached: 0
+							};
+							request.get(api_url + '/app/get_live_job_log' + Tools.composeQueryString({
+								id: remote_id,
+								session_id: log_auth_sessions.allowed
+							}), function (err, resp, data) {
+								test.ok(!err, "Manager proxied an authorized remote raw live log");
+								test.ok(resp.statusCode == 200, "Remote raw live log returned HTTP 200");
+								test.ok(String(data) == 'REMOTE LIVE LOG', "Remote raw live log returned exact bytes");
+								test.ok(/^text\/plain/i.test(resp.headers['content-type']), "Remote raw live log is text/plain");
+								fs.unlinkSync(remote_file);
+								delete cronicle.remoteLogFetchJobs[remote_id];
+								if (old_worker) cronicle.workers['127.0.0.1'] = old_worker;
+								else delete cronicle.workers['127.0.0.1'];
+								test.done();
+							});
+						});
+					});
+				});
+			});
+		},
 		
 		// app/get_live_job_log
 		
@@ -1118,12 +1895,15 @@ module.exports = {
 			// test get_live_job_log API (raw HTTP get, not a JSON API)
 			var self = this;
 			
-			request.get( api_url + '/app/get_live_job_log?id=' + this.job_id, function(err, resp, data) {
+			request.get( api_url + '/app/get_live_job_log?id=' + this.job_id + '&session_id=' + session_id, function(err, resp, data) {
 				
 				test.ok( !err, "No error requesting API" );
 				test.ok( resp.statusCode == 200, "HTTP 200 from API" );
 				test.ok( !!data, "Got data buffer" );
 				test.ok( data.length > 0, "Data buffer has length" );
+				test.ok( /^text\/plain/i.test(resp.headers['content-type']), "Live log uses text/plain" );
+				test.ok( resp.headers['x-content-type-options'] == 'nosniff', "Live log disables MIME sniffing" );
+				test.ok( /no-store/.test(resp.headers['cache-control']), "Live log is not cacheable" );
 				
 				test.done();
 				
@@ -1166,6 +1946,75 @@ module.exports = {
 		},
 		
 		// app/update_job
+
+		function testAPIRejectProtectedJobUpdates(test) {
+			var self = this;
+			var job = cronicle.getAllActiveJobs()[this.job_id];
+			var original_log_file = job.log_file;
+			var original_hostname = job.hostname;
+			var original_pid = job.pid;
+
+			request.json(api_url + '/app/update_job', {
+				session_id: session_id,
+				id: this.job_id,
+				notify_fail: 'must-not-apply@example.invalid',
+				log_file: path.join(os.tmpdir(), 'outside-mutated.log')
+			}, function (err, resp, data) {
+				test.ok(!err, "Protected single-job update completed");
+				test.ok(resp.statusCode == 200, "Protected single-job update returned an API response");
+				test.ok(data.code != 0, "Single-job update rejected log_file atomically");
+
+				var current = cronicle.getAllActiveJobs()[self.job_id];
+				test.ok(current.log_file == original_log_file, "Single-job update preserved log_file");
+				test.ok(current.hostname == original_hostname, "Single-job update preserved hostname");
+				test.ok(current.pid == original_pid, "Single-job update preserved pid");
+				test.ok(current.notify_fail == 'test@test.com', "Single-job update did not partially apply mutable fields");
+
+				request.json(api_url + '/app/update_jobs', {
+					session_id: session_id,
+					event: self.event_id,
+					updates: {
+						notify_fail: 'must-not-apply-bulk@example.invalid',
+						log_file: path.join(os.tmpdir(), 'outside-mutated-bulk.log')
+					}
+				}, function (err, resp, data) {
+					test.ok(!err, "Protected bulk update completed");
+					test.ok(resp.statusCode == 200, "Protected bulk update returned an API response");
+					test.ok(data.code != 0, "Bulk update rejected log_file atomically");
+					current = cronicle.getAllActiveJobs()[self.job_id];
+					test.ok(current.log_file == original_log_file, "Bulk update preserved log_file");
+					test.ok(current.notify_fail == 'test@test.com', "Bulk update did not partially apply mutable fields");
+
+					request.json(api_url + '/app/update_job', {
+						session_id: session_id,
+						id: self.job_id,
+						timeout: { invalid: true }
+					}, function (err, resp, data) {
+						test.ok(!err, "Invalid allowlisted value request completed");
+						test.ok(resp.statusCode == 200, "Invalid allowlisted value returned an API response");
+						test.ok(data.code != 0, "Allowlisted fields still require valid types and values");
+						test.done();
+					});
+				});
+			});
+		},
+
+		function testAPIAllowlistedBulkJobUpdate(test) {
+			var self = this;
+			request.json(api_url + '/app/update_jobs', {
+				session_id: session_id,
+				event: this.event_id,
+				updates: { notify_fail: 'bulk@example.invalid' }
+			}, function (err, resp, data) {
+				test.ok(!err, "Allowlisted bulk update completed");
+				test.ok(resp.statusCode == 200, "Allowlisted bulk update returned HTTP 200");
+				test.ok(data.code == 0, "Allowlisted bulk update succeeded");
+				test.ok(data.count == 1, "Allowlisted bulk update changed one job");
+				var job = cronicle.getAllActiveJobs()[self.job_id];
+				test.ok(job.notify_fail == 'bulk@example.invalid', "Allowlisted bulk field was applied");
+				test.done();
+			});
+		},
 		
 		function testAPIUpdateJob(test) {
 			// test app/update_job api
@@ -1246,6 +2095,38 @@ module.exports = {
 		},
 		
 		// app/get_job_log
+
+		function testCompletedJobLogAuthorization(test) {
+			var self = this;
+			var denied_sessions = [
+				{ name: 'missing session', id: '' },
+				{ name: 'foreign category', id: log_auth_sessions.category_denied },
+				{ name: 'foreign group', id: log_auth_sessions.group_denied }
+			];
+
+			async.eachSeries(denied_sessions, function (entry, callback) {
+				var query = { id: self.job_id };
+				if (entry.id) query.session_id = entry.id;
+				request.get(api_url + '/app/get_job_log' + Tools.composeQueryString(query), function (err, resp, data) {
+					test.ok(!err, "Completed-log denial completed for " + entry.name);
+					test.ok(resp.statusCode == 200, "Completed-log denial is an API response for " + entry.name);
+					test.ok(String(data).indexOf('# Job completed successfully') < 0, "Completed-log denial did not leak bytes for " + entry.name);
+					callback();
+				});
+			}, function (err) {
+				if (err) return test.done(err);
+				var query = { id: self.job_id, session_id: log_auth_sessions.allowed };
+				request.get(api_url + '/app/get_job_log' + Tools.composeQueryString(query), function (err, resp, data) {
+					test.ok(!err, "Scoped user requested completed log");
+					test.ok(resp.statusCode == 200, "Scoped user received completed log");
+					test.ok(String(data).match(/success/i), "Scoped user received completed log bytes");
+					test.ok(/^text\/plain/i.test(resp.headers['content-type']), "Completed log is text/plain");
+					test.ok(resp.headers['x-content-type-options'] == 'nosniff', "Completed log disables MIME sniffing");
+					test.ok(/no-store/.test(resp.headers['cache-control']), "Completed log is not cacheable");
+					test.done();
+				});
+			});
+		},
 		
 		function testAPIGetJobLog(test) {
 			// test get_job_log API (raw HTTP get, not a JSON API)
@@ -1258,6 +2139,9 @@ module.exports = {
 				test.ok( !!data, "Got data buffer" );
 				test.ok( data.length > 0, "Data buffer has length" );
 				test.ok( data.toString().match(/success/i), "Log buffer contains expected string" );
+				test.ok( /^text\/plain/i.test(resp.headers['content-type']), "Completed log uses text/plain" );
+				test.ok( resp.headers['x-content-type-options'] == 'nosniff', "Completed log disables MIME sniffing" );
+				test.ok( /no-store/.test(resp.headers['cache-control']), "Completed log is not cacheable" );
 				
 				test.done();
 				

--- a/lib/test.js
+++ b/lib/test.js
@@ -355,6 +355,518 @@ module.exports = {
 			test.done();
 		},
 
+		function testWorkerRunAsLifecycle(test) {
+			// Manager-side serialization is platform-neutral, so this models a
+			// Windows manager dispatching Plugin identity to a Unix worker.
+			var canonical = {
+				id: 'unitdebugsudodispatch',
+				hostname: server.hostname,
+				plugin: 'shellplug',
+				command: '/bin/sh',
+				cwd: '/srv/cronicle',
+				params: {
+					script: 'echo safe',
+					nested: { answer: 42, enabled: true },
+					array_like: { 0: 'zero', length: 1, forEach: 'payload data' },
+					_cronicle_run_as: 'nested payload data'
+				},
+				env: {
+					PATH: '/usr/bin', SAFE_VALUE: '1',
+					NODE_OPTIONS: '--no-deprecation', LD_PRELOAD: ''
+				},
+				stdin: true,
+				stdin_script: 'echo safe',
+				args: 'safe-argument',
+				files: [
+					{ name: 'first.txt', content: 'first' },
+					{ name: 'second.txt', content: 'second' }
+				],
+				workflow: [
+					{ id: 'step-one', title: 'First' },
+					{ id: 'step-two', title: 'Second' }
+				],
+				chain_data: { source: 'trusted', count: 2 },
+				secret: 'encrypted-event-secret',
+				globalenv: 'encrypted-global-secret',
+				cat_secret: 'encrypted-category-secret',
+				plug_secret: 'encrypted-plugin-secret'
+			};
+			cronicle.setJobRunAsFromPlugin(canonical, { uid: 'restricted-user', gid: 'restricted-group' });
+			test.ok(canonical.uid == 'restricted-user', 'Manager serialized Plugin UID into the job');
+			test.ok(canonical.gid == 'restricted-group', 'Manager serialized Plugin GID into the job');
+
+			var unix_options = cronicle.getChildRunAsOptions(canonical, 'linux', 501, 502);
+			test.ok(unix_options.uid == 'restricted-user', 'Unix worker passes Plugin UID to spawn');
+			test.ok(unix_options.gid == 'restricted-group', 'Unix worker passes Plugin GID to spawn');
+
+			var windows_options = cronicle.getChildRunAsOptions(canonical, 'win32', 501, 502);
+			test.ok(!Object.prototype.hasOwnProperty.call(windows_options, 'uid'), 'Windows worker omits the Unix UID spawn option');
+			test.ok(!Object.prototype.hasOwnProperty.call(windows_options, 'gid'), 'Windows worker omits the Unix GID spawn option');
+
+			var zero_job = { id: 'unitzerotype', hostname: server.hostname, plugin: 'shellplug' };
+			cronicle.setJobRunAsFromPlugin(zero_job, { uid: 0, gid: 0 });
+			var zero_options = cronicle.getChildRunAsOptions(zero_job, 'linux', 501, 502);
+			test.ok(zero_options.uid === 0, 'Numeric Plugin UID zero survives manager and worker handling');
+			test.ok(zero_options.gid === 0, 'Numeric Plugin GID zero survives manager and worker handling');
+
+			var string_zero_job = { id: 'unitzerotype', hostname: server.hostname, plugin: 'shellplug' };
+			cronicle.setJobRunAsFromPlugin(string_zero_job, { uid: '0', gid: '0' });
+			var string_zero_options = cronicle.getChildRunAsOptions(string_zero_job, 'linux', 501, 502);
+			test.ok(string_zero_options.uid === '0', 'String Plugin UID zero remains compatible');
+			test.ok(string_zero_options.gid === '0', 'String Plugin GID zero remains compatible');
+
+			var dispatch_session = new Array(65).join('a');
+			var capable_worker = {
+				hostname: server.hostname,
+				job_dispatch_capabilities: cronicle.getJobDispatchCapabilities(),
+				job_dispatch_session: dispatch_session,
+				job_dispatch_sequence: 0
+			};
+			var zero_worker = {
+				hostname: server.hostname,
+				job_dispatch_capabilities: cronicle.getJobDispatchCapabilities(),
+				job_dispatch_session: dispatch_session,
+				job_dispatch_sequence: 0
+			};
+			var string_zero_worker = Tools.copyHash(zero_worker, true);
+			var zero_dispatch = cronicle.createJobDispatchPayload(zero_job, zero_worker, false);
+			var string_zero_dispatch = cronicle.createJobDispatchPayload(string_zero_job, string_zero_worker, false);
+			test.ok(!!cronicle.verifyJobRunAsContext(zero_dispatch, server.hostname, { session: dispatch_session }), 'Numeric zero dispatch signature verified');
+			test.ok(!!cronicle.verifyJobRunAsContext(string_zero_dispatch, server.hostname, { session: dispatch_session }), 'String zero dispatch signature verified');
+			test.ok(
+				zero_dispatch._cronicle_run_as.signature !== string_zero_dispatch._cronicle_run_as.signature,
+				'Typed HMAC input distinguishes numeric and string zero'
+			);
+
+			var dispatch = cronicle.createJobDispatchPayload(canonical, capable_worker, true);
+			test.ok(dispatch !== canonical, 'Trusted debug launch uses an isolated dispatch copy');
+			test.ok(!Object.prototype.hasOwnProperty.call(canonical, 'debug_sudo'), 'Manager canonical job has no debug_sudo marker');
+			test.ok(!Object.prototype.hasOwnProperty.call(canonical, '_cronicle_run_as'), 'Manager canonical job has no signed transport context');
+			test.ok(!Object.prototype.hasOwnProperty.call(dispatch, 'debug_sudo'), 'Wire copy has no legacy debug_sudo marker');
+			test.ok(Object.prototype.hasOwnProperty.call(dispatch, '_cronicle_run_as'), 'Wire copy carries a distinct signed transport context');
+			test.ok(dispatch._cronicle_run_as.version === 2, 'Wire context uses full-payload dispatch protocol v2');
+			test.ok(!!dispatch._cronicle_run_as.payload_sha256.match(/^[a-f0-9]{64}$/), 'Wire context carries a canonical payload digest');
+			var dispatch_state = { session: dispatch_session, last_sequence: 0 };
+			var verified_context = cronicle.verifyJobRunAsContext(dispatch, server.hostname, dispatch_state);
+			test.ok(verified_context && verified_context.mode == 'service', 'Worker verified the signed service run-as context');
+			test.ok(dispatch.params.array_like.length === 1, 'Canonical serializer accepts ordinary objects with a length field');
+
+			var tamper_cases = [
+				{ name: 'Plugin UID', mutate: function(payload) { payload.uid = 'attacker'; } },
+				{ name: 'command', mutate: function(payload) { payload.command = '/bin/sh -c id'; } },
+				{ name: 'cwd', mutate: function(payload) { payload.cwd = '/tmp'; } },
+				{ name: 'nested params', mutate: function(payload) { payload.params.nested.answer = 7; } },
+				{ name: 'nested param type', mutate: function(payload) { payload.params.nested.answer = '42'; } },
+				{ name: 'nested context-named param', mutate: function(payload) { payload.params._cronicle_run_as = 'tampered'; } },
+				{ name: 'environment', mutate: function(payload) { payload.env.PATH = '/tmp/attacker'; } },
+				{ name: 'NODE_OPTIONS environment', mutate: function(payload) { payload.env.NODE_OPTIONS = '--require=/tmp/attacker.js'; } },
+				{ name: 'LD_PRELOAD environment', mutate: function(payload) { payload.env.LD_PRELOAD = '/tmp/attacker.so'; } },
+				{ name: 'stdin mode', mutate: function(payload) { payload.stdin = false; } },
+				{ name: 'stdin script', mutate: function(payload) { payload.stdin_script = 'id'; } },
+				{ name: 'detached mode', mutate: function(payload) { payload.detached = 1; } },
+				{ name: 'arguments', mutate: function(payload) { payload.args = 'attacker-argument'; } },
+				{ name: 'files', mutate: function(payload) { payload.files[0].content = 'replacement'; } },
+				{ name: 'files array order', mutate: function(payload) { payload.files.reverse(); } },
+				{ name: 'workflow', mutate: function(payload) { payload.workflow[0].id = 'attacker-step'; } },
+				{ name: 'workflow array order', mutate: function(payload) { payload.workflow.reverse(); } },
+				{ name: 'chain data', mutate: function(payload) { payload.chain_data.source = 'attacker'; } },
+				{ name: 'event secret', mutate: function(payload) { payload.secret = 'replacement'; } },
+				{ name: 'global secret', mutate: function(payload) { payload.globalenv = 'replacement'; } },
+				{ name: 'category secret', mutate: function(payload) { payload.cat_secret = 'replacement'; } },
+				{ name: 'Plugin secret', mutate: function(payload) { payload.plug_secret = 'replacement'; } },
+				{ name: 'added field', mutate: function(payload) { payload.attacker_field = 'replacement'; } },
+				{ name: 'deleted field', mutate: function(payload) { delete payload.cwd; } }
+			];
+			tamper_cases.forEach(function(tamper_case) {
+				var tampered_payload = cronicle.createJobDispatchPayload(canonical, capable_worker, true);
+				tamper_case.mutate(tampered_payload);
+				test.ok(
+					!cronicle.verifyJobRunAsContext(tampered_payload, server.hostname, dispatch_state),
+					'Full-payload HMAC rejected tampered ' + tamper_case.name
+				);
+			});
+
+			var reordered_dispatch = {};
+			Object.keys(dispatch).reverse().forEach(function(key) { reordered_dispatch[key] = dispatch[key]; });
+			reordered_dispatch.params = {};
+			Object.keys(dispatch.params).reverse().forEach(function(key) {
+				reordered_dispatch.params[key] = dispatch.params[key];
+			});
+			reordered_dispatch.env = {};
+			Object.keys(dispatch.env).reverse().forEach(function(key) {
+				reordered_dispatch.env[key] = dispatch.env[key];
+			});
+			test.ok(
+				!!cronicle.verifyJobRunAsContext(reordered_dispatch, server.hostname, dispatch_state),
+				'Canonical digest accepts semantically identical object key ordering'
+			);
+
+			var wire_semantics_job = {
+				id: 'unitwiresemantics', hostname: server.hostname, plugin: 'shellplug',
+				ignored: undefined,
+				ignored_function: function() { return 'not on the wire'; },
+				values: [ undefined, function() {}, NaN, Infinity, -Infinity, -0 ]
+			};
+			var wire_semantics_worker = {
+				hostname: server.hostname,
+				job_dispatch_capabilities: cronicle.getJobDispatchCapabilities(),
+				job_dispatch_session: dispatch_session,
+				job_dispatch_sequence: 0
+			};
+			var wire_semantics_dispatch = cronicle.createJobDispatchPayload(
+				wire_semantics_job, wire_semantics_worker, false
+			);
+			test.ok(
+				!Object.prototype.hasOwnProperty.call(wire_semantics_dispatch, 'ignored') &&
+				!Object.prototype.hasOwnProperty.call(wire_semantics_dispatch, 'ignored_function') &&
+				(JSON.stringify(wire_semantics_dispatch.values) == '[null,null,null,null,null,0]'),
+				'Manager normalizes undefined, functions and non-finite numbers to exact JSON wire semantics before signing'
+			);
+			test.ok(
+				!!cronicle.verifyJobRunAsContext(wire_semantics_dispatch, server.hostname, { session: dispatch_session }),
+				'Worker verifies the normalized Socket.IO JSON payload'
+			);
+
+			var cyclic_job = Tools.copyHash(canonical, true);
+			cyclic_job.params.cycle = cyclic_job;
+			var cyclic_create_failed = false;
+			try { cronicle.createJobDispatchPayload(cyclic_job, capable_worker, true); }
+			catch (err) { cyclic_create_failed = true; }
+			test.ok(cyclic_create_failed, 'Manager fails closed instead of signing a cyclic non-JSON payload');
+			var cyclic_wire_job = Tools.copyHash(dispatch, true);
+			cyclic_wire_job.params.cycle = cyclic_wire_job;
+			test.ok(
+				!cronicle.verifyJobRunAsContext(cyclic_wire_job, server.hostname, dispatch_state),
+				'Worker fails closed without throwing on a cyclic non-wire payload'
+			);
+
+			var bigint_job = Tools.copyHash(canonical, true);
+			bigint_job.params.count = BigInt(1);
+			var bigint_create_failed = false;
+			try { cronicle.createJobDispatchPayload(bigint_job, capable_worker, true); }
+			catch (err) { bigint_create_failed = true; }
+			test.ok(bigint_create_failed, 'Manager fails closed instead of signing a BigInt non-JSON payload');
+			var bigint_wire_job = Tools.copyHash(dispatch, true);
+			bigint_wire_job.params.count = BigInt(1);
+			test.ok(
+				!cronicle.verifyJobRunAsContext(bigint_wire_job, server.hostname, dispatch_state),
+				'Worker fails closed without throwing on a BigInt non-wire payload'
+			);
+
+			var tampered_signature = cronicle.createJobDispatchPayload(canonical, capable_worker, true);
+			var first_signature_char = tampered_signature._cronicle_run_as.signature.charAt(0);
+			tampered_signature._cronicle_run_as.signature =
+				(first_signature_char == '0' ? '1' : '0') + tampered_signature._cronicle_run_as.signature.slice(1);
+			test.ok(!cronicle.verifyJobRunAsContext(tampered_signature, server.hostname, dispatch_state), 'Worker rejected a modified dispatch signature');
+			var wrong_job = cronicle.createJobDispatchPayload(canonical, capable_worker, true);
+			wrong_job.id = 'unitdebugsudowrongjob';
+			test.ok(!cronicle.verifyJobRunAsContext(wrong_job, server.hostname, dispatch_state), 'Signed context could not be rebound to another job ID');
+			var wrong_worker = {
+				hostname: 'different-worker.example',
+				job_dispatch_capabilities: cronicle.getJobDispatchCapabilities(),
+				job_dispatch_session: dispatch_session,
+				job_dispatch_sequence: 0
+			};
+			var wrong_worker_dispatch = cronicle.createJobDispatchPayload(canonical, wrong_worker, true);
+			test.ok(!cronicle.verifyJobRunAsContext(wrong_worker_dispatch, server.hostname, dispatch_state), 'Context signed for another worker was rejected');
+			test.ok(!cronicle.verifyJobRunAsContext(dispatch, 'different-manager.example', dispatch_state), 'Context signed for another manager was rejected');
+			var v1_service_dispatch = Tools.copyHash(dispatch, true);
+			v1_service_dispatch._cronicle_run_as.version = 1;
+			v1_service_dispatch._cronicle_run_as.signature = new Array(65).join('b');
+			test.ok(
+				!cronicle.verifyJobRunAsContext(v1_service_dispatch, server.hostname, dispatch_state),
+				'Worker fails closed for an incoming v1 service-mode context'
+			);
+			var v1_plugin_dispatch = Tools.copyHash(v1_service_dispatch, true);
+			v1_plugin_dispatch._cronicle_run_as.mode = 'plugin';
+			test.ok(
+				!cronicle.verifyJobRunAsContext(v1_plugin_dispatch, server.hostname, dispatch_state),
+				'Worker rejects v1 contexts even when they request only Plugin identity'
+			);
+			var replayed_dispatch = Tools.copyHash(dispatch, true);
+
+			var original_launch_local_job = cronicle.launchLocalJob;
+			var verified_launch_options = null;
+			cronicle.launchLocalJob = function(job, launch_options) {
+				verified_launch_options = launch_options;
+				cronicle.consumeJobDispatchContext(job, launch_options, 'linux', 601);
+			};
+			try {
+				test.ok(cronicle.launchJobFromManager(dispatch, server.hostname, dispatch_state), 'New worker accepted a valid signed dispatch from the new manager');
+				test.ok(!cronicle.launchJobFromManager(replayed_dispatch, server.hostname, dispatch_state), 'Worker rejected a replayed sequence in the same dispatch session');
+			}
+			finally { cronicle.launchLocalJob = original_launch_local_job; }
+			test.ok(verified_launch_options && verified_launch_options.service_uid === true, 'Verified service mode became an in-memory launch decision');
+			test.ok(dispatch.uid === 601, 'Unix worker materialized its own service UID');
+			test.ok(dispatch.gid == 'restricted-group', 'Worker-local debug launch preserved Plugin GID');
+			test.ok(!Object.prototype.hasOwnProperty.call(dispatch, '_cronicle_run_as'), 'Worker consumed signed context before persistence');
+
+			// The same object is used for a delayed/retry launch.  Consuming it again
+			// must retain the already materialized worker identity without a marker.
+			cronicle.consumeJobDispatchContext(dispatch, null, 'linux', 999);
+			test.ok(dispatch.uid === 601, 'Retry retained the original worker-local service UID');
+			test.ok(!Object.prototype.hasOwnProperty.call(dispatch, 'debug_sudo'), 'Retry state contains no debug_sudo marker');
+			test.ok(!Object.prototype.hasOwnProperty.call(dispatch, '_cronicle_run_as'), 'Retry state contains no signed transport context');
+
+			// Manager-first rolling upgrade: a legacy worker never receives an unknown
+			// marker.  An admin debug request safely falls back to the Plugin identity.
+			var legacy_job = Tools.copyHash(canonical, true);
+			legacy_job.hostname = 'legacy-worker.example';
+			legacy_job.debug_sudo = 1;
+			legacy_job._cronicle_run_as = { forged: true };
+			var legacy_payload = cronicle.createJobDispatchPayload(legacy_job, {
+				hostname: 'legacy-worker.example',
+				job_dispatch_capabilities: Object.create(null)
+			}, true);
+			test.ok(legacy_payload !== legacy_job, 'Legacy worker receives an isolated clean payload');
+			test.ok(legacy_payload.uid == 'restricted-user', 'Legacy worker retains the Plugin UID');
+			test.ok(!Object.prototype.hasOwnProperty.call(legacy_payload, 'debug_sudo'), 'Legacy worker receives no debug_sudo marker');
+			test.ok(!Object.prototype.hasOwnProperty.call(legacy_payload, '_cronicle_run_as'), 'Legacy worker receives no unknown signed context');
+
+			// Worker-first rolling upgrade: legacy top-level authority is never trusted,
+			// and unsigned jobs are rejected before launch.
+			var unsigned_launches = 0;
+			var unsigned_job = Tools.copyHash(canonical, true);
+			unsigned_job.debug_sudo = 1;
+			cronicle.launchLocalJob = function() { unsigned_launches++; };
+			try {
+				test.ok(!cronicle.launchJobFromManager(unsigned_job, server.hostname, { session: dispatch_session, last_sequence: 0 }), 'New worker rejected an unsigned legacy-manager dispatch');
+			}
+			finally { cronicle.launchLocalJob = original_launch_local_job; }
+			test.ok(unsigned_launches === 0, 'Rejected legacy-manager dispatch never reached launchLocalJob');
+			cronicle.consumeJobDispatchContext(unsigned_job, null, 'linux', 777);
+			test.ok(unsigned_job.uid == 'restricted-user', 'Legacy debug_sudo did not replace the Plugin UID');
+			test.ok(!Object.prototype.hasOwnProperty.call(unsigned_job, 'debug_sudo'), 'Legacy debug_sudo was removed defensively');
+
+			var pending_job = cronicle.createJobDispatchPayload({
+				id: 'unitdebugsudopending',
+				hostname: server.hostname,
+				plugin: 'shellplug',
+				uid: 'restricted-user',
+				gid: 'restricted-group',
+				when: Tools.timeNow() + 60
+			}, capable_worker, true);
+			var pending_context = cronicle.verifyJobRunAsContext(pending_job, server.hostname, { session: dispatch_session });
+			var old_enqueue_internal = cronicle.enqueueInternal;
+			var captured_pending = null;
+			var pending_enqueues = 0;
+			cronicle.enqueueInternal = function(job) { captured_pending = job; pending_enqueues++; };
+			try {
+				cronicle.launchLocalJob(pending_job, { service_uid: pending_context.mode == 'service' });
+				cronicle.launchLocalJob(pending_job);
+			}
+			finally { cronicle.enqueueInternal = old_enqueue_internal; }
+			test.ok(captured_pending === pending_job, 'Delayed job entered the worker pending queue');
+			test.ok(!Object.prototype.hasOwnProperty.call(pending_job, 'debug_sudo'), 'Worker pending queue contains no debug_sudo marker');
+			test.ok(!Object.prototype.hasOwnProperty.call(pending_job, '_cronicle_run_as'), 'Worker pending queue contains no signed transport context');
+			test.ok(pending_enqueues === 2, 'Retry re-entered launchLocalJob through the same worker boundary');
+			test.ok(!Object.prototype.hasOwnProperty.call(pending_job, 'debug_sudo'), 'Worker retry queue contains no debug_sudo marker');
+			test.ok(!Object.prototype.hasOwnProperty.call(pending_job, '_cronicle_run_as'), 'Worker retry queue contains no signed transport context');
+			if (process.platform != 'win32') {
+				test.ok(pending_job.uid === process.getuid(), 'Pending job stored the executing worker service UID');
+			}
+
+			var debug_descriptor = Object.getOwnPropertyDescriptor(Object.prototype, 'debug_sudo');
+			var uid_descriptor = Object.getOwnPropertyDescriptor(Object.prototype, 'uid');
+			var gid_descriptor = Object.getOwnPropertyDescriptor(Object.prototype, 'gid');
+			Object.defineProperty(Object.prototype, 'debug_sudo', { value: 1, enumerable: true, configurable: true, writable: true });
+			Object.defineProperty(Object.prototype, 'uid', { value: 0, enumerable: true, configurable: true, writable: true });
+			Object.defineProperty(Object.prototype, 'gid', { value: 0, enumerable: true, configurable: true, writable: true });
+			try {
+				var polluted_job = {};
+				cronicle.setJobRunAsFromPlugin(polluted_job, { uid: 'restricted-user', gid: 'restricted-group' });
+				cronicle.consumeJobDispatchContext(polluted_job, null, 'linux', 901);
+				var polluted_options = cronicle.getChildRunAsOptions(polluted_job, 'linux', 901, 902);
+				test.ok(polluted_options.uid == 'restricted-user', 'Inherited debug_sudo did not bypass the Plugin UID');
+				test.ok(polluted_options.gid == 'restricted-group', 'Inherited GID did not replace the Plugin GID');
+
+				var inherited_plugin_job = {};
+				cronicle.setJobRunAsFromPlugin(inherited_plugin_job, {});
+				test.ok(!Object.prototype.hasOwnProperty.call(inherited_plugin_job, 'uid'), 'Inherited Plugin UID was not serialized');
+				test.ok(!Object.prototype.hasOwnProperty.call(inherited_plugin_job, 'gid'), 'Inherited Plugin GID was not serialized');
+
+				var inherited_dispatch = cronicle.createJobDispatchPayload(inherited_plugin_job, capable_worker, true);
+				test.ok(!Object.prototype.hasOwnProperty.call(inherited_dispatch, 'uid'), 'Wire copy did not materialize an inherited UID');
+				test.ok(!Object.prototype.hasOwnProperty.call(inherited_dispatch, 'gid'), 'Wire copy did not materialize an inherited GID');
+				cronicle.consumeJobDispatchContext(inherited_dispatch, { service_uid: true }, 'linux', 903);
+				test.ok(inherited_dispatch.uid === 903, 'Polluted wire job still materialized the local worker UID');
+				test.ok(!Object.prototype.hasOwnProperty.call(inherited_dispatch, '_cronicle_run_as'), 'Polluted wire job consumed its signed context');
+
+				var inherited_capabilities = Object.create({ signed_job_run_as_v2: 2 });
+				test.ok(!cronicle.supportsSignedJobDispatch(inherited_capabilities), 'Inherited capability did not enable signed dispatch');
+				var inherited_worker_capability = Object.create({
+					job_dispatch_capabilities: cronicle.getJobDispatchCapabilities(),
+					job_dispatch_ready: false
+				});
+				inherited_worker_capability.hostname = server.hostname;
+				var inherited_capability_payload = cronicle.createJobDispatchPayload(
+					canonical, inherited_worker_capability, true
+				);
+				test.ok(!Object.prototype.hasOwnProperty.call(inherited_capability_payload, '_cronicle_run_as'), 'Inherited worker capability did not authorize a signed context');
+				test.ok(cronicle.isWorkerJobDispatchReady(inherited_worker_capability), 'Inherited readiness flag did not disable an otherwise legacy worker object');
+
+				var v1_only_worker = {
+					hostname: server.hostname,
+					job_dispatch_capabilities: { signed_job_run_as_v1: 1 },
+					job_dispatch_session: dispatch_session
+				};
+				var v1_fallback_payload = cronicle.createJobDispatchPayload(canonical, v1_only_worker, true);
+				test.ok(!cronicle.supportsSignedJobDispatch(v1_only_worker.job_dispatch_capabilities), 'V1-only capability is not accepted as full-payload signing');
+				test.ok(!Object.prototype.hasOwnProperty.call(v1_fallback_payload, '_cronicle_run_as'), 'V1-only worker receives a clean legacy Plugin-mode payload');
+				test.ok(v1_fallback_payload.uid == 'restricted-user', 'V1-only fallback retains the administrator-controlled Plugin UID');
+			}
+			finally {
+				if (debug_descriptor) Object.defineProperty(Object.prototype, 'debug_sudo', debug_descriptor);
+				else delete Object.prototype.debug_sudo;
+				if (uid_descriptor) Object.defineProperty(Object.prototype, 'uid', uid_descriptor);
+				else delete Object.prototype.uid;
+				if (gid_descriptor) Object.defineProperty(Object.prototype, 'gid', gid_descriptor);
+				else delete Object.prototype.gid;
+			}
+
+			test.done();
+		},
+
+		function testMixedVersionJobDispatchHandshake(test) {
+			var make_socket = function(id) {
+				var handlers = Object.create(null);
+				var outbound = [];
+				return {
+					id: id,
+					request: { connection: { remoteAddress: '127.0.0.1' } },
+					client: { conn: { remoteAddress: '127.0.0.1' } },
+					handlers: handlers,
+					outbound: outbound,
+					on: function(name, handler) { handlers[name] = handler; },
+					emit: function(name, data) { outbound.push({ name: name, data: data }); },
+					disconnect: function() {}
+				};
+			};
+
+			var manager_hostname = 'legacy-manager.example';
+			var now = Tools.timeNow(true);
+			var token = Tools.digestHex(manager_hostname + now + server.config.get('secret_key'));
+			var legacy_socket = make_socket('unit-legacy-manager');
+			cronicle.handleNewSocket(legacy_socket);
+			legacy_socket.handlers.authenticate({
+				manager_hostname: manager_hostname,
+				now: now,
+				token: token
+			});
+			test.ok(!legacy_socket._pixl_manager, 'New worker rejected an old manager without signed-dispatch capability');
+			test.ok(legacy_socket.outbound.some(function(item) {
+				return (item.name == 'auth_failure') && item.data && item.data.description.match(/Upgrade managers before workers/);
+			}), 'Worker returned an explicit fail-closed rolling-order error');
+			legacy_socket.handlers.disconnect();
+
+			var v1_socket = make_socket('unit-v1-manager');
+			cronicle.handleNewSocket(v1_socket);
+			v1_socket.handlers.authenticate({
+				manager_hostname: manager_hostname,
+				now: now,
+				token: token,
+				job_dispatch_capabilities: { signed_job_run_as_v1: 1 }
+			});
+			test.ok(!v1_socket._pixl_manager, 'New worker rejected a v1-only manager without full-payload signing');
+			test.ok(v1_socket.outbound.some(function(item) {
+				return (item.name == 'auth_failure') && item.data && item.data.description.match(/Upgrade managers before workers/);
+			}), 'V1-only manager received the same fail-closed rolling-order error');
+			v1_socket.handlers.disconnect();
+
+			var original_multi = cronicle.multi;
+			var original_goworker = cronicle.goworker;
+			var original_check_eligibility = cronicle.checkmanagerEligibility;
+			var ack = null;
+			var current_socket = make_socket('unit-current-manager');
+			cronicle.multi = { worker: true, manager: false };
+			cronicle.goworker = function() {};
+			cronicle.checkmanagerEligibility = function() {};
+			try {
+				cronicle.handleNewSocket(current_socket);
+				current_socket.handlers.authenticate({
+					manager_hostname: server.hostname,
+					now: now,
+					token: Tools.digestHex(server.hostname + now + server.config.get('secret_key')),
+					job_dispatch_capabilities: cronicle.getJobDispatchCapabilities()
+				}, function(response) { ack = response; });
+				test.ok(current_socket._pixl_manager, 'New worker authenticated a capability-advertising manager');
+				test.ok(ack && !ack.code && cronicle.supportsSignedJobDispatch(ack.job_dispatch_capabilities), 'Worker acknowledged the exact signed-dispatch capability');
+				test.ok(ack && cronicle.isValidJobDispatchSession(ack.job_dispatch_session), 'Worker issued a fresh replay-bound dispatch session');
+				current_socket.handlers.disconnect();
+			}
+			finally {
+				cronicle.multi = original_multi;
+				cronicle.goworker = original_goworker;
+				cronicle.checkmanagerEligibility = original_check_eligibility;
+			}
+
+			var worker = { socket: current_socket };
+			cronicle.resetWorkerJobDispatchNegotiation(worker);
+			test.ok(worker.job_dispatch_ready === false, 'Manager gates a worker while capability negotiation is pending');
+			test.ok(cronicle.completeWorkerJobDispatchNegotiation(
+				worker, current_socket, cronicle.getJobDispatchCapabilities(), ack.job_dispatch_session
+			), 'Manager accepted the current socket capability ACK');
+			test.ok(worker.job_dispatch_ready && cronicle.supportsSignedJobDispatch(worker.job_dispatch_capabilities), 'Manager enabled signed dispatch after ACK');
+			test.ok(worker.job_dispatch_session === ack.job_dispatch_session && worker.job_dispatch_sequence === 0, 'Manager bound sequence zero to the negotiated socket session');
+			var stale_socket = {};
+			test.ok(!cronicle.completeWorkerJobDispatchNegotiation(worker, stale_socket, null, null), 'Stale socket could not downgrade negotiated capabilities');
+
+			var invalid_session_worker = { socket: current_socket };
+			cronicle.resetWorkerJobDispatchNegotiation(invalid_session_worker);
+			test.ok(!cronicle.completeWorkerJobDispatchNegotiation(
+				invalid_session_worker, current_socket, cronicle.getJobDispatchCapabilities(), 'invalid'
+			), 'Manager rejected a malformed signed-dispatch session');
+			test.ok(invalid_session_worker.job_dispatch_ready === false, 'Malformed session kept the worker dispatch gate closed');
+
+			worker = { socket: current_socket };
+			cronicle.resetWorkerJobDispatchNegotiation(worker);
+			test.ok(cronicle.completeWorkerJobDispatchNegotiation(
+				worker, current_socket, { signed_job_run_as_v1: 1 }, null
+			), 'Manager treats a v1-only worker as legacy because v1 does not bind the payload');
+			test.ok(worker.job_dispatch_ready && !cronicle.supportsSignedJobDispatch(worker.job_dispatch_capabilities), 'V1-only worker was enabled only in clean Plugin-identity mode');
+
+			worker = { socket: current_socket };
+			cronicle.resetWorkerJobDispatchNegotiation(worker);
+			test.ok(cronicle.completeWorkerJobDispatchNegotiation(worker, current_socket, null, null), 'Manager completed bounded negotiation for an old worker');
+			test.ok(worker.job_dispatch_ready && !cronicle.supportsSignedJobDispatch(worker.job_dispatch_capabilities), 'Old worker was enabled only in legacy Plugin-identity mode');
+			test.done();
+		},
+
+		function testDebugSudoAuthorizationIsNotPersistedInEventQueue(test) {
+			var event_id = 'unitdebugsudoqueue';
+			var list_path = 'global/event_queue/' + event_id;
+			var original_launch_job = cronicle.launchJob;
+			var initial_options = null;
+			cronicle.launchJob = function(event, callback, options) {
+				initial_options = options;
+				callback(new Error('Unit test launch deferral'));
+			};
+
+			cronicle.launchOrQueueJob({
+				id: event_id,
+				queue: 1,
+				debug_sudo: 1
+			}, function(err, jobs) {
+				cronicle.launchJob = original_launch_job;
+				test.ok(!err, 'Failed launch was queued');
+				test.ok(!!jobs && (jobs.length == 0), 'Queued launch returned the zero-job response');
+				test.ok(initial_options && initial_options.debug_sudo, 'Initial launch received trusted debug_sudo authorization');
+
+				async.retry({ times: 20, interval: 10 }, function(callback) {
+					storage.listGet(list_path, 0, 1, function(queue_err, events) {
+						if (queue_err || !events || !events[0]) return callback(queue_err || new Error('Queue item not ready'));
+						callback(null, events[0]);
+					});
+				}, function(queue_err, queued_event) {
+					test.ok(!queue_err && !!queued_event, 'Persistent event queue item was stored');
+					test.ok(queued_event && !Object.prototype.hasOwnProperty.call(queued_event, 'debug_sudo'), 'Persistent event queue omitted debug_sudo authorization');
+					test.ok(queued_event && !Object.prototype.hasOwnProperty.call(queued_event, '_cronicle_run_as'), 'Persistent event queue omitted signed dispatch context');
+					delete cronicle.eventQueue[event_id];
+					storage.listDelete(list_path, true, function() { test.done(); });
+				});
+			}, { debug_sudo: true });
+		},
+
 		function testJobLogTransferBoundary(test) {
 			var outside_log = path.join(os.tmpdir(), 'cronicle-edge-unit-outside-' + process.pid + '.log');
 			var traversal_id = '../cronicle-edge-unit-outside-' + process.pid;
@@ -1169,7 +1681,7 @@ module.exports = {
 		function testAPICreatePlugin(test) {
 			// test app/create_plugin api
 			var self = this;
-			var params = {"params":[{"type":"textarea","id":"script","title":"Script Source","rows":10,"value":"#!/bin/sh\n\n# Enter your shell script code here"}],"title":"Copy of Shell Script","command":"bin/shell-plugin.js","enabled":1,"session_id":session_id};
+			var params = {"params":[{"type":"textarea","id":"script","title":"Script Source","rows":10,"value":"#!/bin/sh\n\n# Enter your shell script code here"}],"title":"Copy of Shell Script","command":"bin/shell-plugin.js","enabled":1,"uid":0,"gid":"0","session_id":session_id};
 			
 			request.json( api_url + '/app/create_plugin', params, function(err, resp, data) {
 				
@@ -1188,6 +1700,8 @@ module.exports = {
 					test.ok( !!plugin, "Data record record is non-null" );
 					test.ok( plugin.username == "admin", "Username is correct" );
 					test.ok( plugin.created > 0, "Record creation date is non-zero" );
+					test.ok( plugin.uid === 0, "Numeric UID zero was stored" );
+					test.ok( plugin.gid === '0', "String GID zero was stored without losing its type" );
 					
 					test.done();
 				} );
@@ -1199,7 +1713,7 @@ module.exports = {
 		function testAPIUpdatePlugin(test) {
 			// test app/update_plugin api
 			var self = this;
-			var params = {"id":this.plugin_id, "title":"Updated Plugin Title","session_id":session_id};
+			var params = {"id":this.plugin_id, "title":"Updated Plugin Title","uid":"0","gid":0,"session_id":session_id};
 			
 			request.json( api_url + '/app/update_plugin', params, function(err, resp, data) {
 				
@@ -1215,6 +1729,8 @@ module.exports = {
 					test.ok( plugin.username == "admin", "Username is correct" );
 					test.ok( plugin.created > 0, "Record creation date is non-zero" );
 					test.ok( plugin.title == "Updated Plugin Title", "Title was updated correctly" );
+					test.ok( plugin.uid === '0', "String UID zero was accepted on update" );
+					test.ok( plugin.gid === 0, "Numeric GID zero was accepted on update" );
 					
 					test.done();
 				} );
@@ -1626,6 +2142,7 @@ module.exports = {
 				"gid": 0,
 				"cwd": "/tmp",
 				"env": { "PATH": "/tmp" },
+				"debug_sudo": 1,
 				"session_id": session_id
 			};
 			
@@ -1650,6 +2167,7 @@ module.exports = {
 					test.ok( !('gid' in event), "Event-level gid was not stored" );
 					test.ok( !('cwd' in event), "Event-level cwd was not stored" );
 					test.ok( !('env' in event), "Event-level env was not stored" );
+					test.ok( !('debug_sudo' in event), "Event-level debug_sudo authorization was not stored" );
 					
 					test.done();
 				} );
@@ -1664,6 +2182,7 @@ module.exports = {
 			var params = {
 				"id": this.event_id,
 				"title": "Updated Event Title",
+				"debug_sudo": 1,
 				"session_id": session_id
 			};
 			
@@ -1681,10 +2200,113 @@ module.exports = {
 					test.ok( event.username == "admin", "Username is correct" );
 					test.ok( event.created > 0, "Record creation date is non-zero" );
 					test.ok( event.title == "Updated Event Title", "New title is correct" );
+					test.ok( !('debug_sudo' in event), "Event update did not persist debug_sudo authorization" );
 					
 					test.done();
 				} );
 			} );
+		},
+
+		function testNonAdminCannotPersistOrLaunchDebugSudo(test) {
+			var key_record = {
+				id: 'unitnonadmin',
+				key: 'unitnonadminkey',
+				title: 'Unit Non-Admin',
+				username: 'unit-non-admin',
+				active: 1,
+				privileges: {
+					admin: 0,
+					create_events: 1,
+					edit_events: 1,
+					run_events: 1
+				}
+			};
+			var event_id = 'unitdebugsudo';
+			var original_launch_local_job = cronicle.launchLocalJob;
+			var captured_job = null;
+
+			async.series([
+				function(callback) {
+					storage.listPush('global/api_keys', key_record, callback);
+				},
+				function(callback) {
+					storage.listFindUpdate('global/plugins', { id: 'shellplug' }, {
+						uid: 'trusted-plugin-user',
+						gid: 'trusted-plugin-group'
+					}, callback);
+				},
+				function(callback) {
+					request.json(api_url + '/app/create_event', {
+						id: event_id,
+						title: 'Non-Admin Debug Sudo Regression',
+						enabled: 1,
+						category: 'general',
+						target: 'maingrp',
+						plugin: 'shellplug',
+						params: { script: testScript },
+						debug_sudo: 1,
+						api_key: key_record.key
+					}, function(err, resp, data) {
+						test.ok(!err, 'Non-admin create_event request completed');
+						test.ok(resp && (resp.statusCode == 200), 'Non-admin create_event returned HTTP 200');
+						test.ok(data && (data.code == 0), 'Non-admin with create privilege created the event');
+						storage.listFind('global/schedule', { id: event_id }, function(find_err, event) {
+							test.ok(!find_err && !!event, 'Created non-admin event was stored');
+							test.ok(event && !Object.prototype.hasOwnProperty.call(event, 'debug_sudo'), 'Non-admin create_event did not persist debug_sudo');
+							callback(find_err || (!event ? new Error('Event was not stored') : null));
+						});
+					});
+				},
+				function(callback) {
+					request.json(api_url + '/app/update_event', {
+						id: event_id,
+						debug_sudo: 1,
+						api_key: key_record.key
+					}, function(err, resp, data) {
+						test.ok(!err, 'Non-admin update_event request completed');
+						test.ok(resp && (resp.statusCode == 200), 'Non-admin update_event returned HTTP 200');
+						test.ok(data && (data.code == 0), 'Non-admin with edit privilege updated the event');
+						storage.listFind('global/schedule', { id: event_id }, function(find_err, event) {
+							test.ok(!find_err && !!event, 'Updated non-admin event remained stored');
+							test.ok(event && !Object.prototype.hasOwnProperty.call(event, 'debug_sudo'), 'Non-admin update_event did not persist debug_sudo');
+							callback(find_err || (!event ? new Error('Event disappeared') : null));
+						});
+					});
+				},
+				function(callback) {
+					cronicle.launchLocalJob = function(job) { captured_job = job; };
+					request.json(api_url + '/app/run_event', {
+						id: event_id,
+						debug_sudo: 1,
+						api_key: key_record.key
+					}, function(err, resp, data) {
+						cronicle.launchLocalJob = original_launch_local_job;
+						test.ok(!err, 'Non-admin run_event request completed');
+						test.ok(resp && (resp.statusCode == 200), 'Non-admin run_event returned HTTP 200');
+						test.ok(data && (data.code == 0), 'Non-admin with run privilege launched the event');
+						test.ok(!!captured_job, 'Captured the non-admin launched job');
+						test.ok(captured_job && (captured_job.uid == 'trusted-plugin-user'), 'Non-admin launch retained Plugin UID');
+						test.ok(captured_job && !Object.prototype.hasOwnProperty.call(captured_job, 'debug_sudo'), 'Non-admin launch had no debug_sudo marker');
+						callback(err);
+					});
+				}
+			], function(err) {
+				cronicle.launchLocalJob = original_launch_local_job;
+				async.parallel([
+					function(callback) {
+						storage.listFindDelete('global/schedule', { id: event_id }, function() { callback(); });
+					},
+					function(callback) {
+						storage.listFindDelete('global/api_keys', { id: key_record.id }, function() { callback(); });
+					},
+					function(callback) {
+						storage.listFindUpdate('global/plugins', { id: 'shellplug' }, { uid: '', gid: '' }, function() { callback(); });
+					}
+				], function() {
+					test.ok(!err, 'Non-admin debug_sudo lifecycle regression completed');
+					test.done();
+				});
+			});
 		},
 		
 		// app/get_schedule
@@ -2260,7 +2882,8 @@ module.exports = {
 			var params = {
 				"session_id": session_id, 
 				id: this.event_id,
-				notify_fail: 'test@test.com'
+				notify_fail: 'test@test.com',
+				debug_sudo: 1
 			};
 			
 			request.json( api_url + '/app/run_event', params, function(err, resp, data) {
@@ -2293,11 +2916,13 @@ module.exports = {
 			var queuePath = 'global/event_queue/' + this.event_id;
 			var originalEvent = null;
 			var launchedJob = null;
+			var launchOptions = null;
 			var allowedNow = Tools.timeNow(true) - 60;
 			var finished = false;
 
-			function captureLaunch(job, callback) {
+			function captureLaunch(job, callback, options) {
 				launchedJob = job;
+				launchOptions = options;
 				callback(null, []);
 			}
 
@@ -2328,9 +2953,11 @@ module.exports = {
 			function runEditorChecks() {
 				cronicle.launchOrQueueJob = captureLaunch;
 				launchedJob = null;
+				launchOptions = null;
 				request.json(api_url + '/app/run_event', {
 					id: self.event_id,
 					session_id: session_id,
+					debug_sudo: 1,
 					chain_data: { args: ['editor-injected'] },
 					memo: 'args:editor-injected',
 					source: 'editor-injected',
@@ -2352,6 +2979,8 @@ module.exports = {
 					test.ok(launchedJob && !('source_event' in launchedJob), "Editor source event override was ignored");
 					test.ok(launchedJob && !('source_log' in launchedJob), "Editor source log override was ignored");
 					test.ok(launchedJob && !('api_key' in launchedJob), "Editor API key override was ignored");
+					test.ok(launchedJob && !Object.prototype.hasOwnProperty.call(launchedJob, 'debug_sudo'), "Admin request marker was not copied into the event job");
+					test.ok(launchOptions && launchOptions.debug_sudo === true, "Admin debug_sudo request became a trusted one-shot launch option");
 
 					launchedJob = null;
 					request.json(api_url + '/app/run_event', {
@@ -2435,6 +3064,7 @@ module.exports = {
 						.digest('hex');
 
 					cronicle.launchOrQueueJob = captureLaunch;
+					launchOptions = null;
 					request.json(api_url + '/app/run_event', {
 						id: self.event_id,
 						token: token,
@@ -2473,7 +3103,8 @@ module.exports = {
 						test.ok(launchedJob && !launchedJob.files, "Event token file override was ignored");
 						test.ok(launchedJob && (!launchedJob.params || launchedJob.params.script != 'echo attacker-override'), "Event token plugin parameters were ignored");
 						test.ok(launchedJob && launchedJob.notify_fail != 'attacker@example.com', "Event token notification override was ignored");
-						test.ok(launchedJob && !launchedJob.debug_sudo, "Event token debug_sudo override was ignored");
+						test.ok(launchedJob && !Object.prototype.hasOwnProperty.call(launchedJob, 'debug_sudo'), "Event token debug_sudo override was ignored");
+						test.ok(launchOptions && launchOptions.debug_sudo === false, "Event token received no trusted debug_sudo launch option");
 						test.ok(launchedJob && launchedJob.repeat === originalEvent.repeat, "Positive repeat override was ignored");
 						test.ok(launchedJob && launchedJob.enabled === originalEvent.enabled, "Enabled override was ignored");
 						test.ok(launchedJob && launchedJob.source == 'Event Token', "Server-derived source was preserved");
@@ -2512,6 +3143,11 @@ module.exports = {
 			test.ok( job.progress > 0, "Job has positive progress" );
 			test.ok( job.notify_fail == "test@test.com", "Our notify_fail override made it in" );
 			test.ok( !!job.pid, "Job has a PID" );
+			test.ok( !Object.prototype.hasOwnProperty.call(job, 'debug_sudo'), "Active job contains no debug_sudo marker" );
+			test.ok( !Object.prototype.hasOwnProperty.call(job, '_cronicle_run_as'), "Active job contains no signed dispatch context" );
+			var recovery_job = JSON.parse(fs.readFileSync(job.log_file.replace(/\.log$/, '.json'), 'utf8'));
+			test.ok( !Object.prototype.hasOwnProperty.call(recovery_job, 'debug_sudo'), "Crash-recovery job file contains no debug_sudo marker" );
+			test.ok( !Object.prototype.hasOwnProperty.call(recovery_job, '_cronicle_run_as'), "Crash-recovery job file contains no signed dispatch context" );
 			
 			// try to ping pid
 			var ping = false;
@@ -2812,6 +3448,8 @@ module.exports = {
 					test.ok( job.code == 0, "Job is not marked as an error" );
 					test.ok( !!job.perf, "Job has perf metrics" );
 					test.ok( !!job.pid, "Job record still has a pid" );
+					test.ok( !Object.prototype.hasOwnProperty.call(job, 'debug_sudo'), "Completed job record contains no debug_sudo marker" );
+					test.ok( !Object.prototype.hasOwnProperty.call(job, '_cronicle_run_as'), "Completed job record contains no signed dispatch context" );
 					
 					// job pid should be dead at this point
 					var ping = false;
@@ -3075,45 +3713,70 @@ module.exports = {
 			} );
 		},
 
-		function testLaunchJobStripsEventLaunchContext(test) {
-			// make sure event/API payloads cannot override admin-only Plugin launch options
-			var orig_launch_local_job = cronicle.launchLocalJob;
+		function testLaunchJobUsesOnlyPluginLaunchContext(test) {
+			// Event/API payloads cannot override admin-only Plugin launch options,
+			// while trusted Plugin UID/GID survive manager-to-worker serialization.
+			var self = this;
+			var original_launch_local_job = cronicle.launchLocalJob;
 			var captured_job = null;
-			
-			storage.listFind( 'global/schedule', { id: this.event_id }, function(err, event) {
-				test.ok( !err, "No error locating event in schedule" );
-				test.ok( !!event, "Found event in schedule" );
-				
-				var job = Tools.copyHash( event, true );
-				
-				// These are intentionally hostile event-level overrides.  The
-				// trusted Plugin record should be the only source for these fields.
-				job.uid = 0;
-				job.gid = 0;
-				job.cwd = '/tmp';
-				job.env = { PATH: '/tmp' };
-				job.web_hook = '';
-				
-				cronicle.launchLocalJob = function(job) {
-					captured_job = job;
-				};
-				
-				cronicle.launchJob( job, function(err, jobs) {
-					cronicle.launchLocalJob = orig_launch_local_job;
-					
-					test.ok( !err, "No error launching job" );
-					test.ok( !!jobs, "Got array of launched jobs" );
-					test.ok( jobs.length == 1, "Launched exactly one job" );
-					test.ok( !!captured_job, "Captured local launch job" );
-					test.ok( !('uid' in captured_job), "Event-level uid was stripped from job" );
-					test.ok( !('gid' in captured_job), "Event-level gid was stripped from job" );
-					test.ok( !('cwd' in captured_job), "Event-level cwd was stripped from job" );
-					// don't check env, since this fork adding extra env values with base urls etc.
-					// test.ok( !('env' in captured_job), "Event-level env was stripped from job" );
-					
-					test.done();
-				} );
-			} );
+
+			storage.listFindUpdate('global/plugins', { id: 'shellplug' }, {
+				uid: 'trusted-plugin-user',
+				gid: 'trusted-plugin-group'
+			}, function(plugin_err) {
+				test.ok(!plugin_err, 'Trusted Plugin launch identity was stored');
+
+				storage.listFind('global/schedule', { id: self.event_id }, function(err, event) {
+					test.ok(!err, 'No error locating event in schedule');
+					test.ok(!!event, 'Found event in schedule');
+
+					var hostile_job = Tools.copyHash(event, true);
+					hostile_job.uid = 0;
+					hostile_job.gid = 0;
+					hostile_job.cwd = '/tmp';
+					hostile_job.env = { PATH: '/tmp' };
+					hostile_job.debug_sudo = 1;
+					hostile_job.web_hook = '';
+
+					cronicle.launchLocalJob = function(job, launch_options) {
+						cronicle.consumeJobDispatchContext(job, launch_options, 'linux', 801);
+						captured_job = job;
+					};
+
+					cronicle.launchJob(hostile_job, function(launch_err, jobs) {
+						var untrusted_job = captured_job;
+						test.ok(!launch_err, 'Untrusted launch-context regression completed');
+						test.ok(!!jobs && (jobs.length == 1), 'Untrusted launch produced one job');
+						test.ok(!!untrusted_job, 'Captured local launch job');
+						test.ok(untrusted_job && (untrusted_job.uid == 'trusted-plugin-user'), 'Plugin UID replaced the event-level UID');
+						test.ok(untrusted_job && (untrusted_job.gid == 'trusted-plugin-group'), 'Plugin GID replaced the event-level GID');
+						test.ok(untrusted_job && !Object.prototype.hasOwnProperty.call(untrusted_job, 'cwd'), 'Event-level cwd was stripped from job');
+						test.ok(untrusted_job && untrusted_job.env.PATH != '/tmp', 'Event-level env was replaced by trusted launch context');
+						test.ok(untrusted_job && !Object.prototype.hasOwnProperty.call(untrusted_job, 'debug_sudo'), 'Untrusted event-level debug_sudo was stripped');
+						test.ok(untrusted_job && !Object.prototype.hasOwnProperty.call(untrusted_job, '_cronicle_run_as'), 'Local manager job had no transport context');
+
+						var worker_options = cronicle.getChildRunAsOptions(untrusted_job, 'linux', 701, 702);
+						test.ok(worker_options.uid == 'trusted-plugin-user', 'Unix worker received the serialized Plugin UID');
+						test.ok(worker_options.gid == 'trusted-plugin-group', 'Unix worker received the serialized Plugin GID');
+
+						captured_job = null;
+						cronicle.launchJob(Tools.copyHash(event, true), function(admin_err, admin_jobs) {
+							var admin_job = captured_job;
+							cronicle.launchLocalJob = original_launch_local_job;
+							storage.listFindUpdate('global/plugins', { id: 'shellplug' }, { uid: '', gid: '' }, function(restore_err) {
+								test.ok(!restore_err, 'Test Plugin launch identity was restored');
+								test.ok(!admin_err, 'Trusted admin debug launch succeeded');
+								test.ok(!!admin_jobs && (admin_jobs.length == 1), 'Trusted admin launch produced one job');
+								test.ok(!!admin_job && (admin_job.uid === 801), 'Trusted debug launch used the executing worker service UID');
+								test.ok(admin_job && (admin_job.gid == 'trusted-plugin-group'), 'Trusted debug launch retained Plugin GID');
+								test.ok(admin_job && !Object.prototype.hasOwnProperty.call(admin_job, 'debug_sudo'), 'Worker removed the one-shot marker before active state');
+								test.ok(admin_job && !Object.prototype.hasOwnProperty.call(admin_job, '_cronicle_run_as'), 'Local debug launch never entered persistent transport context');
+								test.done();
+							});
+						}, { debug_sudo: true });
+					});
+				});
+			});
 		},
 		
 		

--- a/lib/test.js
+++ b/lib/test.js
@@ -3,6 +3,7 @@
 // Released under the MIT License
 
 var cp = require('child_process');
+var crypto = require('crypto');
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
@@ -1769,6 +1770,223 @@ module.exports = {
 				}, 1000 * 5 );
 				
 			} );
+		},
+
+		function testRunEventRejectsUnprivilegedEventOverrides(test) {
+			var self = this;
+			var salt = 'unit_test_token_salt';
+			var oldLaunch = cronicle.launchOrQueueJob;
+			var oldLaunchJob = cronicle.launchJob;
+			var oldEventQueueCount = cronicle.eventQueue[this.event_id];
+			var queuePath = 'global/event_queue/' + this.event_id;
+			var originalEvent = null;
+			var launchedJob = null;
+			var allowedNow = Tools.timeNow(true) - 60;
+			var finished = false;
+
+			function captureLaunch(job, callback) {
+				launchedJob = job;
+				callback(null, []);
+			}
+
+			function restoreEventQueueCount() {
+				if (typeof(oldEventQueueCount) == 'undefined') delete cronicle.eventQueue[self.event_id];
+				else cronicle.eventQueue[self.event_id] = oldEventQueueCount;
+			}
+
+			function finish() {
+				if (finished) return;
+				finished = true;
+				cronicle.launchOrQueueJob = oldLaunch;
+				cronicle.launchJob = oldLaunchJob;
+				restoreEventQueueCount();
+				storage.listDelete(queuePath, true, function() {
+					var restore = {
+						salt: originalEvent && originalEvent.salt ? originalEvent.salt : '',
+						queue: originalEvent && originalEvent.queue ? originalEvent.queue : false,
+						queue_max: originalEvent && originalEvent.queue_max ? originalEvent.queue_max : 0
+					};
+					storage.listFindUpdate('global/schedule', { id: self.event_id }, restore, function(err) {
+						test.ok(!err, "Event token and queue fixtures were restored");
+						test.done();
+					});
+				});
+			}
+
+			function runEditorChecks() {
+				cronicle.launchOrQueueJob = captureLaunch;
+				launchedJob = null;
+				request.json(api_url + '/app/run_event', {
+					id: self.event_id,
+					session_id: session_id,
+					chain_data: { args: ['editor-injected'] },
+					memo: 'args:editor-injected',
+					source: 'editor-injected',
+					source_id: 'editor-injected',
+					source_event: 'editor-injected',
+					source_log: 'javascript:alert(1)',
+					username: 'editor-injected',
+					api_key: 'editor_injected',
+					params: { script: 'echo editor-override' }
+				}, function(err, resp, data) {
+					test.ok(!err, "Editor request succeeded");
+					test.ok(data.code == 0, "Editor launched the configured event");
+					test.ok(launchedJob && !('chain_data' in launchedJob), "Editor chain data was ignored");
+					test.ok(launchedJob && !('memo' in launchedJob), "Editor memo was ignored");
+					test.ok(launchedJob && launchedJob.params && launchedJob.params.script == 'echo editor-override', "Editor plugin parameters remain customizable");
+					test.ok(launchedJob && launchedJob.source == 'Manual (admin)', "Editor source was derived by the server");
+					test.ok(launchedJob && launchedJob.username == 'admin', "Editor username was derived by the server");
+					test.ok(launchedJob && !('source_id' in launchedJob), "Editor source ID override was ignored");
+					test.ok(launchedJob && !('source_event' in launchedJob), "Editor source event override was ignored");
+					test.ok(launchedJob && !('source_log' in launchedJob), "Editor source log override was ignored");
+					test.ok(launchedJob && !('api_key' in launchedJob), "Editor API key override was ignored");
+
+					launchedJob = null;
+					request.json(api_url + '/app/run_event', {
+						id: self.event_id,
+						session_id: session_id,
+						'__proto__/polluted': 'yes'
+					}, function(err, resp, data) {
+						test.ok(!err, "Malformed editor nested request returned a response");
+						test.ok(data.code == 'api', "Prototype-chain nested request was rejected");
+						test.ok(!launchedJob, "Rejected nested request did not launch a job");
+						test.ok(!({}).polluted, "Editor nested input did not modify Object.prototype");
+
+						launchedJob = null;
+						var prototypePayload = JSON.parse('{"id":"' + self.event_id + '","session_id":"' + session_id + '","__proto__":{"target":"attacker-target","plugin":"attacker_plugin","debug_sudo":1}}');
+						request.json(api_url + '/app/run_event', prototypePayload, function(err, resp, data) {
+							test.ok(!err, "Raw prototype payload returned a response");
+							test.ok(data.code == 'api', "Raw prototype-control key was rejected");
+							test.ok(!launchedJob, "Raw prototype payload did not launch a job");
+							test.ok(!({}).polluted, "Raw prototype payload did not modify Object.prototype");
+							finish();
+						});
+					});
+				});
+			}
+
+			function runDurableQueueCheck(token) {
+				storage.listDelete(queuePath, true, function() {
+					storage.listFindUpdate('global/schedule', { id: self.event_id }, { queue: 1, queue_max: 5 }, function(err) {
+						test.ok(!err, "Durable event queue fixture was enabled");
+						if (err) return runEditorChecks();
+
+						cronicle.launchOrQueueJob = oldLaunch;
+						cronicle.launchJob = function(job, callback) {
+							callback(new Error('Intentional capacity failure for durable queue regression'));
+						};
+
+						request.json(api_url + '/app/run_event', {
+							id: self.event_id,
+							token: token,
+							repeat: -1,
+							enabled: false
+						}, function(err, resp, data) {
+							cronicle.launchJob = oldLaunchJob;
+							test.ok(!err, "Queued event-token request succeeded");
+							test.ok(data && data.code == 0, "Launch failure was converted into an event queue entry");
+							test.ok(data && data.ids && data.ids.length == 0 && data.queue, "Queued response reported no launched jobs");
+
+							async.retry({ times: 20, interval: 25 }, function(callback) {
+								storage.listGet(queuePath, 0, 0, function(err, items) {
+									if (!err && items && items.length) return callback(null, items);
+									callback(err || new Error('Queued record is not durable yet'));
+								});
+							}, function(queueErr, items) {
+								test.ok(!queueErr, "Launch failure persisted an event queue record");
+								var queuedEvent = items && items[0];
+								test.ok(!!queuedEvent, "Persisted event queue record was readable");
+								test.ok(queuedEvent && queuedEvent.repeat === originalEvent.repeat, "Persisted event used the configured repeat value");
+								test.ok(queuedEvent && queuedEvent.repeat !== -1, "Caller repeat override was not persisted");
+								test.ok(queuedEvent && queuedEvent.enabled === originalEvent.enabled, "Caller enabled override was not persisted");
+
+								storage.listDelete(queuePath, true, function() {
+									restoreEventQueueCount();
+									runEditorChecks();
+								});
+							});
+						});
+					});
+				});
+			}
+
+			storage.listFind('global/schedule', { id: self.event_id }, function(err, event) {
+				test.ok(!err && !!event, "Original event fixture was loaded");
+				if (err || !event) return finish();
+				originalEvent = Tools.copyHash(event, true);
+
+				storage.listFindUpdate('global/schedule', { id: self.event_id }, { salt: salt }, function(err) {
+					test.ok(!err, "Event token was enabled");
+					if (err) return finish();
+					var token = crypto.createHmac('sha1', server.config.get('secret_key'))
+						.update(self.event_id + salt)
+						.digest('hex');
+
+					cronicle.launchOrQueueJob = captureLaunch;
+					request.json(api_url + '/app/run_event', {
+						id: self.event_id,
+						token: token,
+						now: allowedNow,
+						arg: 'allowed-argument',
+						args: 'allowed-argument',
+						post_data: { allowed: true },
+						repeat: 1,
+						enabled: false,
+						chain_data: { args: ['injected'] },
+						memo: 'args:injected',
+						plugin: 'attacker_plugin',
+						workflow: [{ id: 'attacker_event' }],
+						target: 'attacker-target',
+						chain: 'attacker_event',
+						chain_error: 'attacker_event',
+						options: { wf_start_from_step: 99 },
+						files: [{ name: 'payload.sh', content: 'malicious' }],
+						params: { script: 'echo attacker-override' },
+						notify_fail: 'attacker@example.com',
+						debug_sudo: 1,
+						source: 'attacker',
+						source_id: 'attacker',
+						'__proto__/polluted': 'yes'
+					}, function(err, resp, data) {
+						test.ok(!err, "Event token request succeeded");
+						test.ok(data.code == 0, "Event token launched the configured event");
+						test.ok(launchedJob && !('chain_data' in launchedJob), "Event token chain data was ignored");
+						test.ok(launchedJob && !('memo' in launchedJob), "Event token memo was ignored");
+						test.ok(launchedJob && launchedJob.plugin != 'attacker_plugin', "Event token plugin override was ignored");
+						test.ok(launchedJob && launchedJob.target != 'attacker-target', "Event token target override was ignored");
+						test.ok(launchedJob && launchedJob.chain != 'attacker_event', "Event token success-chain override was ignored");
+						test.ok(launchedJob && launchedJob.chain_error != 'attacker_event', "Event token error-chain override was ignored");
+						test.ok(launchedJob && !launchedJob.workflow, "Event token workflow override was ignored");
+						test.ok(launchedJob && !launchedJob.options, "Event token workflow options were ignored");
+						test.ok(launchedJob && !launchedJob.files, "Event token file override was ignored");
+						test.ok(launchedJob && (!launchedJob.params || launchedJob.params.script != 'echo attacker-override'), "Event token plugin parameters were ignored");
+						test.ok(launchedJob && launchedJob.notify_fail != 'attacker@example.com', "Event token notification override was ignored");
+						test.ok(launchedJob && !launchedJob.debug_sudo, "Event token debug_sudo override was ignored");
+						test.ok(launchedJob && launchedJob.repeat === originalEvent.repeat, "Positive repeat override was ignored");
+						test.ok(launchedJob && launchedJob.enabled === originalEvent.enabled, "Enabled override was ignored");
+						test.ok(launchedJob && launchedJob.source == 'Event Token', "Server-derived source was preserved");
+						test.ok(launchedJob && launchedJob.now == allowedNow, "Event token current-time override remained available");
+						test.ok(launchedJob && launchedJob.arg == 'allowed-argument', "Event token job argument remained available");
+						test.ok(launchedJob && launchedJob.args == 'allowed-argument', "Event token args alias remained available");
+						test.ok(launchedJob && launchedJob.post_data && launchedJob.post_data.allowed, "Event token POST data remained available");
+						test.ok(!({}).polluted, "Run-only nested input did not modify Object.prototype");
+
+						launchedJob = null;
+						request.json(api_url + '/app/run_event', {
+							id: self.event_id,
+							token: token,
+							repeat: -1,
+							enabled: false
+						}, function(err, resp, data) {
+							test.ok(!err, "Negative repeat event-token request succeeded");
+							test.ok(data && data.code == 0, "Negative repeat did not alter launch authorization");
+							test.ok(launchedJob && launchedJob.repeat === originalEvent.repeat, "Negative repeat override was ignored");
+							test.ok(launchedJob && launchedJob.enabled === originalEvent.enabled, "Negative repeat request could not disable the job");
+							runDurableQueueCheck(token);
+						});
+					});
+				});
+			});
 		},
 		
 		function testJobInProgress(test) {


### PR DESCRIPTION
## Summary

This change preserves administrator-controlled Plugin UID/GID across manager-to-worker dispatch and makes the one-shot admin `debug_sudo` path safe across mixed-version clusters.

It:

- serializes Plugin UID/GID independently of the manager operating system;
- preserves numeric `0` and string `"0"` without truthiness fallbacks;
- removes trust in legacy top-level `job.debug_sudo`;
- introduces a versioned, HMAC-SHA256-authenticated run-as dispatch context;
- binds it to a canonical digest of the complete job payload, plus the job, manager, worker, socket session, sequence, mode, Plugin, UID, and GID;
- prevents replay within or across worker connections;
- consumes the context before active, pending, retry, recovery, or completed state;
- keeps capacity-queued jobs fail-closed under their configured Plugin identity.

There is no new persistent schema or durable authorization state.

## Security impact and severity

**Proposed severity: High**

The manager selected or serialized job identity, while the worker ultimately performed the Unix process spawn. A Windows manager did not serialize Plugin UID/GID because identity handling was conditional on the manager platform. A Unix worker could consequently fall back to the Cronicle service UID, which is commonly `root`. Separately, a worker could not distinguish an authorized one-shot admin `debug_sudo` request from a legacy field preserved by an older manager or job record.

An authenticated non-admin caller with `run_events` access to an affected event could therefore cause its configured Plugin command to run under the worker service identity instead of the administrator-configured restricted identity. For a shell-like or otherwise attacker-influenceable Plugin, this can become service-level or root command execution.

The highest-impact path requires:

1. an authenticated caller with applicable `run_events`, category, and group access;
2. an event using a Plugin configured with a restricted UID/GID, or a legacy job carrying `debug_sudo`;
3. a Unix worker whose Cronicle service identity is more privileged than the Plugin identity;
4. commonly, a Windows-manager-to-Unix-worker topology;
5. a Plugin whose command or parameters make the identity change security-relevant.

This is rated High rather than Critical because it is not an unauthenticated default remote compromise: the caller already needs scoped event-execution authority, the affected topology or legacy-marker condition must exist, root impact requires a root-running worker service, and useful command execution depends on the configured Plugin behavior. The impact can nevertheless reach root on an affected worker, so Medium would understate it.

## Signed dispatch boundary

New managers advertise `signed_job_run_as_v2`. A capable worker acknowledges it and returns a fresh random 256-bit dispatch-session identifier. The earlier v1 draft was never published and is intentionally rejected rather than treated as a compatibility protocol.

For every remote job sent to a v2-capable worker, the manager computes a canonical SHA-256 digest of the complete JSON-normalized wire job, excluding only the top-level `_cronicle_run_as` context. It then creates a transport-only context containing the protocol version, `plugin` or `service` mode, job ID, manager hostname, worker hostname, dispatch session, monotonically increasing sequence, payload digest, and HMAC-SHA256 signature. The signature uses the existing cluster secret with domain-separated context and the canonical JSON payload digest, so numeric and string UID/GID values cannot be confused and the authorization cannot be detached from the exact command, arguments, environment, files, workflow data, or other execution inputs.

The worker recomputes the canonical payload digest and verifies the context and sequence before `launchLocalJob`. The context cannot be rebound to another payload, job, manager, worker, or connection, and a consumed sequence cannot be replayed. Cycles, unsupported values, and other non-canonical payloads fail closed. For `service` mode, the worker materializes its own local service UID. It then removes the signed context and any legacy `debug_sudo` field before queueing, persistence, recovery, retry, or completed storage.

## Rolling upgrade order

This protocol intentionally requires a **manager-first** rolling upgrade.

1. Upgrade managers first. A new manager gates dispatch during negotiation. An old worker receives no `_cronicle_run_as` or `debug_sudo` marker, preserves Plugin UID/GID, and safely degrades an admin debug request to the Plugin identity.
2. Drain and upgrade workers. A new worker rejects authentication from an old manager that does not advertise signed dispatch. Worker-first deployment may therefore make that worker temporarily unavailable, but cannot silently elevate a job.
3. New manager and new worker negotiate a fresh session and use signed, replay-protected dispatch for every remote job.

Jobs already active, pending, retrying, or recoverable inside an old worker remain governed by that old binary until drained or completed. This PR deliberately does not rewrite old worker-owned runtime state. Operators should drain existing work and upgrade workers promptly after the manager upgrade.

## Persistent-state boundary

The authorization lifecycle is intentionally short:

1. `run_event` records an admin debug request only in an in-memory launch option.
2. The manager's canonical job contains neither `debug_sudo` nor `_cronicle_run_as`.
3. A capable remote worker receives the signed context only in a deep-copied wire payload.
4. The worker verifies and consumes it synchronously.
5. Active jobs, delayed jobs, retry jobs, recovery JSON, completed jobs, and persistent event queues contain no dispatch context or debug marker.
6. Capacity deferral drops debug authority and retries under the normal Plugin identity.

Only the negotiated session and sequence are ephemeral socket/worker connection state. They are cleared on disconnect and never written to storage.

## Dependencies and tested DAG

This change is based on the published head of [#286](https://github.com/cronicle-edge/cronicle-edge/pull/286), which includes the relevant work from [#284](https://github.com/cronicle-edge/cronicle-edge/pull/284), [#257](https://github.com/cronicle-edge/cronicle-edge/pull/257), and the corrected workflow-capability scope.

```text
upstream/main 9ebbaf3
  -> #284 12989d9
  -> #257-equivalent caa8fe7
  -> #286 78c2695
  -> this change
```

This PR should be reviewed and merged after #286, or rebased onto `main` after #286 lands.

## File scope

Exactly seven files are changed relative to #286:

- `htdocs/js/pages/admin/Plugins.js`: preserves numeric/string UID/GID, including zero.
- `lib/api.js`: strips run-as transport fields at the event persistence boundary.
- `lib/api/event.js`: converts an admin `debug_sudo` request into a one-shot launch option.
- `lib/api/plugin.js`: accepts validated numeric or string UID/GID values.
- `lib/comm.js`: negotiates capability/session/sequence, gates dispatch, and rejects failed verification.
- `lib/job.js`: handles platform-neutral Plugin identity, computes/verifies the signed payload context, and consumes worker-local run-as state.
- `lib/test.js`: adds authorization, mixed-version, replay, prototype, zero-value, queue, and lifecycle regressions.

No `lib/api/job.js` or `lib/engine.js` change is introduced by this PR relative to #286.

## Validation

The exact patch was integrated on #286 head `78c269516d3767760959b8463e0b2795e8abc3be`.

```text
Tests passed: 104 of 104
Tests failed: 0
Assertions: 910
Test suites: 2
```

`git diff --cached --check` and `node --check` passed for all changed JavaScript files.

A focused test with real Socket.IO server/client connections on random loopback ports covered:

| Manager | Worker | Result |
|---|---|---|
| old | new | authentication rejected; no launch |
| new | old | clean legacy payload; debug degrades to Plugin UID/GID |
| new | new | signed context accepted; worker-local service UID applied only after verification |
| replayed new-manager packet | new | repeated sequence rejected and connection authorization revoked |

Regression coverage also includes Windows-manager-to-Unix-worker serialization, numeric and string zero, HMAC tampering, mutation of command, working directory, parameters, environment, loader options, stdin, files, workflow and chain data, wrong job/manager/worker/session, stale ACK and reconnect state, inherited/prototype-polluted fields, non-admin create/update/run attempts, and active/pending/retry/recovery/capacity/completed lifecycles.

This change secures the run-as authorization boundary. During the short legacy-worker phase, the pre-existing plaintext cluster channel still does not provide complete payload integrity, and non-launch cluster controls retain their existing transport properties. Those broader transport concerns are outside this PR. The required manager-first order and prompt worker drain keep the corrected `debug_sudo` boundary fail-closed throughout the supported rollout.

## Provenance and review disclosure

The original finding and generated proposal [frankii91/cronicle-edge#42](https://github.com/frankii91/cronicle-edge/pull/42) came from Codex Security / Codex Ultra. It was not ported 1:1: independent review demonstrated that its top-level `job.debug_sudo` marker was unsafe across mixed versions. That design was discarded and replaced with the versioned, HMAC-bound, capability-negotiated protocol above.

Initially surfaced by Codex Security / Codex Ultra, then manually re-analyzed, corrected, regression-tested, and independently reviewed. Submitted for maintainer review.
