### PR TITLE
Fix silent SQL engine bundle failures

### DIFF
--- a/bundle
+++ b/bundle
@@ -334,8 +334,8 @@ fi
 # ----- SQL Storage Engine
 sqlDrivers=()
 sqlArgs=("--bundle" "--minify" "--platform=node" "--outdir=$dist/bin/engines")
-# exclude unused drivers
-sqlArgs+=("--external:better-sqlite3" "--external:mysql")
+# Knex references optional dialect drivers even when they are not selected.
+sqlArgs+=("--external:better-sqlite3" "--external:mysql" "--external:mariadb")
 
 if [ "$sql" = 1 ]; then
   oracle=1
@@ -384,8 +384,14 @@ if [[ ${#sqlDrivers[@]} -gt 0 ]]; then
   sqlArgs+=("engines/SQL.js")
 
   echo "      - bundling SQL Engine [${sqlDrivers[@]}]"
-  npm "${sqlInstall[@]}"
-  esbuild "${sqlArgs[@]}"
+  if ! npm "${sqlInstall[@]}"; then
+    echo "Failed to install SQL bundle dependencies" >&2
+    exit 1
+  fi
+  if ! esbuild "${sqlArgs[@]}"; then
+    echo "Failed to bundle SQL Engine" >&2
+    exit 1
+  fi
   if [ "$sqlite" = 1 ]; then
     cp -r node_modules/sqlite3/build $dist/bin/
   fi

--- a/bundle.ps1
+++ b/bundle.ps1
@@ -358,8 +358,8 @@ if ($Level) {
 
 $sqlDrivers = [System.Collections.ArrayList]::new()
 $sqlArgs = [System.Collections.ArrayList]::new(@("--bundle", "--minify", "--platform=node", "--outdir=$Path/bin/engines"))
-# exclude unused drivers
-$sqlArgs.AddRange(@("--external:better-sqlite3", "--external:mysql"))
+# Knex references optional dialect drivers even when they are not selected.
+$sqlArgs.AddRange(@("--external:better-sqlite3", "--external:mysql", "--external:mariadb"))
 
 if($SQL) { $Oracle = $MSSQL = $Mysql = $Pgsql = $true }
 
@@ -398,7 +398,13 @@ if($sqlDrivers.Count -gt 0) {
   Write-Host "     - bundling SQL Engine [$($sqlDrivers -join ",")]"
   $engines += ", SQL [$($sqlDrivers -join ",")]"
   & npm $sqlInstall
+  if($LASTEXITCODE -ne 0) {
+    throw "Failed to install SQL bundle dependencies"
+  }
   & esbuild $sqlArgs
+  if($LASTEXITCODE -ne 0) {
+    throw "Failed to bundle SQL Engine"
+  }
   if($Sqlite) {
     Copy-Item -Recurse -Force node_modules/sqlite3/build $Path/bin/
   }


### PR DESCRIPTION
## Problem

The Docker build currently reports:

```text
Could not resolve "mariadb/callback"
```

but `bundle` continues, prints `Bundle is ready`, and Docker exits successfully. The resulting image does not contain `bin/engines/SQL.js`, despite the Dockerfile explicitly requesting MySQL, PostgreSQL, and SQLite support.

Knex 3.3.0 references its optional MariaDB dialect while esbuild traverses Knex. MariaDB is not one of the SQL clients selected or documented by Cronicle's SQL engine, so that optional driver should remain external just like the already excluded `mysql` and `better-sqlite3` drivers.

## Change

- Mark the optional `mariadb` package external in both bundle implementations.
- Stop the Linux and PowerShell bundle immediately if SQL dependencies cannot be installed.
- Stop the Linux and PowerShell bundle immediately if esbuild cannot produce the SQL engine.

The selected MySQL (`mysql2`), PostgreSQL, SQLite, Oracle, and MSSQL behavior is unchanged.

## Validation

- Unmodified baseline: reproduced the `mariadb/callback` error, exit code `0`, and missing `bin/engines/SQL.js`.
- Patched bundle with Docker's `--mysql --pgsql --s3 --sqlite --tools` options: succeeded and produced the 1.4 MB SQL engine.
- Controlled negative test with an esbuild shim failing only for `engines/SQL.js`: bundle stopped with a non-zero exit and `Failed to bundle SQL Engine` instead of reporting success.
- Fresh Docker build: succeeded without the MariaDB resolution error and included the SQL engine.
- Runtime Docker smoke test: `manager --sqlite` completed setup, logged `SQL connected successfully`, started Cronicle, and returned HTTP 200.
- Full `npm test`: 92/92 passed, 375 assertions.
- `bash -n bundle` and diff checks passed.

The PowerShell path was updated symmetrically; a Windows runtime was not available for an end-to-end local execution.

This PR is independent of #289 and contains no OAuth/OIDC changes.
