### PR TITLE
Fix Plugin run-as propagation from Windows managers

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -292,11 +292,9 @@ module.exports = Class.create({
 
 					job.command = plugin.command;
 					if (plugin.cwd) job.cwd = plugin.cwd;
-					if (isUnix) {
-						if (plugin.uid) job.uid = plugin.uid;
-						if (job.debug_sudo) job.uid = process.getuid();
-						if (plugin.gid) job.gid = plugin.gid;
-					}
+					if (plugin.uid) job.uid = plugin.uid;
+					if (plugin.gid) job.gid = plugin.gid;
+					if (isUnix && job.debug_sudo) job.uid = process.getuid();
 
 					job.env = self.server.config.get('job_env') || {} 
 					let proto = 'http://'

--- a/lib/test.js
+++ b/lib/test.js
@@ -1869,6 +1869,7 @@ module.exports = {
 					});
 				});
 			});
+		},
 		function testLaunchJobPassesOneShotDebugSudoToWorker(test) {
 			var fake_hostname = 'unit-test-debug-worker';
 			var captured_job = null;

--- a/lib/test.js
+++ b/lib/test.js
@@ -1723,6 +1723,76 @@ module.exports = {
 				} );
 			} );
 		},
+
+		function testWindowsManagerDispatchesPluginRunAs(test) {
+			var os = require('os');
+			var job_module_path = require.resolve('./job.js');
+			var cached_job_module = require.cache[job_module_path];
+			var original_platform = os.platform;
+			var WindowsJob = null;
+			var fake_hostname = 'unit-test-unix-worker';
+			var captured_job = null;
+
+			try {
+				os.platform = function() { return 'win32'; };
+				delete require.cache[job_module_path];
+				WindowsJob = require('./job.js');
+			}
+			finally {
+				os.platform = original_platform;
+				delete require.cache[job_module_path];
+				if (cached_job_module) require.cache[job_module_path] = cached_job_module;
+			}
+
+			storage.listFind('global/schedule', { id: this.event_id }, function(err, event) {
+				test.ok(!err && !!event, "Found event for Windows manager dispatch test");
+				if (err || !event) return test.done();
+
+				storage.listFind('global/plugins', { id: event.plugin }, function(err, plugin) {
+					test.ok(!err && !!plugin, "Found Plugin for Windows manager dispatch test");
+					if (err || !plugin) return test.done();
+
+					var original_run_as = { uid: plugin.uid, gid: plugin.gid };
+					storage.listFindUpdate('global/plugins', { id: plugin.id }, {
+						uid: '65534',
+						gid: '65533'
+					}, function(err) {
+						test.ok(!err, "Configured Plugin UID and GID fixture");
+						if (err) return test.done();
+
+						cronicle.workers[fake_hostname] = {
+							hostname: fake_hostname,
+							disabled: false,
+							active_jobs: {},
+							socket: {
+								emit: function(action, job) {
+									if (action == 'launch_job') captured_job = job;
+								}
+							}
+						};
+
+						var job = Tools.copyHash(event, true);
+						job.target = fake_hostname;
+						job.uid = 'event-user';
+						job.gid = 'event-group';
+						job.web_hook = '';
+
+						WindowsJob.prototype.launchJob.call(cronicle, job, function(err, jobs) {
+							delete cronicle.workers[fake_hostname];
+							storage.listFindUpdate('global/plugins', { id: plugin.id }, original_run_as, function(restore_err) {
+								test.ok(!restore_err, "Restored Plugin UID and GID fixture");
+								test.ok(!err, "Windows manager dispatched the job");
+								test.ok(jobs && jobs.length == 1, "Windows manager launched one remote job");
+								test.ok(!!captured_job, "Captured the remote job payload");
+								test.ok(captured_job && captured_job.uid == '65534', "Remote job uses the Plugin UID");
+								test.ok(captured_job && captured_job.gid == '65533', "Remote job uses the Plugin GID");
+								test.done();
+							});
+						});
+					});
+				});
+			});
+		},
 		
 		
 		function testSchedulerTick(test) {


### PR DESCRIPTION
Split from #287 as requested.

## Problem

Setup: a Windows manager dispatches a Plugin with `uid` / `gid` configured to a Unix worker.

Expected: the worker receives the administrator-configured Plugin identity.

Actual: `launchJob()` copied these fields only when the manager itself was Unix, so the Windows manager dropped them and the Unix worker fell back to its service identity.

## Change

- Copy non-empty Plugin `uid` and `gid` into the job on every manager platform.
- Keep the existing `debug_sudo` service-UID lookup behind the Unix guard.
- Leave Unix-only child spawn handling on the executing worker unchanged.

This uses the existing job payload fields and requires no protocol change.

## Regression coverage

The test loads the job manager with a simulated `win32` platform, dispatches to a fake remote Unix worker, and verifies that Plugin `uid` / `gid` replace hostile event-level values in the transmitted job.

Validation:

- `npm test`: 97/97 tests, 443 assertions
- repository `Dockerfile`: image build completed successfully, including the SQL bundle

## Unchanged

- Numeric zero handling is not changed.
- `debug_sudo` lifecycle is not changed in this PR.
- Windows workers still do not receive Unix child-process options.
