### PR TITLE
Keep debug sudo authorization one-shot

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -264,6 +264,7 @@ module.exports = Class.create({
 		delete event.uid;
 		delete event.gid;
 		delete event.env;
+		delete event.debug_sudo;
 
 
 		// make sure title doesn't contain HTML metacharacters

--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -443,6 +443,10 @@ module.exports = Class.create({
 		if (params.id) criteria.id = params.id;
 		else if (params.title) criteria.title = params.title;
 		else return this.doError('event', "Failed to locate event: No criteria specified", callback);
+		var requested_debug_sudo = Object.prototype.hasOwnProperty.call(params, 'debug_sudo') && (
+			(params.debug_sudo === true) || (params.debug_sudo === 1) ||
+			(params.debug_sudo === '1') || (params.debug_sudo === 'true')
+		);
 
 		// validate optional event data parameters
 		if (!this.requireValidEventData(params, callback)) return;
@@ -509,8 +513,6 @@ module.exports = Class.create({
 
 				let privs = user.privileges || {}
 				let canEdit = privs.edit_events || privs.create_events || privs.admin
-				// only admin can set debug_sudo option
-				if(!privs.admin) delete params.debug_sudo
 				
 				// Run-only callers may supply only the documented ad-hoc runtime inputs.
 				// Everything else must come from the stored event that passed RBAC above.
@@ -548,7 +550,9 @@ module.exports = Class.create({
 					}
 				}
 
-				var job = Tools.mergeHashes(Tools.copyHash(event, true), params);
+				var event_copy = Tools.copyHash(event, true);
+				delete event_copy.debug_sudo;
+				var job = Tools.mergeHashes(event_copy, params);
 				// Also discard stale provenance stored by older event records.
 				[ 'api_key', 'token', 'username', 'source', 'source_id', 'source_event', 'source_log' ].forEach(function(key) {
 					delete job[key];
@@ -597,7 +601,7 @@ module.exports = Class.create({
 					var resp = { code: 0, ids: ids };
 					if (!ids.length) resp.queue = self.eventQueue[event.id] || 1;
 					callback(resp);
-				}); // launch job
+				}, { debug_sudo: !!(privs.admin && requested_debug_sudo) }); // launch job
 			}); // find event
 		}); // load session
 	},

--- a/lib/job.js
+++ b/lib/job.js
@@ -20,7 +20,7 @@ const isUnix = os.platform() != 'win32';
 
 module.exports = Class.create({
 
-	launchOrQueueJob: function (event, callback) {
+	launchOrQueueJob: function (event, callback, launch_options) {
 		// launch job, or queue upon failure (if event desires)
 		var self = this;
 
@@ -45,8 +45,10 @@ module.exports = Class.create({
 					// add now time if not already set
 					if (!event.now) event.now = Tools.timeNow(true);
 
-					// add job to actual queue in storage, async
-					self.storage.listPush('global/event_queue/' + event.id, event, function (err) {
+					// request authorization is one-shot and must not enter durable queues
+					var queued_event = Tools.copyHash(event, true);
+					delete queued_event.debug_sudo;
+					self.storage.listPush('global/event_queue/' + event.id, queued_event, function (err) {
 						if (err) {
 							self.logError('queue', "Failed to push job onto event queue: " + err);
 						}
@@ -58,7 +60,7 @@ module.exports = Class.create({
 				}
 			}
 			callback(err, jobs);
-		});
+		}, launch_options);
 	},
 
 	// safeJobLog(job) { // print less verbose, more readable job data on logging
@@ -68,7 +70,7 @@ module.exports = Class.create({
 	// 	return Object.keys(jc).filter(e => !excl.includes(e)).map(e => e + ': ' + ("params|workflow|perf".indexOf(e) > -1 ? JSON.stringify(jc[e]) : jc[e]) ).join(" | ")
 	// },
 
-	launchJob: function (event, callback) {
+	launchJob: function (event, callback, launch_options) {
 		// locate suitable server and launch job
 		let self = this;
 		let orig_event = null;
@@ -80,6 +82,7 @@ module.exports = Class.create({
 		let cat_secret = {};
 		let plug_secret = {};
 		let lag = Date.now();
+		let trusted_debug_sudo = !!(launch_options && launch_options.debug_sudo);
 
 		// must be manager to do this
 		if (!this.multi.manager) return callback(new Error("Only a manager server can launch jobs."));
@@ -232,6 +235,7 @@ module.exports = Class.create({
 				    delete job.uid;
 				    delete job.gid;
 				    delete job.env;
+				    delete job.debug_sudo;
 	
 
 					delete job.id;
@@ -266,6 +270,7 @@ module.exports = Class.create({
 					job.lag	= lag
 					job.stdin = !!plugin.stdin
 					job.stdin_script = plugin.script		
+					job.debug_sudo = trusted_debug_sudo;
 
 					// SECRETS - decryption will occur at LaunchLocalJob
 					job.secret = orig_event.secret	// should be encrypted
@@ -314,6 +319,7 @@ module.exports = Class.create({
 					job.env['BASE_URL'] = base_url
 
 					job.env['BASE_APP_URL'] = self.server.config.get('base_app_url') || ''
+					delete job.debug_sudo;
 					if(plugin.id === 'workflow' || plugin.wf) {
 						self.workflowKeys.set(job.id, Tools.digestHex(job.id + self.config.get('secret_key'), 'MD5'))
 				    }
@@ -552,6 +558,7 @@ module.exports = Class.create({
 		var self = this;
 		var child = null;
 		var worker = null;
+		delete job.debug_sudo;
 		// if(self.server.config.get('profile')) self.logDebug(6, `PROFILE: LAG ${job.id} manager`, Date.now() - job.lag)
 
 		// check for job delay request (multiplex stagger)

--- a/lib/test.js
+++ b/lib/test.js
@@ -942,6 +942,7 @@ module.exports = {
 				"memory_limit": 0,
 				"memory_sustain": 0,
 				"notes": "",
+				"debug_sudo": 1,
 				"uid": 0,
 				"gid": 0,
 				"cwd": "/tmp",
@@ -970,6 +971,7 @@ module.exports = {
 					test.ok( !('gid' in event), "Event-level gid was not stored" );
 					test.ok( !('cwd' in event), "Event-level cwd was not stored" );
 					test.ok( !('env' in event), "Event-level env was not stored" );
+					test.ok( !('debug_sudo' in event), "One-shot debug_sudo was not stored" );
 					
 					test.done();
 				} );
@@ -984,6 +986,7 @@ module.exports = {
 			var params = {
 				"id": this.event_id,
 				"title": "Updated Event Title",
+				"debug_sudo": 1,
 				"session_id": session_id
 			};
 			
@@ -1001,6 +1004,7 @@ module.exports = {
 					test.ok( event.username == "admin", "Username is correct" );
 					test.ok( event.created > 0, "Record creation date is non-zero" );
 					test.ok( event.title == "Updated Event Title", "New title is correct" );
+					test.ok( !('debug_sudo' in event), "Event update did not store one-shot debug_sudo" );
 					
 					test.done();
 				} );
@@ -1060,6 +1064,76 @@ module.exports = {
 		},
 		
 		// app/run_event
+
+		function testAdminDebugSudoIsOneShot(test) {
+			var old_launch = cronicle.launchOrQueueJob;
+			var captured_job = null;
+			var captured_options = null;
+
+			cronicle.launchOrQueueJob = function(job, callback, launch_options) {
+				captured_job = job;
+				captured_options = launch_options;
+				callback(null, []);
+			};
+
+			request.json(api_url + '/app/run_event', {
+				id: this.event_id,
+				session_id: session_id,
+				debug_sudo: 1
+			}, function(err, resp, data) {
+				cronicle.launchOrQueueJob = old_launch;
+				test.ok(!err, "Admin debug_sudo request completed");
+				test.ok(data && data.code == 0, "Admin debug_sudo request launched the event");
+				test.ok(captured_job && !('debug_sudo' in captured_job), "debug_sudo was not copied into the job");
+				test.ok(captured_options && captured_options.debug_sudo === true, "Admin debug_sudo was passed as a one-shot launch option");
+				test.done();
+			});
+		},
+
+		function testNonAdminEditorCannotRequestDebugSudo(test) {
+			var api_key = {
+				id: 'unit_debug_sudo_editor',
+				key: 'unit_debug_sudo_editor_key',
+				title: 'Unit Test Event Editor',
+				active: 1,
+				privileges: {
+					admin: 0,
+					create_events: 1,
+					edit_events: 1,
+					run_events: 1
+				}
+			};
+			var old_launch = cronicle.launchOrQueueJob;
+			var captured_job = null;
+			var captured_options = null;
+
+			storage.listPush('global/api_keys', api_key, function(err) {
+				test.ok(!err, "Created non-admin event editor fixture");
+				if (err) return test.done();
+
+				cronicle.launchOrQueueJob = function(job, callback, launch_options) {
+					captured_job = job;
+					captured_options = launch_options;
+					callback(null, []);
+				};
+
+				request.json(api_url + '/app/run_event', {
+					id: this.event_id,
+					api_key: api_key.key,
+					debug_sudo: 1
+				}, function(err, resp, data) {
+					cronicle.launchOrQueueJob = old_launch;
+					storage.listFindCut('global/api_keys', { id: api_key.id }, function(cleanup_err) {
+						test.ok(!cleanup_err, "Removed non-admin event editor fixture");
+						test.ok(!err, "Non-admin editor request completed");
+						test.ok(data && data.code == 0, "Non-admin editor launched the configured event");
+						test.ok(captured_job && !('debug_sudo' in captured_job), "Non-admin editor added no debug_sudo marker");
+						test.ok(!captured_options || !captured_options.debug_sudo, "Non-admin editor received no debug_sudo launch option");
+						test.done();
+					});
+				});
+			}.bind(this));
+		},
 		
 		function testAPIRunEvent(test) {
 			// test app/run_event api
@@ -1101,11 +1175,13 @@ module.exports = {
 			var queuePath = 'global/event_queue/' + this.event_id;
 			var originalEvent = null;
 			var launchedJob = null;
+			var launchedOptions = null;
 			var allowedNow = Tools.timeNow(true) - 60;
 			var finished = false;
 
-			function captureLaunch(job, callback) {
+			function captureLaunch(job, callback, launch_options) {
 				launchedJob = job;
+				launchedOptions = launch_options;
 				callback(null, []);
 			}
 
@@ -1282,6 +1358,7 @@ module.exports = {
 						test.ok(launchedJob && (!launchedJob.params || launchedJob.params.script != 'echo attacker-override'), "Event token plugin parameters were ignored");
 						test.ok(launchedJob && launchedJob.notify_fail != 'attacker@example.com', "Event token notification override was ignored");
 						test.ok(launchedJob && !launchedJob.debug_sudo, "Event token debug_sudo override was ignored");
+						test.ok(!launchedOptions || !launchedOptions.debug_sudo, "Event token received no debug_sudo launch option");
 						test.ok(launchedJob && launchedJob.repeat === originalEvent.repeat, "Positive repeat override was ignored");
 						test.ok(launchedJob && launchedJob.enabled === originalEvent.enabled, "Enabled override was ignored");
 						test.ok(launchedJob && launchedJob.source == 'Event Token', "Server-derived source was preserved");
@@ -1722,6 +1799,79 @@ module.exports = {
 					test.done();
 				} );
 			} );
+		},
+
+		function testLaunchJobPassesOneShotDebugSudoToWorker(test) {
+			var fake_hostname = 'unit-test-debug-worker';
+			var captured_job = null;
+
+			storage.listFind('global/schedule', { id: this.event_id }, function(err, event) {
+				test.ok(!err && !!event, "Found event for debug_sudo dispatch test");
+				if (err || !event) return test.done();
+
+				cronicle.workers[fake_hostname] = {
+					hostname: fake_hostname,
+					disabled: false,
+					active_jobs: {},
+					socket: {
+						emit: function(action, job) {
+							if (action != 'launch_job') return;
+							captured_job = job;
+						}
+					}
+				};
+
+				var job = Tools.copyHash(event, true);
+				job.target = fake_hostname;
+				job.debug_sudo = 1;
+				job.web_hook = '';
+
+				cronicle.launchJob(job, function(err, jobs) {
+					delete cronicle.workers[fake_hostname];
+					test.ok(!err, "Manager dispatched the debug_sudo job");
+					test.ok(jobs && jobs.length == 1, "Manager launched one remote job");
+					test.ok(captured_job && !('debug_sudo' in captured_job), "Remote job contains no debug_sudo marker");
+					if (process.platform != 'win32') {
+						test.ok(captured_job && captured_job.uid === process.getuid(), "Manager materialized its service UID for the worker");
+					}
+					test.done();
+				}, { debug_sudo: true });
+			});
+		},
+
+		function testCapacityQueueDropsOneShotDebugSudo(test) {
+			var old_launch_job = cronicle.launchJob;
+			var old_list_push = storage.listPush;
+			var old_queue_count = cronicle.eventQueue.unit_debug_sudo_queue;
+			var queued_event = null;
+			var received_options = null;
+
+			cronicle.launchJob = function(event, callback, launch_options) {
+				received_options = launch_options;
+				callback(new Error('Intentional capacity failure'));
+			};
+			storage.listPush = function(path, event, callback) {
+				queued_event = event;
+				callback();
+			};
+
+			cronicle.launchOrQueueJob({
+				id: 'unit_debug_sudo_queue',
+				queue: 1,
+				queue_max: 1,
+				debug_sudo: 1
+			}, function(err, jobs) {
+				cronicle.launchJob = old_launch_job;
+				storage.listPush = old_list_push;
+				if (typeof(old_queue_count) == 'undefined') delete cronicle.eventQueue.unit_debug_sudo_queue;
+				else cronicle.eventQueue.unit_debug_sudo_queue = old_queue_count;
+
+				test.ok(!err, "Capacity failure queued the event");
+				test.ok(jobs && jobs.length == 0, "Queued event returned no launched jobs");
+				test.ok(received_options && received_options.debug_sudo === true, "One-shot option reached the immediate launch attempt");
+				test.ok(queued_event && !('debug_sudo' in queued_event), "Durable event queue contains no debug_sudo marker");
+				test.done();
+			}, { debug_sudo: true });
 		},
 		
 		


### PR DESCRIPTION
Split from #287 as requested.

## Problem

The Sudo checkbox is described as a manual, non-persistent debug option. However, `debug_sudo` was accepted as unknown event data, so it could be stored by create/update. `run_event` then checked only the caller-supplied field before merging the stored event, allowing a persisted marker to select the manager service UID later. A capacity queue could also retain the marker.

## Change

- Remove `debug_sudo` from all validated event data so create/update cannot persist it.
- Capture only explicit `true`, `1`, `"1"`, or `"true"` values from the manual run request.
- Authorize that one-shot choice only for an administrator and pass it separately from the event/job object.
- Materialize the manager service UID before the existing `launch_job` transport, then remove the marker before active state, hooks, queues, delays, or worker execution can retain it.
- Ignore stale top-level markers received by a newer worker.

The existing manager/worker protocol remains unchanged; no HMAC or capability layer is introduced.

## Regression coverage

Coverage verifies create/update persistence, admin manual execution, non-admin editor and event-token denial, remote dispatch identity, stale marker removal, and capacity-queue cleanup.

Validation:

- `npm test`: 100/100 tests, 456 assertions
- repository `Dockerfile`: image build completed successfully, including the SQL bundle

## Unchanged

- Plugin `uid` / `gid` behavior is not changed in this PR.
- Numeric zero handling is not changed.
- Existing manager-side `debug_sudo` resolution and mixed-version `launch_job` transport are preserved.
